### PR TITLE
Close files on SpawnProcess#stop

### DIFF
--- a/lib/aruba/spawn_process.rb
+++ b/lib/aruba/spawn_process.rb
@@ -62,20 +62,21 @@ module Aruba
       unless @process.exited?
         @process.poll_for_exit(@exit_timeout)
       end
-      reader.stdout stdout
-      reader.stderr stderr
       @exit_code = @process.exit_code
       @process = nil
       close_and_cache_out
       close_and_cache_err
+      if reader
+        reader.stdout stdout
+        reader.stderr stderr
+      end
       @exit_code
     end
 
     def terminate
       if @process
-        stdout && stderr # flush output
         @process.stop
-        stdout && stderr # flush output
+        stop nil
       end
     end
 


### PR DESCRIPTION
Alternate implementation to #149

`SpawnProcess` creates files to use for stdout and stderr which are opened but never closed, this leaks file descriptors that eventually cause larger test suites to fail on some systems (I encountered this with [rspec-core](/rspec/rspec-core) ).

This implementation closes the tmp files during the `SpawnProcess#stop(reader)` thus cleaning up the files and preventing the issue, however this causes an issue if steps attempt to access the files after the process has finished, to handle that eventuality the output of reading the streams is captured and used in the event of an `IOError`.
