### PR TITLE
Execute process as late as possible.

### DIFF
--- a/spec/aruba/process_spec.rb
+++ b/spec/aruba/process_spec.rb
@@ -20,11 +20,10 @@ module Aruba
     end
 
     describe "#stop" do
-      before { process.run! }
-
       it "sends any output to the reader" do
         reader = stub.as_null_object
         reader.should_receive(:stdout).with("yo\n")
+        process.run!
         process.stop(reader, false)
       end
     end


### PR DESCRIPTION
This gives the #stop! call chance to catch this process running and spec succeed. This should address #146.
