### PR TITLE
Added case insensitive step definitions

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'aruba'
-  s.version     = "0.2.3"
+  s.version     = "0.2.3.2"
   s.authors     = ["Aslak Hellesøy", "David Chelimsky"]
   s.description = 'CLI Steps for Cucumber, hand-crafted for you in Aruba'
   s.summary     = "aruba-#{s.version}"
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'cucumber', '~> 0.9.0'
   s.add_dependency 'background_process' # Can't specify a version - bundler/rubygems chokes on '2.1'
-  s.add_development_dependency 'rspec', '~> 2.0.0.beta.22'
+  s.add_development_dependency 'rspec', '~> 2.0.0'
 
   s.rubygems_version   = "1.3.7"
   s.files            = `git ls-files`.split("\n")

--- a/features/debug.feature
+++ b/features/debug.feature
@@ -1,0 +1,39 @@
+Feature: Debug
+  In order to value
+  As a role
+  I want feature
+
+@active
+Scenario Outline: Detect subset of one-line output
+    When I run "<command_line> "
+    Then the output should contain "<output_array>"
+
+Scenarios: Detect subset of one-line output table
+ | command_line                      | output_array             |
+ | ruby -e \"puts '<output_array>'\" | line1                    |
+ | ruby -e \"puts '<output_array>'\" | 'Line two' fudgy whale   |
+ | ruby -e \"puts '<output_array>'\" | fudgy 'line three' whale |
+ | ruby -e \"puts '<output_array>'\" | fudgy whale 'line four'  |
+ | ruby -e \"puts '<output_array>'\" | 'line five'              |
+ | ruby -e \"puts '<output_array>'\" | line six                 |
+
+
+#@active
+Scenario: Detect subset of one-line output, regardless of case
+  When I run "echo 'Hello World'"
+  Then the output should, regardless of case, contain "hello world"
+
+  
+#@active
+Scenario: create a dir
+  Given a directory named "foo/bar"
+  When I run "ruby -e \"puts test ?d, 'foo'\""
+  Then the stdout should contain "true"
+
+#@active
+Scenario: Detect subset of multiline output, regardless of case
+  When I run "ruby -e 'puts \"hello\\nworld\"'"
+  Then the output should, regardless of case, contain:
+    """
+    Hello
+    """

--- a/features/output.feature
+++ b/features/output.feature
@@ -46,7 +46,6 @@ Feature: Output
       hello
       """
 
-
   Scenario: Detect subset of multiline output, regardless of case
     When I run "ruby -e 'puts \"hello\\nworld\"'"
     Then the output should, regardless of case, contain:

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -89,11 +89,10 @@ module Aruba
     end
 
     def unescape(string)
-      eval(%{"#{string}"})
+       eval(%{"#{string}"})
     end
 
     def regexp(string_or_regexp, case_insensitive = :case_sensitive)
-      #puts "case_insensitive: #{case_insensitive}"
       Regexp === string_or_regexp ? string_or_regexp : Regexp.compile(Regexp.escape(string_or_regexp), (case_insensitive == :case_insensitive))
     end
 

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -103,8 +103,13 @@ When /^I type "([^"]*)"$/ do |input|
   write_interactive(ensure_newline(input))
 end
 
-Then /^the output should(, regardless of case,|) contain "([^"]*)"$/ do |case_insensitive, partial_output|
-  assert_partial_output(partial_output, (case_insensitive == "" ? :case_sensitive : :case_insensitive))
+#(\w+ |\".*?\"|'.*?')
+#(\w+)|(?:')(.+)(?:')|(?: )(\w+)|(\w+)(?: )
+
+Then /^the output should(, regardless of case,|) contain "([^"]*)"( each of these|)$/ do |case_insensitive, partial_output, is_array|
+  (is_array == nil ? [partial_output] : partial_output.scan(/(\w+)|(?:')(.+)(?:')/).flatten.compact).each do |partial_output_each|
+    assert_partial_output(partial_output_each, (case_insensitive == "" ? :case_sensitive : :case_insensitive))
+  end
 end
 
 Then /^the output should not(, regardless of case,|) contain "([^"]*)"$/ do |case_insensitive, partial_output|


### PR DESCRIPTION
I was trying to do a case insensitive match using a regex matcher, eg "/my text/i", and realized I couldn't so I added it just for regex's. I then realized if I was going to do it for one kind of matcher I should do it for all of them.

I'm a complete Ruby newbie so hopefully I haven't made too many silly mistakes and this is actually useful. I tried to make the additions as easy to use and understandable as possible. Where a regex is given I added a simple matcher for the trailing "i" like so "/blah/i". In the other matchers I added a regex for ", regardless of case," after the "should" or "should not." I then modified the api.rb to allow for case insensitive searches but made sure all the added parameters were optional with the default as case sensitive.

It's a bit verbose but it seems to be fairly clear when reading the Cucumber specs. Though I'm not sure if I should have made separate step definitions for the ", regardless of case," matchers. I may have been too clever by half in jamming that all into the same step.

I, of course, followed the behaviour-driven development protocol so there are tests for all added features.

Thank you for your time (and all the work you've put into this and the cucumber projects).
