### PR TITLE
Removing failing comment. Signaling EOF depends on cat, not on OS

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -324,7 +324,7 @@ module Aruba
     end
 
     def type(input)
-      return eot if "" == input ##If on Windows it is actually  (26 == 0x1A)
+      return eot if "" == input
       _write_interactive(_ensure_newline(input))
     end
 


### PR DESCRIPTION
Should resolve https://github.com/cucumber/aruba/issues/136
