### PR TITLE
Add Ruby 2.1.0 and rbx to .travis.yml.  Add required Rubinius gems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: ruby
-rvm: 
+rvm:
+  - 2.1.0
   - 2.0.0
   - 1.9.3
   - 1.8.7
   - jruby-18mode
-
+  - rbx
+matrix:
+  allow_failures:
+    - rvm: rbx
 notifications:
   email:
     - cukes-devs@googlegroups.com

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,11 @@
 source "http://rubygems.org"
 gemspec
 
+platforms :rbx do
+  gem 'rubysl', '~> 2.0'
+  gem 'rubinius-developer_tools'
+end
+
 # Use source from sibling folders (if available) instead of gems
 # %w[cucumber].each do |g|
 #   if File.directory?(File.dirname(__FILE__) + "/../#{g}")


### PR DESCRIPTION
1. Added Ruby 2.1.0 to Travis
2. Added gems required for Rubinius to Gemfile
3. Added rbx label to .travis.yml, but allowed failures

I'm seeing a couple of failures under Rubinius that are occurring because a process is still alive after stop_process is called.  Otherwise rbx runs green.
