### PR TITLE
Alternate command quotes

### DIFF
--- a/features/exit_statuses.feature
+++ b/features/exit_statuses.feature
@@ -8,6 +8,10 @@ Feature: exit statuses
     When I run "ruby -h"
     Then the exit status should be 0
 
+  Scenario: exit status of 0 with `
+    When I run `ruby -h`
+    Then the exit status should be 0
+
   Scenario: Not explicitly exiting at all
     When I run "ruby -e '42'"
     Then the exit status should be 0
@@ -20,10 +24,17 @@ Feature: exit statuses
   Scenario: Successfully run something
     When I successfully run "ruby -e 'exit 0'"
 
+  Scenario: Successfully run something with `
+    When I successfully run `ruby -e 'exit 0'`
+
   Scenario: Unsuccessfully run something
     When I do aruba I successfully run "ruby -e 'exit 10'"
     Then aruba should fail with "Exit status was 10"
 
   Scenario: Try to run something that doesn't exist
     When I run "does_not_exist"
+    Then the exit status should be 1
+
+  Scenario: Try to run something that doesn't exist with `
+    When I run `does_not_exist`
     Then the exit status should be 1

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -95,7 +95,15 @@ When /^I run "(.*)"$/ do |cmd|
   run_simple(unescape(cmd), false)
 end
 
+When /^I run `([^`]*)`$/ do |cmd|
+  run_simple(unescape(cmd), false)
+end
+
 When /^I successfully run "(.*)"$/ do |cmd|
+  run_simple(unescape(cmd))
+end
+
+When /^I successfully run `([^`]*)`$/ do |cmd|
   run_simple(unescape(cmd))
 end
 


### PR DESCRIPTION
I think that the regular expression for matching what commands to run is a bit to hungry for me, especially when I want to write new steps like:

  When I run "command foo bar" with "blah"

This commit provides an alternate syntax using backticks:

  When I run `command foo bar`

Thus allowing things like:

  When I run `command` with "blah"

The double quote syntax has not been removed, I've simply added an alternative.

-Anthony
