### PR TITLE
Ignore Rubymine project directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ tmtags
 \#*
 .\#*
 
+## RUBYMINE
+.idea
+
 ## VIM
 *.swp
 tags


### PR DESCRIPTION
Ignore the `.idea` directory used by Rubymine similar to the ignores for other editors.
