### PR TITLE
Document "I close the stdin stream" for interactive processes that run indefinitely

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ Before('@slow_process') do
 end
 ```
 
+If you are testing output from an interactive process, your test may time out and fail if the process
+continues to run after outputting. To prevent this, you should run the "I close the stdin stream" step
+before testing the output:
+
+```gherkin
+When I run `cat` interactively
+And I type "hello"
+And I close the stdin stream
+Then the stdout should contain "hello"
+```
+
 ### Tags
 
 Aruba defines several tags that you can put on on individual scenarios, or on a feature.


### PR DESCRIPTION
I ran into a [problem](https://github.com/zaaanderson/glittery/issues/1) a few months ago in which Aruba would time out when testing output from an interactive process that was still running when the "the stdout should contain" step ran. This is intended behavior in Aruba, of course, since it's supposed to wait for an interactive process to finish in order to prevent race conditions, but it wasn't clear to me that the "the stdout should contain" step would by default be affected by this feature.

An "I close the stdin stream" step has been added to Aruba that addresses this problem, but it's undocumented. I've added some brief documentation to the readme that describes how to use it to keep Aruba from timing out in a situation like this.
