### PR TITLE
(Failing feature) - Directory manipulation inside an interactive process

### DIFF
--- a/features/interactive.feature
+++ b/features/interactive.feature
@@ -28,3 +28,11 @@ Feature: Interactive process control
       """
       7
       """
+
+  Scenario: Directory manipulation in an interactive process
+    Given a directory named "rename_me"
+    When I run "mv rename_me renamed" interactively
+    Then the following directories should exist:
+      | renamed |
+    And the following directories should not exist:
+      | rename_me |


### PR DESCRIPTION
I was attempting to use aruba to test an application I'm working on which needs interactive input and also does some filesystem manipulation, including directory renaming.

After running the app interactively, providing it input through "Then I type ..." and then checking that a directory exists and another one doesn't, I got a failing feature even after verifying their existence/non-existence with ruby-debug.

I've added a failing feature in this branch which demonstrates the behavior.

<pre>
[failing_feature][~/Code/ruby/aruba] cucumber features/interactive.feature
Feature: Interactive process control
  In order to test interactive command line applications
  As a developer using Cucumber
  I want to use the interactive session steps

  Scenario: Running ruby interactively      # features/interactive.feature:7
    Given a file named "echo.rb" with:      # lib/aruba/cucumber.rb:66
      """
      while res = gets.chomp
        break if res == "quit"
        puts res.reverse
      end
      """
    When I run "ruby echo.rb" interactively # lib/aruba/cucumber.rb:98
    And I type "hello, world"               # lib/aruba/cucumber.rb:102
    And I type "quit"                       # lib/aruba/cucumber.rb:102
    Then the output should contain:         # lib/aruba/cucumber.rb:114
      """
      dlrow ,olleh
      """

  Scenario: Running a native binary interactively # features/interactive.feature:23
    When I run "bc -q" interactively              # lib/aruba/cucumber.rb:98
    And I type "4 + 3"                            # lib/aruba/cucumber.rb:102
    And I type "quit"                             # lib/aruba/cucumber.rb:102
    Then the output should contain:               # lib/aruba/cucumber.rb:114
      """
      7
      """

  Scenario: Directory manipulation in an interactive process # features/interactive.feature:32
    Given a directory named "rename_me"                      # lib/aruba/cucumber.rb:62
    When I run "mv rename_me renamed" interactively          # lib/aruba/cucumber.rb:98
    Then the following directories should exist:             # lib/aruba/cucumber.rb:187
      | renamed |
      expected directory?("renamed") to return true, got false (RSpec::Expectations::ExpectationNotMetError)
      ./features/support/../../lib/aruba/api.rb:79:in `check_directory_presence'
      ./features/support/../../lib/aruba/api.rb:77:in `each'
      ./features/support/../../lib/aruba/api.rb:77:in `check_directory_presence'
      ./features/support/../../lib/aruba/api.rb:9:in `chdir'
      ./features/support/../../lib/aruba/api.rb:9:in `in_current_dir'
      ./features/support/../../lib/aruba/api.rb:76:in `check_directory_presence'
      ./features/support/../../lib/aruba/cucumber.rb:188:in `/^the following directories should exist:$/'
      features/interactive.feature:35:in `Then the following directories should exist:'
    And the following directories should not exist:          # lib/aruba/cucumber.rb:191
      | rename_me |

Failing Scenarios:
cucumber features/interactive.feature:32 # Scenario: Directory manipulation in an interactive process

3 scenarios (1 failed, 2 passed)
13 steps (1 failed, 1 skipped, 11 passed)
0m0.085s
[failing_feature][~/Code/ruby/aruba] ruby -e "puts File.directory? 'tmp/aruba/renamed'"
true
[failing_feature][~/Code/ruby/aruba] ruby -e "puts File.directory? 'tmp/aruba/rename_me'"
false
</pre>
