### PR TITLE
Reporting argument error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
 matrix:
   allow_failures:
     - rvm: rbx
+
+before_install: "sudo easy_install Pygments"
+
 notifications:
   email:
     - cukes-devs@googlegroups.com

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'kramdown', '>= 0.14'
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'rspec', '>= 2.11.0'
-  s.add_development_dependency 'rdiscount', '>= 2.1.6'
+  s.add_development_dependency 'rdiscount', '>= 2.1.6' unless RUBY_PLATFORM == 'java'
   s.add_development_dependency 'fuubar', '>= 1.1.1'
 
   s.rubygems_version = ">= 1.6.1"

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'kramdown', '>= 0.14'
   s.add_development_dependency 'rake', '>= 0.9.2'
   s.add_development_dependency 'rspec', '>= 2.11.0'
+  s.add_development_dependency 'rdiscount', '>= 2.1.6'
   s.add_development_dependency 'fuubar', '>= 1.1.1'
 
   s.rubygems_version = ">= 1.6.1"

--- a/features/reporting.feature
+++ b/features/reporting.feature
@@ -7,6 +7,7 @@ Feature: Reporting
   - The output from those commands (in colour if the output uses ANSI escapes)
   - The files that were created (syntax highlighted in in colour)
 
+  @wip-jruby-java-1.6
   Scenario: Running a simple Aruba feature with reporting on should not error
     When I run `cucumber ../../features/before_cmd_hooks.feature ARUBA_REPORT_DIR=doc`
     Then the exit status should be 0

--- a/features/reporting.feature
+++ b/features/reporting.feature
@@ -1,0 +1,12 @@
+Feature: Reporting
+
+  Aruba can generate a HTML page for each scenario that contains:
+  - The title of the scenario
+  - The description from the scenario (You can use Markdown here)
+  - The command(s) that were run
+  - The output from those commands (in colour if the output uses ANSI escapes)
+  - The files that were created (syntax highlighted in in colour)
+
+  Scenario: Running a simple Aruba feature with reporting on should not error
+    When I run `cucumber ../../features/before_cmd_hooks.feature ARUBA_REPORT_DIR=doc`
+    Then the exit status should be 0

--- a/lib/aruba/reporting.rb
+++ b/lib/aruba/reporting.rb
@@ -1,6 +1,6 @@
 if(ENV['ARUBA_REPORT_DIR'])
   ENV['ARUBA_REPORT_TEMPLATES'] ||= File.dirname(__FILE__) + '/../../templates'
-  
+
   require 'fileutils'
   require 'erb'
   require 'cgi'
@@ -17,14 +17,14 @@ if(ENV['ARUBA_REPORT_DIR'])
           end
         end
       end
-      
+
       def pygmentize(file)
         pygmentize = SpawnProcess.new(%{pygmentize -f html -O encoding=utf-8 "#{file}"}, 3, 0.5)
         pygmentize.run! do |p|
           exit_status = p.stop(false)
           if(exit_status == 0)
-            p.stdout(false)
-          elsif(p.stderr(false) =~ /no lexer/) # Pygment's didn't recognize it
+            p.stdout
+          elsif(p.stderr =~ /no lexer/) # Pygment's didn't recognize it
             IO.read(file)
           else
             STDERR.puts "\e[31m#{p.stderr} - is pygments installed?\e[0m"
@@ -61,13 +61,13 @@ if(ENV['ARUBA_REPORT_DIR'])
         erb = ERB.new(template('main.erb'), nil, '-')
         erb.result(binding)
       end
-      
+
       def files
         erb = ERB.new(template('files.erb'), nil, '-')
         file = current_dir
         erb.result(binding)
       end
-      
+
       def again(erb, _erbout, file)
         _erbout.concat(erb.result(binding))
       end


### PR DESCRIPTION
Given I have pygments, bcat, and rdiscount installed
When I ran my cucumber features with ARUBA_REPORT_DIR=doc
Then I received an ArgumentError from inside lib/aruba/reporting.rb

I poked around the history of ```SpawnProcess``` and ```Reporting``` to try and confirm that you dropped the ```filter_ansi``` flag support, seems so.

I suppose this'll take more work to make Travis happy... I tried tagging it as ```@wip``` for jruby, but i didn't take a close look at how to do that right.