### PR TITLE
Fixing build. Ensuring all parents exists, making a clean dir for each test

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -23,7 +23,7 @@ module Aruba
     end
 
     def dirs
-      @dirs ||= ['tmp/aruba']
+      @dirs ||= ['tmp', 'aruba']
     end
 
     def write_file(file_name, file_content)


### PR DESCRIPTION
The problem is reproducable by making a 

```
rm -rf tmp
```

before running 

```
rake
```

That showed that the tests where not completely decoupled. I have ensured that parent dirs exists and futher that the current_dir is clean before each test.
