### PR TITLE
Clear processes at After hook to avoid Tempfile leakage.

### DIFF
--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -53,4 +53,5 @@ end
 
 After do
   restore_env
+  processes.clear
 end


### PR DESCRIPTION
This is a workaround for Tempfile leakage problem reported on Issue #143.  
It will clear all the registered processes at the After hook of each Scenario execution.  
