### PR TITLE
Fixed spelling mistake, renamed varibable to variable in scenarios and co

### DIFF
--- a/features/output.feature
+++ b/features/output.feature
@@ -222,9 +222,9 @@ Feature: Output
   Scenario: Detect output from named source with custom name
 
   Scenario: Detect second output from named source with custom name
-    When I set env varibable "ARUBA_TEST_VAR" to "first"
+    When I set env variable "ARUBA_TEST_VAR" to "first"
     And I run `ruby -e 'puts ENV[%q(ARUBA_TEST_VAR)]'`
     Then the output from "ruby -e 'puts ENV[%q(ARUBA_TEST_VAR)]'" should contain "first"
-    When I set env varibable "ARUBA_TEST_VAR" to "second"
+    When I set env variable "ARUBA_TEST_VAR" to "second"
     And I run `ruby -e 'puts ENV[%q(ARUBA_TEST_VAR)]'`
     Then the output from "ruby -e 'puts ENV[%q(ARUBA_TEST_VAR)]'" should contain "second"

--- a/features/step_definitions/aruba_dev_steps.rb
+++ b/features/step_definitions/aruba_dev_steps.rb
@@ -11,7 +11,7 @@ When /^sleep (\d+)$/ do |time|
   sleep time.to_i
 end
 
-When /^I set env varibable "(\w+)" to "([^"]*)"$/ do |var, value|
+When /^I set env variable "(\w+)" to "([^"]*)"$/ do |var, value|
   ENV[var] = value
 end
 


### PR DESCRIPTION
Fixed spelling mistake, renamed varibable to variable in scenarios and corresponding step definitions
