### PR TITLE
Changing rspec syntax because that seems to be the future of rspec http:...

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'bcat', '>= 0.6.1'
   s.add_development_dependency 'kramdown', '>= 0.14'
   s.add_development_dependency 'rake', '>= 0.9.2'
-  s.add_development_dependency 'rspec', '>= 2.7.0'
+  s.add_development_dependency 'rspec', '>= 2.11.0'
   s.add_development_dependency 'fuubar', '>= 1.1.1'
 
   s.rubygems_version = ">= 1.6.1"

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -108,15 +108,15 @@ module Aruba
         paths.each do |path|
           if path.kind_of? Regexp
             if expect_presence
-              Dir.glob('**/*').should include_regexp(path)
+              expect(Dir.glob('**/*')).to include_regexp(path)
             else
-              Dir.glob('**/*').should_not include_regexp(path)
+              expect(Dir.glob('**/*')).not_to include_regexp(path)
             end
           else
             if expect_presence
-              File.should be_file(path)
+              expect(File).to be_file(path)
             else
-              File.should_not be_file(path)
+              expect(File).not_to be_file(path)
             end
           end
         end
@@ -134,7 +134,7 @@ module Aruba
     def check_file_size(paths_and_sizes)
       prep_for_fs_check do
         paths_and_sizes.each do |path, size|
-          File.size(path).should == size
+          expect(File.size(path)).to eq size
         end
       end
     end
@@ -151,24 +151,24 @@ module Aruba
       prep_for_fs_check do
         content = IO.read(file)
         if expect_match
-          content.should =~ regexp
+          expect(content).to match regexp
         else
-          content.should_not =~ regexp
+          expect(content).not_to match regexp
         end
       end
     end
 
     def check_exact_file_content(file, exact_content)
-      prep_for_fs_check { IO.read(file).should == exact_content }
+      prep_for_fs_check { expect(IO.read(file)).to eq exact_content }
     end
 
     def check_directory_presence(paths, expect_presence)
       prep_for_fs_check do
         paths.each do |path|
           if expect_presence
-            File.should be_directory(path)
+            expect(File).to be_directory(path)
           else
-            File.should_not be_directory(path)
+            expect(File).not_to be_directory(path)
           end
         end
       end
@@ -228,30 +228,30 @@ module Aruba
 
     def assert_exact_output(expected, actual)
       actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-      unescape(actual).should == unescape(expected)
+      expect(unescape(actual)).to eq unescape(expected)
     end
 
     def assert_partial_output(expected, actual)
       actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-      unescape(actual).should include(unescape(expected))
+      expect(unescape(actual)).to include(unescape(expected))
     end
 
     def assert_matching_output(expected, actual)
       actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-      unescape(actual).should =~ /#{unescape(expected)}/m
+      expect(unescape(actual)).to match /#{unescape(expected)}/m
     end
 
     def assert_not_matching_output(expected, actual)
       actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-      unescape(actual).should_not =~ /#{unescape(expected)}/m
+      expect(unescape(actual)).not_to match /#{unescape(expected)}/m
     end
 
     def assert_no_partial_output(unexpected, actual)
       actual.force_encoding(unexpected.encoding) if RUBY_VERSION >= "1.9"
       if Regexp === unexpected
-        unescape(actual).should_not =~ unexpected
+        expect(unescape(actual)).not_to match unexpected
       else
-        unescape(actual).should_not include(unexpected)
+        expect(unescape(actual)).not_to include(unexpected)
       end
     end
 
@@ -287,12 +287,12 @@ module Aruba
     end
 
     def assert_exit_status(status)
-      last_exit_status.should eq(status),
+      expect(last_exit_status).to eq(status),
         append_output_to("Exit status was #{last_exit_status} but expected it to be #{status}.")
     end
 
     def assert_not_exit_status(status)
-      last_exit_status.should_not eq(status),
+      expect(last_exit_status).not_to eq(status),
         append_output_to("Exit status was #{last_exit_status} which was not expected.")
     end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -31,7 +31,7 @@ describe Aruba::Api  do
 
   describe 'current_dir' do
     it "should return the current dir as 'tmp/aruba'" do
-      @aruba.current_dir.should match(/^tmp\/aruba$/)
+      expect(@aruba.current_dir).to match(/^tmp\/aruba$/)
     end
 
     it "can be cleared" do
@@ -59,7 +59,7 @@ describe Aruba::Api  do
       end
       it 'should delete directory' do
         @aruba.remove_dir(@directory_name)
-        File.exist?(@directory_path).should == false
+        expect(File.exist?(@directory_path)).to eq false
       end
     end
   end
@@ -68,8 +68,8 @@ describe Aruba::Api  do
     context 'fixed size' do
       it "should write a fixed sized file" do
         @aruba.write_fixed_size_file(@file_name, @file_size)
-        File.exist?(@file_path).should == true
-        File.size(@file_path).should == @file_size
+        expect(File.exist?(@file_path)).to eq true
+        expect(File.size(@file_path)).to eq @file_size
       end
 
       it "should check an existing file size" do
@@ -79,14 +79,14 @@ describe Aruba::Api  do
 
       it "should check an existing file size and fail" do
         @aruba.write_fixed_size_file(@file_name, @file_size)
-        lambda { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.should raise_error
+        expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
       end
     end
     context 'existing' do
       before(:each) { File.open(@file_path, 'w') { |f| f << "" } }
       it "should delete file" do
         @aruba.remove_file(@file_name)
-        File.exist?(@file_path).should == false
+        expect(File.exist?(@file_path)).to eq false
       end
 
       it "should change a file's mode" do
@@ -151,19 +151,19 @@ describe Aruba::Api  do
       after(:each){@aruba.stop_processes!}
       context 'enabled' do
         it "should announce to stdout exactly once" do
-          @aruba.should_receive(:announce_or_puts).once
+          expect(@aruba).to receive(:announce_or_puts).once
           @aruba.set_tag(:announce_stdout, true)
           @aruba.run_simple('echo "hello world"', false)
-          @aruba.all_output.should match(/hello world/)
+          expect(@aruba.all_output).to match(/hello world/)
         end
       end
 
       context 'disabled' do
         it "should not announce to stdout" do
-          @aruba.should_not_receive(:announce_or_puts)
+          expect(@aruba).not_to receive(:announce_or_puts)
           @aruba.set_tag(:announce_stdout, false)
           @aruba.run_simple('echo "hello world"', false)
-          @aruba.all_output.should match(/hello world/)
+          expect(@aruba.all_output).to match(/hello world/)
         end
       end
     end
@@ -176,7 +176,7 @@ describe Aruba::Api  do
 
     it "checks the given file's full content against the expectations in the passed block" do
        @aruba.with_file_content @file_name do |full_content|
-         full_content.should == "foo bar baz"
+         expect(full_content).to eq "foo bar baz"
        end
     end
 
@@ -184,8 +184,8 @@ describe Aruba::Api  do
       it "is successful when the inner expectations match" do
         expect do
           @aruba.with_file_content @file_name do |full_content|
-            full_content.should     match /foo/
-            full_content.should_not match /zoo/
+            expect(full_content).to     match /foo/
+            expect(full_content).not_to match /zoo/
           end
         end . not_to raise_error
       end
@@ -193,8 +193,8 @@ describe Aruba::Api  do
       it "raises RSpec::Expectations::ExpectationNotMetError when the inner expectations don't match"  do
         expect do
           @aruba.with_file_content @file_name do |full_content|
-            full_content.should     match /zoo/
-            full_content.should_not match /foo/
+            expect(full_content).to     match /zoo/
+            expect(full_content).not_to match /foo/
           end
         end . to raise_error RSpec::Expectations::ExpectationNotMetError
       end
@@ -222,20 +222,20 @@ describe Aruba::Api  do
     it "respond to input" do
       @aruba.type "Hello"
       @aruba.type ""
-      @aruba.all_output.should == "Hello\n"
+      expect(@aruba.all_output).to eq  "Hello\n"
     end
 
     it "respond to close_input" do
       @aruba.type "Hello"
       @aruba.close_input
-      @aruba.all_output.should == "Hello\n"
+      expect(@aruba.all_output).to eq  "Hello\n"
     end
 
     it "pipes data" do
       @aruba.write_file(@file_name, "Hello\nWorld!")
       @aruba.pipe_in_file(@file_name)
       @aruba.close_input
-      @aruba.all_output.should == "Hello\nWorld!"
+      expect(@aruba.all_output).to eq  "Hello\nWorld!"
     end
   end
 
@@ -244,12 +244,12 @@ describe Aruba::Api  do
     after(:each){@aruba.stop_processes!}
     describe "get_process" do
       it "returns a process" do
-        @aruba.get_process("true").should_not be(nil)
+        expect(@aruba.get_process("true")).not_to be(nil)
       end
 
       it "raises a descriptive exception" do
         expect do
-          @aruba.get_process("false").should_not be(nil)
+          expect(@aruba.get_process("false")).not_to be(nil)
         end.to raise_error(ArgumentError, "No process named 'false' has been started")
       end
     end
@@ -260,7 +260,7 @@ describe Aruba::Api  do
     it "runs with different env" do
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.run "env"
-      @aruba.all_output.should include("LONG_LONG_ENV_VARIABLE")
+      expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE")
     end
 
   end

--- a/spec/aruba/hooks_spec.rb
+++ b/spec/aruba/hooks_spec.rb
@@ -5,14 +5,14 @@ describe Aruba::Hooks do
     hook_was_run = false
     subject.append :hook_label, lambda { hook_was_run = true }
     subject.execute :hook_label, self
-    hook_was_run.should be_true
+    expect(hook_was_run).to be_true
   end
 
   it 'executes a stored hook that takes multiple arguments' do
     hook_values = []
     subject.append :hook_label, lambda { |a,b,c| hook_values = [a,b,c] }
     subject.execute :hook_label, self, 1, 2, 3
-    hook_values.should == [1,2,3]
+    expect(hook_values).to eq [1,2,3]
   end
 
 end

--- a/spec/aruba/jruby_spec.rb
+++ b/spec/aruba/jruby_spec.rb
@@ -17,8 +17,8 @@ describe "Aruba JRuby Startup Helper"  do
     with_constants :ENV => @fake_env, :RUBY_PLATFORM => 'x86_64-chocolate' do
       load 'aruba/jruby.rb'
       Aruba.config.hooks.execute :before_cmd, self
-      ENV['JRUBY_OPTS'].should  == "--1.9"
-      ENV['JAVA_OPTS'].should  == "-Xdebug"
+      expect(ENV['JRUBY_OPTS']).to eq "--1.9"
+      expect(ENV['JAVA_OPTS']).to eq "-Xdebug"
     end
   end
 
@@ -27,8 +27,8 @@ describe "Aruba JRuby Startup Helper"  do
       RbConfig::CONFIG.stub(:[] => 'solaris')
       load 'aruba/jruby.rb'
       Aruba.config.hooks.execute :before_cmd, self
-      ENV['JRUBY_OPTS'].should  == "-X-C --1.9"
-      ENV['JAVA_OPTS'].should  == "-d32 -Xdebug"
-    end 
+      expect(ENV['JRUBY_OPTS']).to eq "-X-C --1.9"
+      expect(ENV['JAVA_OPTS']).to eq "-d32 -Xdebug"
+    end
   end
 end

--- a/spec/aruba/spawn_process_spec.rb
+++ b/spec/aruba/spawn_process_spec.rb
@@ -9,12 +9,12 @@ module Aruba
       before { process.run! }
 
       it "returns the stdout" do
-        process.stdout.should == "yo\n"
+        expect(process.stdout).to eq "yo\n"
       end
 
       it "returns all the stdout, every time you call it" do
-        process.stdout.should == "yo\n"
-        process.stdout.should == "yo\n"
+        expect(process.stdout).to eq "yo\n"
+        expect(process.stdout).to eq "yo\n"
       end
 
     end
@@ -36,7 +36,7 @@ module Aruba
         let(:process_failure) { SpawnProcess.new('does_not_exists', 1, 1) }
 
         it "raises a Aruba::LaunchError" do
-          lambda{process_failure.run!}.should raise_error(::Aruba::LaunchError)
+          expect{process_failure.run!}.to raise_error(::Aruba::LaunchError)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,9 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.include(ManipulatesConstants)
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
 
   config.before( :each ) {
     clean_current_dir


### PR DESCRIPTION
Hi folk after having read
http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax

It seems like the `expect` syntax is going to be the future syntax for rspec, so I was considering if this was the way for us to go...

Even though I am most used to the `should` syntax I personally I don't have a strong opinion about this, but there are some good arguments in the blog, so I thought this might be the right opportunity to shift to the `expect` syntax,

Any opinions?
