### PR TITLE
Add fixtures to aruba

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,69 @@ end
 
 Refer to http://blog.headius.com/2010/03/jruby-startup-time-tips.html for other tips on startup time.
 
+## Fixtures
+
+Sometimes your tests need existing files to work - e.g binary data files you
+cannot create programmatically. Since `aruba` >= 0.6.3 includes some basic
+support for fixtures. All you need to do is the following:
+
+1. Create a `fixtures`-directory
+2. Create fixture files in this directory
+
+The `expand_path`-helper will expand `%` to the path of your fixtures
+directory:
+
+```ruby
+expand_path('%/song.mp3')
+# => /home/user/projects/my_project/fixtures/song.mp3
+```
+
+*Example*
+
+1. Create fixtures directory
+
+  ```bash
+  cd project
+  
+  mkdir -p fixtures/
+  # or
+  mkdir -p test/fixtures/
+  # or
+  mkdir -p spec/fixtures/
+  # or
+  mkdir -p features/fixtures/
+  ```
+
+2. Store `song.mp3` in `fixtures`-directory
+
+  ```bash
+  cp song.mp3 fixtures/
+  ```
+
+3. Add fixture to vcs-repository - e.g. `git`, `mercurial`
+
+4. Create test
+
+  ```ruby
+  RSpec.describe 'My Feature' do
+    describe '#read_music_file' do
+      context 'when the file exists' do
+        let(:path) { expand_path('%/song.mp3') }
+
+        before :each do
+          in_current_directory { FileUtils.cp path, 'file.mp3' }
+        end
+
+        before :each do
+          run 'my_command'
+        end
+
+        it { expect(all_stdout).to include('Rate is 128 KB') }
+      end
+    end
+  end
+  ```
+
 ## Reporting
 
 *Important* - you need [Pygments](http://pygments.org/) installed to use this feature.

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -2,8 +2,8 @@
 RSpec::Matchers.define :have_same_file_content_like do |expected|
   match do |actual|
     FileUtils.compare_file(
-      absolute_path(actual),
-      absolute_path(expected)
+      expand_path(actual),
+      expand_path(expected)
     )
   end
 

--- a/lib/aruba/matchers/mode.rb
+++ b/lib/aruba/matchers/mode.rb
@@ -8,21 +8,21 @@ RSpec::Matchers.define :have_permissions do |expected|
 
   match do |actual|
     file_name = actual
-    actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
+    actual_permissions = sprintf( "%o", File::Stat.new(expand_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
 
     actual_permissions == expected_permissions
   end
 
   failure_message do |actual|
     file_name = actual
-    actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
+    actual_permissions = sprintf( "%o", File::Stat.new(expand_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
 
     format("expected that file \"%s\" would have permissions \"%s\", but has \"%s\".", file_name, expected_permissions, actual_permissions)
   end
 
   failure_message_when_negated do |actual|
     file_name = actual
-    actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
+    actual_permissions = sprintf( "%o", File::Stat.new(expand_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
 
     format("expected that file \"%s\" would not have permissions \"%s\", but has \"%s\".", file_name, expected_permissions, actual_permissions)
   end


### PR DESCRIPTION
This PR adds the basics to support fixtures in `aruba`. Also see  #219.

Things to discuss:

* [ ] Use of `OpenStruct`
  
  I used `OpenStruct` here to make both paths of a fixture available: The relative one which is used to find a fixture and the absolute one, which can be used by a `consumer` of the api like `copy_file`. I can replace this by a `Hash` if this is preferred. Though `OpenStruct` is part of `ruby core distribution`.
  
* [ ] Use of `Pathname`

  I like the `relative_path_from`-functionality of `Pathname`. It makes the intention of the author clear and is quite easy to use to build relative paths.

* [ ] Use of `%/` as fixture path prefix

  It does not have a special meaning in ruby so far - besides percent classes which are not followed by `/`.

* [ ] Order of directories to be searched
  
  I use "my" preferred order here, but I'm open to change it.

* [ ] Commit Style
  
  I will refactor the "commits" after all things above are discussed to make sure that there's one commit for the tests and one commit for the implementation.

* [ ] Rubocop

  I think we will need to "guard" this [line](https://github.com/cucumber/aruba/pull/224/files#diff-65af44ccc0b346dd91178a015aee5560R39) and that [line](https://github.com/cucumber/aruba/pull/224/files#diff-65af44ccc0b346dd91178a015aee5560R786) here because of `===` (3x `=`). But `===` returns `true'/`false` for both `String` AND `Regexp` and thus is more flexible than `==`