### PR TITLE
Fix childprocess STDIN to be synchronous; resolves issue 40

### DIFF
--- a/lib/aruba/process.rb
+++ b/lib/aruba/process.rb
@@ -25,6 +25,7 @@ module Aruba
 
     def stdin
       wait_for_io do
+        @process.io.stdin.sync = true
         @process.io.stdin
       end
     end


### PR DESCRIPTION
Add one line inside the `stdin` function to make the child process's STDIN stream synchronous. Resolves an issue on Windows with testing I/O; full description on [StackOverflow](http://stackoverflow.com/questions/5823907/cucumber-aruba-windows-tests-dont-see-last-line-of-stdout).
