### PR TITLE
[FEATURE] Added to DSL: negative output matching

### DIFF
--- a/features/output.feature
+++ b/features/output.feature
@@ -96,6 +96,25 @@ Feature: Output
       """
 
   @announce
+  Scenario: Negative matching of one-line output with regex
+    When I run `ruby --version`
+    Then the output should contain "ruby"
+    And the output should not match /ruby is a better perl$/
+
+  @announce
+  @posix
+  Scenario: Negative matching of multiline output with regex
+    When I run `ruby -e 'puts "hello\nworld\nextra line1\nextra line2\nimportant line"'`
+    Then the output should not match:
+      """
+      ruby
+      is
+      a
+      .*
+      perl
+      """
+
+  @announce
   @posix
   Scenario: Match passing exit status and partial output
     When I run `ruby -e 'puts "hello\nworld"'`

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -187,6 +187,10 @@ module Aruba
       unescape(actual).should =~ /#{unescape(expected)}/m
     end
 
+    def assert_not_matching_output(expected, actual)
+      unescape(actual).should_not =~ /#{unescape(expected)}/m
+    end
+
     def assert_no_partial_output(unexpected, actual)
       if Regexp === unexpected
         unescape(actual).should_not =~ unexpected

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -118,9 +118,18 @@ end
 Then /^the output should match \/([^\/]*)\/$/ do |expected|
   assert_matching_output(expected, all_output)
 end
- 
+
 Then /^the output should match:$/ do |expected|
   assert_matching_output(expected, all_output)
+end
+
+# The previous two steps antagonists
+Then /^the output should not match \/([^\/]*)\/$/ do |expected|
+  assert_not_matching_output(expected, all_output)
+end
+
+Then /^the output should not match:$/ do |expected|
+  assert_not_matching_output(expected, all_output)
 end
 
 Then /^the exit status should be (\d+)$/ do |exit_status|

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -103,4 +103,19 @@ describe Aruba::Api  do
 
   end #with_file_content
 
+  describe "#assert_not_matching_output" do
+    before :each do
+      @aruba.run_simple("echo foo", false)
+    end
+
+    it "passes when the output doesn't match a regexp" do
+      @aruba.assert_not_matching_output "bar", @aruba.all_output
+    end
+    it "fails when the output does match a regexp" do
+      expect do
+        @aruba.assert_not_matching_output "foo", @aruba.all_output
+      end . to raise_error RSpec::Expectations::ExpectationNotMetError
+    end
+  end
+
 end # Aruba::Api


### PR DESCRIPTION
- Added Aruba::Api#assert_not_matching_output
- Added the corresponding pair of standard cucumber steps

Reason why: I have faced a situation where a stakeholder wanted to clearly state the
negative match of the output.
