### PR TITLE
32-bit optimisation breaks JRuby for some platforms

### DIFF
--- a/lib/aruba/jruby.rb
+++ b/lib/aruba/jruby.rb
@@ -4,6 +4,6 @@ Aruba.configure do |config|
     # ideas taken from: http://blog.headius.com/2010/03/jruby-startup-time-tips.html
     set_env('JRUBY_OPTS', '-X-C') # disable JIT since these processes are so short lived
     # force jRuby to use client JVM for faster startup times. Not all systems support this.
-    set_env('JAVA_OPTS', '-d32')  if Config::CONFIG['host_os'] =~ /solaris|sunos/i
+    set_env('JAVA_OPTS', '-d32')  if RbConfig::CONFIG['host_os'] =~ /solaris|sunos/i
   end
 end


### PR DESCRIPTION
Only Solaris supports switching between 32-bit and 64-bit mode in
the same binary.  Every other platform has separate java binaries
and the -d32 (or -d64) switch will either do nothing or cause the
program to exit with a failure code.
