### PR TITLE
a directory/file named "whatever" should (not) exist

### DIFF
--- a/features/file_system_commands.feature
+++ b/features/file_system_commands.feature
@@ -81,7 +81,7 @@ Feature: file system commands
     Then the following directories should exist:
       | foo/bar |
       | foo/bla |
-  
+
   Scenario: check for absence of directories
     Given a directory named "foo/bar"
     Given a directory named "foo/bla"
@@ -91,7 +91,18 @@ Feature: file system commands
       | foo/bar/ |
       | foo/bla/ |
     """
-  
+
+  Scenario: Check for presence of a single directory
+    Given a directory named "foo/bar"
+    Then a directory named "foo/bar" should exist
+
+  Scenario: Check for absence of a single directory
+    Given a directory named "foo/bar"
+    Then the following step should fail with Spec::Expectations::ExpectationNotMetError:
+      """
+      Then a directory named "foo/bar" should not exist
+      """
+
   Scenario: Check file contents
     Given a file named "foo" with:
       """

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -200,6 +200,14 @@ Then /^the following directories should not exist:$/ do |directories|
   check_directory_presence(directories.raw.map{|directory_row| directory_row[0]}, false)
 end
 
+Then /^a directory named "([^"]*)" should exist$/ do |directory|
+  check_directory_presence(directory, true)
+end
+
+Then /^a directory named "([^"]*)" should not exist$/ do |directory|
+  check_directory_presence(directory, false)
+end
+
 Then /^the file "([^"]*)" should contain "([^"]*)"$/ do |file, partial_content|
   check_file_content(file, partial_content, true)
 end


### PR DESCRIPTION
- a file named "foo" should exist
- a file named "foo" should not exist
- a directory named "foo" should exist
- a directory named "foo" should not exist

Added these "Then" statements, as I found myself wanting to check a single file or directory's existence/absence while using aruba the last couple projects.
