### PR TITLE
Rspec is a runtime dependency, not a development dependency

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'cucumber', '~> 0.10.0'
   s.add_dependency 'background_process' # Can't specify a version - bundler/rubygems chokes on '2.1'
-  s.add_development_dependency 'rspec', '~> 2.0.1'
+  s.add_dependency 'rspec', '~> 2.0.1'
 
   s.rubygems_version   = "1.3.7"
   s.files            = `git ls-files`.split("\n")


### PR DESCRIPTION
rspec is listed as a development dependency, but the step_definitions in aruba/cucumber require rspec.  They use x.should include(y).

Here is some sample output from features using aruba:

Then the output should contain "xyz" # aruba-0.2.7/lib/aruba/cucumber.rb:110
  undefined method `include' for #Object:0x8113c62c (NoMethodError)
