### PR TITLE
Use stub_const in favor of old, custom patch

### DIFF
--- a/spec/aruba/jruby_spec.rb
+++ b/spec/aruba/jruby_spec.rb
@@ -9,29 +9,32 @@ describe "Aruba JRuby Startup Helper"  do
   end
   before(:each) do
     Aruba.config = Aruba::Config.new
+
     @fake_env['JRUBY_OPTS'] = "--1.9"
     @fake_env['JAVA_OPTS'] = "-Xdebug"
+
+    stub_const('ENV', @fake_env)
   end
 
   it 'configuration does not load when RUBY_PLATFORM is not java' do
-    with_constants :ENV => @fake_env, :RUBY_PLATFORM => 'x86_64-chocolate' do
-      load 'aruba/jruby.rb'
-      Aruba.config.hooks.execute :before_cmd, self
-      expect(ENV['JRUBY_OPTS']).to eq "--1.9"
-      expect(ENV['JAVA_OPTS']).to eq "-Xdebug"
-    end
+    stub_const('RUBY_PLATFORM', 'x86_64-chocolate')
+
+    load 'aruba/jruby.rb'
+    Aruba.config.hooks.execute :before_cmd, self
+    expect(ENV['JRUBY_OPTS']).to eq "--1.9"
+    expect(ENV['JAVA_OPTS']).to eq "-Xdebug"
   end
 
   it 'configuration loads for java and merges existing environment variables' do
-    with_constants :ENV => @fake_env, :RUBY_PLATFORM => 'java'  do
-      rb_config = double('rb_config')
-      allow(rb_config).to receive(:[]).and_return('solaris')
-      stub_const 'RbConfig::CONFIG', rb_config
+    stub_const('RUBY_PLATFORM', 'java')
 
-      load 'aruba/jruby.rb'
-      Aruba.config.hooks.execute :before_cmd, self
-      expect(ENV['JRUBY_OPTS']).to eq "-X-C --1.9"
-      expect(ENV['JAVA_OPTS']).to eq "-d32 -Xdebug"
-    end
+    rb_config = double('rb_config')
+    allow(rb_config).to receive(:[]).and_return('solaris')
+    stub_const 'RbConfig::CONFIG', rb_config
+
+    load 'aruba/jruby.rb'
+    Aruba.config.hooks.execute :before_cmd, self
+    expect(ENV['JRUBY_OPTS']).to eq "-X-C --1.9"
+    expect(ENV['JAVA_OPTS']).to eq "-d32 -Xdebug"
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,44 +1,9 @@
 require 'rspec/core'
 require 'aruba/api'
 
-module ManipulatesConstants
-  # http://digitaldumptruck.jotabout.com/?p=551
-  def with_constants(constants, &block)
-    saved_constants = {}
-    constants.each do |constant, val|
-      saved_constants[ constant ] = Object.const_get( constant )
-      Kernel::silence_warnings { Object.const_set( constant, val ) }
-    end
-
-    begin
-      block.call
-    ensure
-      constants.each do |constant, val|
-        Kernel::silence_warnings { Object.const_set( constant, saved_constants[ constant ] ) }
-      end
-    end
-  end
-end
-
-# http://mislav.uniqpath.com/2011/06/ruby-verbose-mode/
-# these methods are already present in Active Support
-module Kernel
-  def silence_warnings
-    with_warnings(nil) { yield }
-  end
-
-  def with_warnings(flag)
-    old_verbose, $VERBOSE = $VERBOSE, flag
-    yield
-  ensure
-    $VERBOSE = old_verbose
-  end
-end unless Kernel.respond_to? :silence_warnings
-
 RSpec.configure do |config|
   config.filter_run :focus => true
   config.run_all_when_everything_filtered = true
-  config.include(ManipulatesConstants)
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
With the introduction of `stub_const` in rspec-mocks 2.11, there was no need for `with_constants` since rspec can handle the constant stubbing itself now.  New code used `stub_const` inside the `with_constants` block, but no one went back yet to refactor the old code to use `stub_const`.
