### PR TITLE
Detect subset of one-line output with regex

### DIFF
--- a/features/output.feature
+++ b/features/output.feature
@@ -75,7 +75,7 @@ Feature: Output
   Scenario: Detect subset of one-line output with regex
     When I run `ruby --version`
     Then the output should contain "ruby"
-    And the output should match /ruby ([\d]+\.[\d]+\.[\d]+)(p\d+)? \(.*$/
+    And the output should match /ruby ([\d]+\.[\d]+\.[\d]+)(\w*\d*)? \(.*$/
 
   @announce
   Scenario: Detect subset of multiline output with regex


### PR DESCRIPTION
Adjusted regular expression so that it works with Ruby 1.9.3dev and Ruby 1.9.XpNNN.
