### PR TITLE
Adds .rvmrc and .ruby-version to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ tmp
 .bundle
 doc
 Gemfile.lock
+
+## RVM and RBENV
+.rvmrc
+.ruby-version

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm @cucumber


### PR DESCRIPTION
Developers can manage their own Ruby versions.
