### PR TITLE
Preserve any existing JRUBY_OPTS or JAVA_OPTS

### DIFF
--- a/lib/aruba/jruby.rb
+++ b/lib/aruba/jruby.rb
@@ -1,7 +1,11 @@
 Aruba.configure do |config|
   config.before_cmd do
     # ideas taken from: http://blog.headius.com/2010/03/jruby-startup-time-tips.html
-    set_env('JRUBY_OPTS', '-X-C') # disable JIT since these processes are so short lived
-    set_env('JAVA_OPTS', '-d32')  # force jRuby to use client JVM for faster startup times
+
+    # disable JIT since these processes are so short lived
+    set_env('JRUBY_OPTS', "-X-C #{ENV['JRUBY_OPTS']}")
+
+    # force jRuby to use client JVM for faster startup times
+    set_env('JAVA_OPTS', "-d32 #{ENV['JAVA_OPTS']}")
   end
 end


### PR DESCRIPTION
- In JRuby 1.6.x, 1.9 mode is enabled by passing JRUBY_OPTS="--1.9"; it
  is desirable for these sorts of options to be passed to child ruby
  processes that aruba spawns.
