### PR TITLE
Updating gem dependancy

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'cucumber', '>= 1.1.1'
   s.add_runtime_dependency 'childprocess', '~> 0.2'
-  s.add_runtime_dependency 'ffi', '>= 1.0.11'
   s.add_runtime_dependency 'rspec-expectations', '>= 2.7.0'
   s.add_development_dependency 'bcat', '>= 0.6.1'
   s.add_development_dependency 'rdiscount', '>= 1.6.8'


### PR DESCRIPTION
- Updating childprocess, it seems to work fine with 0.3 series
- Removing explicit dependancy to ffi. childprocess is dependant on ffi and that is sufficient
