### PR TITLE
Broken 0.3.0 release

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -98,8 +98,8 @@ module Aruba
     end
 
     def unescape(string)
-      string.gsub('\n', "\n")
-            .gsub('\"', '"')
+      string.gsub('\n', "\n").
+             gsub('\"', '"')
     end
 
     def regexp(string_or_regexp)


### PR DESCRIPTION
The 0.3.0 release of Aruba is broken. This fixes it. 
