### PR TITLE
Fix reporting when using 'Given a file named "filename"'

### DIFF
--- a/lib/aruba/reporting.rb
+++ b/lib/aruba/reporting.rb
@@ -23,8 +23,8 @@ if(ENV['ARUBA_REPORT_DIR'])
         pygmentize.run! do |p|
           exit_status = p.stop(false)
           if(exit_status == 0)
-            p.stdout(false)
-          elsif(p.stderr(false) =~ /no lexer/) # Pygment's didn't recognize it
+            p.stdout
+          elsif(p.stderr =~ /no lexer/) # Pygment's didn't recognize it
             IO.read(file)
           else
             STDERR.puts "\e[31m#{p.stderr} - is pygments installed?\e[0m"


### PR DESCRIPTION
With a *.feature* file like this:
```gherkin
  Scenario: use a file
    Given a file named "input" with:
    """
    test
    """
    When I run `cat test`
    Then the output should contain "test"
```
If I run `bundle exec cucumber`, the test will pass. If I enable reporting by setting the environment variable like this `export ARUBA_REPORT_DIR='/tmp/doc'; bundle exec cucumber`, the test will fail with a message like this:
```
      wrong number of arguments (1 for 0) (ArgumentError)
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/spawn_process.rb:49:in `stderr'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:27:in `block in pygmentize'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/spawn_process.rb:34:in `run!'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:23:in `pygmentize'
      (erb):8:in `block in files'
      (erb):3:in `each'
      (erb):3:in `files'
      /mnt/fio/cvoltz/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/erb.rb:838:in `eval'
      /mnt/fio/cvoltz/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/erb.rb:838:in `result'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:68:in `files'
      (erb):23:in `report'
      /mnt/fio/cvoltz/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/erb.rb:838:in `eval'
      /mnt/fio/cvoltz/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/erb.rb:838:in `result'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:62:in `report'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:105:in `block (2 levels) in <top (required)>'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:104:in `open'
      /home/cvoltz/.rvm/gems/ruby-1.9.3-p448/gems/aruba-0.5.4/lib/aruba/reporting.rb:104:in `After'
```
The problem appears to be that in *reporting.rb*, the calls to *stdout* and *stderr* are supplying a parameter which is no longer implemented in *spawn_process.rb*. This patch removes the unused parameters, which lets the test pass with reporting enabled.