### PR TITLE
Added file size specific steps to the Aruba API.

### DIFF
--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -39,6 +39,11 @@ describe Aruba::Api  do
         @aruba.write_fixed_size_file(@file_name, @file_size)
         @aruba.check_file_size([[@file_name, @file_size]])
       end
+
+      it "should check an existing file size and fail" do
+        @aruba.write_fixed_size_file(@file_name, @file_size)
+        lambda { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.should raise_error
+      end
     end
   end
 


### PR DESCRIPTION
I am building a command line tool that requires input files of a certain size as arguments – for example, file size must be greater than `5MB`.  In order to use Aruba and Cucumber to test, I added some additional steps and methods to the API.

Let me know if you have any feedback on this pull request, and thanks for creating/maintaining Aruba!
