### PR TITLE
Rename *_dir to *_directory

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -34,30 +34,51 @@ module Aruba
     #   absolute_path('path', 'file')
     #
     def absolute_path(*args)
-      in_current_dir { File.expand_path File.join(*args) }
+      in_current_directory { File.expand_path File.join(*args) }
     end
 
     # Execute block in current directory
     #
     # @yield
     #   The block which should be run in current directory
-    def in_current_dir(&block)
-      _mkdir(current_dir)
-      Dir.chdir(current_dir, &block)
+    def in_current_directory(&block)
+      _mkdir(current_directory)
+      Dir.chdir(current_directory, &block)
+    end
+
+    # @deprecated
+    # @private
+    def in_current_dir(*args, &block)
+      warn('The use of "in_current_dir" is deprecated. Use "in_current_directory" instead')
+      in_current_directory(*args, &block)
     end
 
     # Clean the current directory
-    def clean_current_dir
-      _rm_rf(current_dir)
-      _mkdir(current_dir)
+    def clean_current_directory
+      _rm_rf(current_directory)
+      _mkdir(current_directory)
+    end
+
+    # @deprecated
+    # @private
+    def clean_current_dir(*args, &block)
+      warn('The use of "clean_current_dir" is deprecated. Use "clean_current_directory" instead')
+      clean_current_directory(*args, &block)
     end
 
     # Get access to current dir
     #
     # @return
     #   Current directory
-    def current_dir
+    def current_directory
       File.join(*dirs)
+    end
+
+    # @deprecated
+    # @private
+    def current_dir(*args, &block)
+      warn('The use of "current_dir" is deprecated. Use "current_directory" instead')
+      current_directory(*args, &block)
     end
 
     # Switch to directory
@@ -66,7 +87,7 @@ module Aruba
     #   The directory
     def cd(dir)
       dirs << dir
-      raise "#{current_dir} is not a directory." unless File.directory?(current_dir)
+      raise "#{current_directory} is not a directory." unless File.directory?(current_directory)
     end
 
     # The path to the directory which should contain all your test data
@@ -138,7 +159,7 @@ module Aruba
 
     # @private
     def _create_file(file_name, file_content, check_presence)
-      in_current_dir do
+      in_current_directory do
         file_name = File.expand_path(file_name)
 
         raise "expected #{file_name} to be present" if check_presence && !File.file?(file_name)
@@ -226,7 +247,7 @@ module Aruba
 
     # @private
     def _create_fixed_size_file(file_name, file_size, check_presence)
-      in_current_dir do
+      in_current_directory do
         file_name = File.expand_path(file_name)
 
         raise "expected #{file_name} to be present" if check_presence && !File.file?(file_name)
@@ -261,7 +282,7 @@ module Aruba
     # @param [String] file_content
     #   The content which should be appended to file
     def append_to_file(file_name, file_content)
-      in_current_dir do
+      in_current_directory do
         file_name = File.expand_path(file_name)
 
         _mkdir(File.dirname(file_name))
@@ -273,19 +294,26 @@ module Aruba
     #
     # @param [String] directory_name
     #   The name of the directory which should be created
-    def create_dir(directory_name)
-      in_current_dir do
+    def create_directory(directory_name)
+      in_current_directory do
         _mkdir(directory_name)
       end
 
       self
     end
 
+    # @private
+    # @deprecated
+    def create_dir(*args)
+      warn('The use of "create_dir" is deprecated. Use "create_directory" instead')
+      create_directory(*args)
+    end
+
     # Remove directory
     #
     # @param [String] directory_name
     #   The name of the directory which should be removed
-    def remove_dir(*args)
+    def remove_directory(*args)
       args = args.flatten
 
       options = if args.last.kind_of? Hash
@@ -297,6 +325,13 @@ module Aruba
       args = args.map { |p| absolute_path(p) }
 
       FileUtils.rm_r(args, options)
+    end
+
+    # @private
+    # @deprecated
+    def remove_dir(*args)
+      warn('The use of "remove_dir" is deprecated. Use "remove_directory" instead')
+      remove_directory(*args)
     end
 
     # Check if paths are present
@@ -333,7 +368,7 @@ module Aruba
     # @param [String] file_name
     #   The file which should be used to pipe in data
     def pipe_in_file(file_name)
-      in_current_dir do
+      in_current_directory do
         file_name = File.expand_path(file_name)
 
         File.open(file_name, 'r').each_line do |line|
@@ -463,7 +498,7 @@ module Aruba
     # @private
     def prep_for_fs_check(&block)
       stop_processes!
-      in_current_dir{ block.call }
+      in_current_directory{ block.call }
     end
 
     # @private
@@ -719,7 +754,7 @@ module Aruba
 
       cmd = detect_ruby(cmd)
 
-      in_current_dir do
+      in_current_directory do
         Aruba.config.hooks.execute(:before_cmd, self, cmd)
 
         announcer.dir(Dir.pwd)

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -69,7 +69,7 @@ When /^I remove the file "([^"]*)"$/ do |file_name|
 end
 
 When(/^I remove the directory "(.*?)"$/) do |directory_name|
-  remove_dir(directory_name)
+  remove_directory(directory_name)
 end
 
 When /^I cd to "([^"]*)"$/ do |dir|

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -12,7 +12,7 @@ After do
 end
 
 Before('~@no-clobber') do
-  clean_current_dir
+  clean_current_directory
 end
 
 Before('@puts') do

--- a/lib/aruba/reporting.rb
+++ b/lib/aruba/reporting.rb
@@ -64,7 +64,7 @@ if(ENV['ARUBA_REPORT_DIR'])
 
       def files
         erb = ERB.new(template('files.erb'), nil, '-')
-        file = current_dir
+        file = current_directory
         erb.result(binding)
       end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -23,32 +23,32 @@ describe Aruba::Api  do
 
     @file_name = "test.txt"
     @file_size = 256
-    @file_path = File.join(@aruba.current_dir, @file_name)
+    @file_path = File.join(@aruba.current_directory, @file_name)
 
     (@aruba.dirs.length - 1).times do |depth| #Ensure all parent dirs exists
       dir = File.join(*@aruba.dirs[0..depth])
       Dir.mkdir(dir) unless File.exist?(dir)
     end
-    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.current_dir[0]
-    FileUtils.rm_rf(@aruba.current_dir)
-    Dir.mkdir(@aruba.current_dir)
+    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.current_directory[0]
+    FileUtils.rm_rf(@aruba.current_directory)
+    Dir.mkdir(@aruba.current_directory)
   end
 
-  describe 'current_dir' do
+  describe 'current_directory' do
     it "should return the current dir as 'tmp/aruba'" do
-      expect(@aruba.current_dir).to match(/^tmp\/aruba$/)
+      expect(@aruba.current_directory).to match(/^tmp\/aruba$/)
     end
 
     it "can be cleared" do
       write_file('test', 'test test test')
 
-      in_current_dir do
+      in_current_directory do
         expect(File.exist?('test')).to be_truthy
       end
 
-      clean_current_dir
+      clean_current_directory
 
-      in_current_dir do
+      in_current_directory do
         expect(File.exist?('test')).to be_falsey
       end
 
@@ -58,7 +58,7 @@ describe Aruba::Api  do
   describe 'directories' do
     before(:each) do
       @directory_name = 'test_dir'
-      @directory_path = File.join(@aruba.current_dir, @directory_name)
+      @directory_path = File.join(@aruba.current_directory, @directory_name)
     end
 
     context '#create_dir' do
@@ -68,13 +68,13 @@ describe Aruba::Api  do
       end
     end
 
-    describe '#remove_dir' do
+    describe '#remove_directory' do
       let(:directory_name) { @directory_name }
       let(:directory_path) { @directory_path }
       let(:options) { {} }
 
       before :each do
-        set_env 'HOME',  File.expand_path(@aruba.current_dir)
+        set_env 'HOME',  File.expand_path(@aruba.current_directory)
       end
 
       context 'when directory exists' do
@@ -83,7 +83,7 @@ describe Aruba::Api  do
         end
 
         before :each do
-          @aruba.remove_dir(directory_name, options)
+          @aruba.remove_directory(directory_name, options)
         end
 
         context 'when is a single directory' do
@@ -92,7 +92,7 @@ describe Aruba::Api  do
 
         context 'when are multiple directorys' do
           let(:directory_name) { %w(directory1 directory2 directory3) }
-          let(:directory_path) { %w(directory1 directory2 directory3).map { |p| File.join(@aruba.current_dir, p) } }
+          let(:directory_path) { %w(directory1 directory2 directory3).map { |p| File.join(@aruba.current_directory, p) } }
 
           it_behaves_like 'a non-existing directory'
         end
@@ -100,7 +100,7 @@ describe Aruba::Api  do
         context 'when path contains ~' do
           let(:string) { random_string }
           let(:directory_name) { File.join('~', string) }
-          let(:directory_path) { File.join(@aruba.current_dir, string) }
+          let(:directory_path) { File.join(@aruba.current_directory, string) }
 
           it_behaves_like 'a non-existing directory'
         end
@@ -108,7 +108,7 @@ describe Aruba::Api  do
 
       context 'when directory does not exist' do
         before :each do
-          @aruba.remove_dir(directory_name, options)
+          @aruba.remove_directory(directory_name, options)
         end
 
         context 'when is forced to delete directory' do
@@ -127,7 +127,7 @@ describe Aruba::Api  do
       let(:options) { {} }
 
       before :each do
-        set_env 'HOME',  File.expand_path(@aruba.current_dir)
+        set_env 'HOME',  File.expand_path(@aruba.current_directory)
       end
 
       before :each do
@@ -142,7 +142,7 @@ describe Aruba::Api  do
 
         context 'and should be created in non-existing directory' do
           let(:file_name) { 'directory/test' }
-          let(:file_path) { File.join(@aruba.current_dir, 'directory/test') }
+          let(:file_path) { File.join(@aruba.current_directory, 'directory/test') }
 
           it_behaves_like 'an existing file'
         end
@@ -150,7 +150,7 @@ describe Aruba::Api  do
         context 'and path includes ~' do
           let(:string) { random_string }
           let(:file_name) { File.join('~', string) }
-          let(:file_path) { File.join(@aruba.current_dir, string) }
+          let(:file_path) { File.join(@aruba.current_directory, string) }
 
           it_behaves_like 'an existing file'
         end
@@ -165,7 +165,7 @@ describe Aruba::Api  do
 
         context 'and multiple file names are given' do
           let(:file_name) { %w(file1 file2 file3) }
-          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_dir, p) } }
+          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_directory, p) } }
           it_behaves_like 'an existing file'
         end
       end
@@ -177,15 +177,15 @@ describe Aruba::Api  do
       end
 
       it 'removes "."' do
-        expect(@aruba.absolute_path('.')).to eq File.expand_path(current_dir)
+        expect(@aruba.absolute_path('.')).to eq File.expand_path(current_directory)
       end
 
       it 'removes ".."' do
-        expect(@aruba.absolute_path('..')).to eq File.expand_path(File.join(current_dir, '..'))
+        expect(@aruba.absolute_path('..')).to eq File.expand_path(File.join(current_directory, '..'))
       end
 
       it 'joins multiple arguments' do
-        expect(@aruba.absolute_path('path', @file_name)).to eq File.expand_path(File.join(current_dir, 'path', @file_name))
+        expect(@aruba.absolute_path('path', @file_name)).to eq File.expand_path(File.join(current_directory, 'path', @file_name))
       end
     end
 
@@ -207,7 +207,7 @@ describe Aruba::Api  do
       it "works with ~ in path name" do
         file_path = File.join('~', random_string)
 
-        with_env 'HOME' => File.expand_path(current_dir) do
+        with_env 'HOME' => File.expand_path(current_directory) do
           @aruba.write_fixed_size_file(file_path, @file_size)
 
           expect(File.exist?(File.expand_path(file_path))).to eq true
@@ -230,7 +230,7 @@ describe Aruba::Api  do
       it "works with ~ in path name" do
         file_path = File.join('~', random_string)
 
-        with_env 'HOME' => File.expand_path(current_dir) do
+        with_env 'HOME' => File.expand_path(current_directory) do
           @aruba.write_fixed_size_file(file_path, @file_size)
           @aruba.check_file_size([[file_path, @file_size]])
         end
@@ -272,7 +272,7 @@ describe Aruba::Api  do
         context 'and path has ~ in it' do
           let(:string) { random_string }
           let(:file_name) { File.join('~', string) }
-          let(:file_path) { File.join(@aruba.current_dir, string) }
+          let(:file_path) { File.join(@aruba.current_directory, string) }
 
           it { expect(actuctual_permissions).to eq('0655') }
         end
@@ -286,7 +286,7 @@ describe Aruba::Api  do
       let(:permissions) { '0655' }
 
       before :each do
-        set_env 'HOME',  File.expand_path(@aruba.current_dir)
+        set_env 'HOME',  File.expand_path(@aruba.current_directory)
       end
 
       before(:each) do
@@ -312,7 +312,7 @@ describe Aruba::Api  do
           context 'and path includes ~' do
             let(:string) { random_string }
             let(:file_name) { File.join('~', string) }
-            let(:file_path) { File.join(@aruba.current_dir, string) }
+            let(:file_path) { File.join(@aruba.current_directory, string) }
 
             it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
           end
@@ -346,7 +346,7 @@ describe Aruba::Api  do
       let(:options) { {} }
 
       before :each do
-        set_env 'HOME',  File.expand_path(@aruba.current_dir)
+        set_env 'HOME',  File.expand_path(@aruba.current_directory)
       end
 
       context 'when file exists' do
@@ -364,7 +364,7 @@ describe Aruba::Api  do
 
         context 'when are multiple files' do
           let(:file_name) { %w(file1 file2 file3) }
-          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_dir, p) } }
+          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_directory, p) } }
 
           it_behaves_like 'a non-existing file'
         end
@@ -372,7 +372,7 @@ describe Aruba::Api  do
         context 'when path contains ~' do
           let(:string) { random_string }
           let(:file_name) { File.join('~', string) }
-          let(:file_path) { File.join(@aruba.current_dir, string) }
+          let(:file_path) { File.join(@aruba.current_directory, string) }
 
           it_behaves_like 'a non-existing file'
         end
@@ -396,7 +396,7 @@ describe Aruba::Api  do
 
       it "should check existence using plain match" do
         file_name = 'nested/dir/hello_world.txt'
-        file_path = File.join(@aruba.current_dir, file_name)
+        file_path = File.join(@aruba.current_directory, file_name)
 
         FileUtils.mkdir_p File.dirname( file_path )
         File.open(file_path, 'w') { |f| f << "" }
@@ -409,7 +409,7 @@ describe Aruba::Api  do
 
       it "should check existence using regex" do
         file_name = 'nested/dir/hello_world.txt'
-        file_path = File.join(@aruba.current_dir, file_name)
+        file_path = File.join(@aruba.current_directory, file_name)
 
         FileUtils.mkdir_p File.dirname( file_path )
         File.open(file_path, 'w') { |f| f << "" }
@@ -422,7 +422,7 @@ describe Aruba::Api  do
 
       it "is no problem to mix both" do
         file_name = 'nested/dir/hello_world.txt'
-        file_path = File.join(@aruba.current_dir, file_name)
+        file_path = File.join(@aruba.current_directory, file_name)
 
         FileUtils.mkdir_p File.dirname( file_path )
         File.open(file_path, 'w') { |f| f << "" }
@@ -434,7 +434,7 @@ describe Aruba::Api  do
       it "works with ~ in path name" do
         file_path = File.join('~', random_string)
 
-        with_env 'HOME' => File.expand_path(current_dir) do
+        with_env 'HOME' => File.expand_path(current_directory) do
           FileUtils.mkdir_p File.dirname(File.expand_path(file_path))
           File.open(File.expand_path(file_path), 'w') { |f| f << "" }
 
@@ -499,7 +499,7 @@ describe Aruba::Api  do
           it "works with ~ in path name" do
             file_path = File.join('~', random_string)
 
-            with_env 'HOME' => File.expand_path(current_dir) do
+            with_env 'HOME' => File.expand_path(current_directory) do
               @aruba.write_file(file_path, "foo bar baz")
               @aruba.check_file_content(file_path, non_matching_content, false)
             end
@@ -520,7 +520,7 @@ describe Aruba::Api  do
           it "works with ~ in path name" do
             file_path = File.join('~', random_string)
 
-            with_env 'HOME' => File.expand_path(current_dir) do
+            with_env 'HOME' => File.expand_path(current_directory) do
               @aruba.write_file(file_path, "foo bar baz")
               @aruba.check_file_content(file_path, non_matching_content, false)
             end
@@ -543,7 +543,7 @@ describe Aruba::Api  do
       it "works with ~ in path name" do
         file_path = File.join('~', random_string)
 
-        with_env 'HOME' => File.expand_path(current_dir) do
+        with_env 'HOME' => File.expand_path(current_directory) do
           @aruba.write_file(file_path, "foo bar baz")
 
           @aruba.with_file_content file_path do |full_content|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,7 @@ RSpec.configure do |config|
   end
 
   config.include Aruba::Api
-  config.before(:each) { clean_current_dir }
+  config.before(:each) { clean_current_directory }
 end
 
 Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }


### PR DESCRIPTION
Every method which works on a file is named `*_file`. Every method which works on a directory is named `*_dir`. While file is fully written, directory is abbreviated. This PR changes this. Now all methods are fully written.