### PR TITLE
Don't auto delete other people's cwd.

### DIFF
--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -16,7 +16,7 @@ After do
 end
 
 Before do
-  FileUtils.rm_rf(current_dir)
+  FileUtils.rm_rf(current_dir) if @dirs[0][/\Atmp\/aruba\Z/]
 end
 
 Before('@puts') do


### PR DESCRIPTION
Arises if you point Aruba to a different scartch
area. Example:

```
Before('@work_in_cwd') do
 @dirs = [Pathname.getwd.expand_path.realdirpath.to_s]
end
```
