### PR TITLE
Use simplecov for coverage reports for specs and cucumber

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,8 +1,40 @@
-SimpleCov.start do
-  add_filter "/features/"
-  add_filter "/spec/"
-  add_filter "/tmp"
-  add_filter "/vendor"
-  
-  add_group "lib", "lib"
+# RM_INFO is set when using Rubymine.  In Rubymine, starting SimpleCov is
+# controlled by running with coverage, so don't explicitly start coverage (and
+# therefore generate a report) when in Rubymine.  This _will_ generate a report
+# whenever `rake spec` is run.
+SimpleCov.start unless ENV.key? 'ARUBA_NO_COVERAGE'
+
+SimpleCov.configure do
+  # ignore this file
+  add_filter '.simplecov'
+
+  # Rake tasks aren't tested with rspec
+  add_filter 'Rakefile'
+  add_filter 'lib/tasks'
+
+  #
+  # Changed Files in Git Group
+  # @see http://fredwu.me/post/35625566267/simplecov-test-coverage-for-changed-files-only
+  #
+
+  untracked = `git ls-files --exclude-standard --others`
+  unstaged = `git diff --name-only`
+  staged = `git diff --name-only --cached`
+  all = untracked + unstaged + staged
+  changed_filenames = all.split("\n")
+
+  add_group 'Changed' do |source_file|
+    changed_filenames.select do |changed_filename|
+      source_file.filename.end_with?(changed_filename)
+    end
+  end
+
+  add_group 'Libraries', 'lib'
+
+  #
+  # Specs are reported on to ensure that all examples are being run and all
+  # lets, befores, afters, etc are being used.
+  #
+
+  add_group 'Specs', 'spec'
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,35 @@
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../../lib')
-require 'aruba/cucumber'
+
+# Has to be the first file required so that all other files show coverage information
+require 'simplecov'
+
+#
+# Standard Library
+#
+
 require 'fileutils'
+require 'pathname'
+
+#
+# Gems
+#
+
+require 'aruba/cucumber'
 require 'rspec/expectations'
+
+Before do |scenario|
+  command_name = case scenario
+                 when Cucumber::RunningTestCase::Scenario
+                   "#{scenario.feature.title} #{scenario.name}"
+                 else
+                   raise TypeError.new("Don't know how to extract command name from #{scenario.class}")
+                 end
+
+  # Used in simplecov_setup so that each scenario has a different name and their coverage results are merged instead
+  # of overwriting each other as 'Cucumber Features'
+  set_env('SIMPLECOV_COMMAND_NAME', command_name)
+
+  simplecov_setup_pathname = Pathname.new(__FILE__).expand_path.parent.join('simplecov_setup')
+  # set environment variable so child processes will merge their coverage data with parent process's coverage data.
+  set_env('RUBYOPT', "-r#{simplecov_setup_pathname} #{ENV['RUBYOPT']}")
+end

--- a/features/support/simplecov_setup.rb
+++ b/features/support/simplecov_setup.rb
@@ -1,0 +1,9 @@
+# @note this file is loaded in env.rb to setup simplecov using RUBYOPTs for child processes and @in-process
+
+require 'simplecov'
+
+root = File.expand_path('../../../', __FILE__)
+
+SimpleCov.command_name(ENV['SIMPLECOV_COMMAND_NAME'])
+SimpleCov.root(root)
+load File.join(root, '.simplecov')

--- a/spec/aruba/spawn_process_spec.rb
+++ b/spec/aruba/spawn_process_spec.rb
@@ -3,7 +3,7 @@ require 'aruba/spawn_process'
 module Aruba
   describe SpawnProcess do
 
-    let(:process) { SpawnProcess.new('echo "yo"', 0.1, 0.1) }
+    let(:process) { SpawnProcess.new('echo "yo"', 1, 1) }
 
     describe "#stdout" do
       before { process.run! }


### PR DESCRIPTION
simplecov is a wrapper on the built-in coverage library for Ruby 1.9+.  When running `rake spec` or `rake cucumber`, a coverage report will be output in coverage/index.html.  If you run both tasks or all tasks with `rake spec` within a close enough time window (I think 10 minutes) the results will all be merged so you can get coverage across both the specs and features.  If this PR is accepts, then I'll add another to use coveralls.io to publish the coverage reports to coveralls.io, but someone with admin access will have to setup the hooks on coveralls.io for that.  Additionally, the reports from simplecov are a confirmation that not all steps are being exercised, include the ones dealing with rvm.  I have a fix for that too that I can post in a later PR.

![screen shot 2014-09-25 at 2 04 16 pm](https://cloud.githubusercontent.com/assets/2230482/4410585/09ea8eb6-44e7-11e4-9572-f7f83ba28451.png)

# Verifications Steps

## specs

- [ ] `rake spec`
- [ ] VERIFY no failures
- [ ] `open coverage/index.html`
- [ ] VERIFY coverage report includes specs
- [ ] `rm -rf coverage`

## cucumber

- [ ] `rake cucumber`
- [ ] VERIFY no failures
- [ ] `open coverage/index.html`
- [ ] VIERFY coverage report includes features and steps
- [ ] `rm -rf coverage`

## all

- [ ] `rake`
- [ ] VERIFY no failures
- [ ] `open coverage/index.html`
- [ ] VERIFY coverage includes specs, features, and steps
