### PR TITLE
Use new travis build infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: ruby
 rvm:
 - 2.1.5


### PR DESCRIPTION
The guys @ TravisCI set up a new build infrastructure which supports "faster" build by using `docker`

See http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/ for more information.