### PR TITLE
Dir should not exist

### DIFF
--- a/features/file_system_commands.feature
+++ b/features/file_system_commands.feature
@@ -74,7 +74,17 @@ Feature: file system commands
     Then the following directories should exist:
       | foo/bar |
       | foo/bla |
-
+  
+  Scenario: check for absence of directories
+    Given a directory named "foo/bar"
+    Given a directory named "foo/bla"
+    Then the following step should fail with Spec::Expectations::ExpectationNotMetError:
+    """
+    Then the following directories should not exist:
+      | foo/bar/ |
+      | foo/bla/ |
+    """
+  
   Scenario: Check file contents
     Given a file named "foo" with:
       """

--- a/features/step_definitions/aruba_dev_steps.rb
+++ b/features/step_definitions/aruba_dev_steps.rb
@@ -22,3 +22,7 @@ end
 Then /^aruba should fail with "([^"]*)"$/ do |error_message|
   @aruba_exception.message.should =~ compile_and_escape(error_message)
 end
+
+Then /^the following step should fail with Spec::Expectations::ExpectationNotMetError:$/ do |multiline_step|
+  proc {steps multiline_step}.should raise_error(RSpec::Expectations::ExpectationNotMetError)
+end

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -155,7 +155,7 @@ Then /^the following directories should exist:$/ do |directories|
 end
 
 Then /^the following directories should not exist:$/ do |directories|
-  check_file_presence(directories.raw.map{|directory_row| directory_row[0]}, false)
+  check_directory_presence(directories.raw.map{|directory_row| directory_row[0]}, false)
 end
 
 Then /^the file "([^"]*)" should contain "([^"]*)"$/ do |file, partial_content|


### PR DESCRIPTION
I'm sending this again because of new github pull request stuff

Long story short - directory should not exist step is broken because it uses file instead of directory test.

It was the only does-not-exist step without a cucumber test, so I added one to demonstrate the failure + the working fixed code.

You might like to refactor the stepdef but this fixes aruba giving false positives.

Regards, Nick
