### PR TITLE
[FEATURE] Check for content from stdout while process is still running

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -188,6 +188,10 @@ module Aruba
       end
     end
 
+    def assert_partial_output_interactive(expected)
+      unescape(_read_interactive).include?(unescape(expected)) ? true : false
+    end
+
     def assert_passing_with(expected)
       assert_exit_status_and_partial_output(true, expected)
     end
@@ -308,6 +312,10 @@ module Aruba
 
     def _write_interactive(input)
       @interactive.stdin.write(input)
+    end
+
+    def _read_interactive
+      @interactive.read_stdout(@aruba_keep_ansi)
     end
 
     def _ensure_newline(str)

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -79,6 +79,15 @@ When /^I type "([^"]*)"$/ do |input|
   type(input)
 end
 
+When /^I wait for (?:output|stdout) to contain "([^"]*)"$/ do |expected|
+  Timeout::timeout(exit_timeout) do
+    loop do
+      break if assert_partial_output_interactive(expected)
+      sleep 0.1
+    end
+  end
+end
+
 Then /^the output should contain "([^"]*)"$/ do |expected|
   assert_partial_output(expected, all_output)
 end

--- a/lib/aruba/process.rb
+++ b/lib/aruba/process.rb
@@ -48,6 +48,13 @@ module Aruba
       end
     end
 
+    def read_stdout(keep_ansi)
+      wait_for_io do
+        @process.io.stdout.flush
+        content = filter_ansi(open(@out.path).read, keep_ansi)
+      end
+    end
+
     def stop(reader, keep_ansi)
       return unless @process
       unless @process.exited?


### PR DESCRIPTION
This update allows you to check the output of the running process while in interactive mode.  It includes a step definition as well.
- Step definition to check for content in output
  - API method to return current stdout data
  - Backend process method to actually get the stdout
