### PR TITLE
Add force flag to remove_dir and remove_file

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -224,11 +224,15 @@ module Aruba
     #
     # @param [String] file_name
     #    The file which should be deleted in current directory
-    def remove_file(file_name)
+    def remove_file(file_name, force = false)
       in_current_dir do
         file_name = File.expand_path(file_name)
 
-        FileUtils.rm(file_name)
+        if force
+          FileUtils.rm_f(file_name)
+        else
+          FileUtils.rm(file_name)
+        end
       end
     end
 
@@ -264,11 +268,15 @@ module Aruba
     #
     # @param [String] directory_name
     #   The name of the directory which should be removed
-    def remove_dir(directory_name)
+    def remove_dir(directory_name, force = true)
       in_current_dir do
         directory_name = File.expand_path(directory_name)
 
-        FileUtils.rmdir(directory_name)
+        if force
+          FileUtils.rm_rf(directory_name)
+        else
+          FileUtils.rm_r(directory_name)
+        end
       end
     end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -91,13 +91,13 @@ describe Aruba::Api  do
 
       it "fails if directory does not exist" do
         expect {
-          @aruba.remove_dir(@directory_name + '1', force: false)
+          @aruba.remove_dir(@directory_name + '1', false)
         }.to raise_error Errno::ENOENT
       end
 
       it "does not care if directory exists" do
         expect {
-          @aruba.remove_dir(@directory_name + '1', force: true)
+          @aruba.remove_dir(@directory_name + '1', true)
         }.not_to raise_error
       end
     end
@@ -278,13 +278,13 @@ describe Aruba::Api  do
 
       it "fails if file does not exist" do
         expect {
-          @aruba.remove_file(@file_name + '1', force: false)
+          @aruba.remove_file(@file_name + '1', false)
         }.to raise_error Errno::ENOENT
       end
 
       it "does not care if file exist" do
         expect {
-          @aruba.remove_file(@file_name + '1', force: true)
+          @aruba.remove_file(@file_name + '1', true)
         }.not_to raise_error
       end
     end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -88,6 +88,18 @@ describe Aruba::Api  do
           expect(File.exist?(File.expand_path(directory_path))).to eq false
         end
       end
+
+      it "fails if directory does not exist" do
+        expect {
+          @aruba.remove_dir(@directory_name + '1', force: false)
+        }.to raise_error Errno::ENOENT
+      end
+
+      it "does not care if directory exists" do
+        expect {
+          @aruba.remove_dir(@directory_name + '1', force: true)
+        }.not_to raise_error
+      end
     end
   end
 
@@ -245,6 +257,7 @@ describe Aruba::Api  do
         end
       end
     end
+
     context '#remove_file' do
       before(:each) { File.open(@file_path, 'w') { |f| f << "" } }
 
@@ -261,6 +274,18 @@ describe Aruba::Api  do
           @aruba.remove_file(file_path)
           expect(File.exist?(file_path)).to eq false
         end
+      end
+
+      it "fails if file does not exist" do
+        expect {
+          @aruba.remove_file(@file_name + '1', force: false)
+        }.to raise_error Errno::ENOENT
+      end
+
+      it "does not care if file exist" do
+        expect {
+          @aruba.remove_file(@file_name + '1', force: true)
+        }.not_to raise_error
       end
     end
 


### PR DESCRIPTION
It was not possible to force `#remove_file` to "delete" an not existing file. It just raised an error. I added a `force`-option, so that no error is raised if a file/directory does not exists.

To make `#remove_dir` backward-compatible I set `force` to `true`, because `Dir.rmdir` does not care if a directory exists or not.