### PR TITLE
Fixes typo and adds code climate to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://secure.travis-ci.org/cucumber/aruba.png)](http://travis-ci.org/cucumber/aruba)
+[![Build Status](https://secure.travis-ci.org/cucumber/aruba.png)](http://travis-ci.org/cucumber/aruba) [![Code Climate](https://codeclimate.com/badge.png)](https://codeclimate.com/github/cucumber/aruba)
 
 Aruba is Cucumber extension for Command line applications written in any programming language. Features at a glance:
 


### PR DESCRIPTION
Adds a sweet code climate badge and fixes a typo in the `@announce` section of the readme.
