### PR TITLE
Support for setting mtime when using #touch_file

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -432,13 +432,10 @@ module Aruba
     # @param [true, false] expect_match
     #   Must the content be in the file or not
     def check_binary_file_content(file, reference_file, expect_match = true)
-      prep_for_fs_check do
-        identical = FileUtils.compare_file(file, reference_file)
-        if expect_match
-          expect(identical).to be(true), "The file \"#{file}\" differs from file \"#{reference_file}\""
-        else
-          expect(identical).not_to be(true), "The file \"#{file}\" is identical to file \"#{reference_file}\""
-        end
+      if expect_match
+        expect(file).to have_same_file_content_like reference_file
+      else
+        expect(file).not_to have_same_file_content_like reference_file
       end
     end
 

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -96,13 +96,19 @@ module Aruba
     #
     # @param [String] file_name
     #   The name of the file
-    def touch_file(file_name, options = {})
-      in_current_dir do
-        file_name = File.expand_path(file_name)
-        _mkdir(File.dirname(file_name))
+    def touch_file(*args)
+      args = args.flatten
 
-        FileUtils.touch file_name, options
-      end
+      options = if args.last.kind_of? Hash
+                  args.pop
+                else
+                  {}
+                end
+
+      args = args.map { |p| absolute_path(p) }
+      args.each { |p| _mkdir(File.dirname(p)) }
+
+      FileUtils.touch(args, options)
 
       self
     end

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -239,12 +239,18 @@ module Aruba
     #
     # @param [String] file_name
     #    The file which should be deleted in current directory
-    def remove_file(file_name)
-      in_current_dir do
-        file_name = File.expand_path(file_name)
+    def remove_file(*args)
+      args = args.flatten
 
-        FileUtils.rm(file_name)
-      end
+      options = if args.last.kind_of? Hash
+                  args.pop
+                else
+                  {}
+                end
+
+      args = args.map { |p| absolute_path(p) }
+
+      FileUtils.rm(args, options)
     end
 
     # Append data to file

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -96,12 +96,12 @@ module Aruba
     #
     # @param [String] file_name
     #   The name of the file
-    def touch_file(file_name)
+    def touch_file(file_name, options = {})
       in_current_dir do
         file_name = File.expand_path(file_name)
         _mkdir(File.dirname(file_name))
 
-        FileUtils.touch file_name
+        FileUtils.touch file_name, options
       end
 
       self

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -285,12 +285,18 @@ module Aruba
     #
     # @param [String] directory_name
     #   The name of the directory which should be removed
-    def remove_dir(directory_name)
-      in_current_dir do
-        directory_name = File.expand_path(directory_name)
+    def remove_dir(*args)
+      args = args.flatten
 
-        FileUtils.rmdir(directory_name)
-      end
+      options = if args.last.kind_of? Hash
+                  args.pop
+                else
+                  {}
+                end
+
+      args = args.map { |p| absolute_path(p) }
+
+      FileUtils.rm_r(args, options)
     end
 
     # Check if paths are present

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -1,0 +1,17 @@
+# @private
+RSpec::Matchers.define :have_same_file_content_like do |expected|
+  match do |actual|
+    FileUtils.compare_file(
+      absolute_path(actual),
+      absolute_path(expected)
+    )
+  end
+
+  failure_message do |actual|
+    format("expected that file \"%s\" is the same as file \"%s\".", actual, expected)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that file \"%s\" differs from file \"%s\".", actual, expected)
+  end
+end

--- a/lib/aruba/matchers/mode.rb
+++ b/lib/aruba/matchers/mode.rb
@@ -17,13 +17,13 @@ RSpec::Matchers.define :have_permissions do |expected|
     file_name = actual
     actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
 
-    format("expected that file \"%s\" would have permissions \"%s\", but has \"\%s\".", file_name, expected_permissions, actual_permissions)
+    format("expected that file \"%s\" would have permissions \"%s\", but has \"%s\".", file_name, expected_permissions, actual_permissions)
   end
 
   failure_message_when_negated do |actual|
     file_name = actual
     actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
 
-    format("expected that file \"%s\" would not have permissions \"%s\", but has \"\%s\".", file_name, expected_permissions, actual_permissions)
+    format("expected that file \"%s\" would not have permissions \"%s\", but has \"%s\".", file_name, expected_permissions, actual_permissions)
   end
 end

--- a/lib/aruba/matchers/mode.rb
+++ b/lib/aruba/matchers/mode.rb
@@ -1,0 +1,29 @@
+# @private
+RSpec::Matchers.define :have_permissions do |expected|
+  expected_permissions = if expected.kind_of? Integer
+                           expected.to_s(8)
+                         else
+                           expected.gsub(/^0*/, '')
+                         end
+
+  match do |actual|
+    file_name = actual
+    actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
+
+    actual_permissions == expected_permissions
+  end
+
+  failure_message do |actual|
+    file_name = actual
+    actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
+
+    format("expected that file \"%s\" would have permissions \"%s\", but has \"\%s\".", file_name, expected_permissions, actual_permissions)
+  end
+
+  failure_message_when_negated do |actual|
+    file_name = actual
+    actual_permissions = sprintf( "%o", File::Stat.new(absolute_path(file_name)).mode )[-4,4].gsub(/^0*/, '')
+
+    format("expected that file \"%s\" would not have permissions \"%s\", but has \"\%s\".", file_name, expected_permissions, actual_permissions)
+  end
+end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -68,24 +68,53 @@ describe Aruba::Api  do
       end
     end
 
-    context '#remove_dir' do
+    describe '#remove_dir' do
+      let(:directory_name) { @directory_name }
+      let(:directory_path) { @directory_path }
+      let(:options) { {} }
+
       before :each do
-        Dir.mkdir(@directory_path)
+        set_env 'HOME',  File.expand_path(@aruba.current_dir)
       end
 
-      it 'should delete directory' do
-        @aruba.remove_dir(@directory_name)
-        expect(File.exist?(@directory_path)).to eq false
+      context 'when directory exists' do
+        before :each do
+          Array(directory_path).each { |p| Dir.mkdir p }
+        end
+
+        before :each do
+          @aruba.remove_dir(directory_name, options)
+        end
+
+        context 'when is a single directory' do
+          it_behaves_like 'a non-existing directory'
+        end
+
+        context 'when are multiple directorys' do
+          let(:directory_name) { %w(directory1 directory2 directory3) }
+          let(:directory_path) { %w(directory1 directory2 directory3).map { |p| File.join(@aruba.current_dir, p) } }
+
+          it_behaves_like 'a non-existing directory'
+        end
+
+        context 'when path contains ~' do
+          let(:string) { random_string }
+          let(:directory_name) { File.join('~', string) }
+          let(:directory_path) { File.join(@aruba.current_dir, string) }
+
+          it_behaves_like 'a non-existing directory'
+        end
       end
 
-      it "works with ~ in path name" do
-        directory_path = File.join('~', random_string)
+      context 'when directory does not exist' do
+        before :each do
+          @aruba.remove_dir(directory_name, options)
+        end
 
-        with_env 'HOME' => File.expand_path(current_dir) do
-          Dir.mkdir(File.expand_path(directory_path))
-          @aruba.remove_dir(directory_path)
+        context 'when is forced to delete directory' do
+          let(:options) { { force: true } }
 
-          expect(File.exist?(File.expand_path(directory_path))).to eq false
+          it_behaves_like 'a non-existing directory'
         end
       end
     end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -448,20 +448,38 @@ describe Aruba::Api  do
         @aruba.write_file(@file_name, "foo bar baz")
       end
 
-      context "#check_binary_file_content" do
-        it "succeeds if file content matches" do
-          @aruba.write_file("fixture", "foo bar baz")
-          @aruba.check_binary_file_content(@file_name, "fixture")
-          @aruba.check_binary_file_content(@file_name, "fixture", true)
+      describe "#check_binary_file_content" do
+        let(:file_name) { @file_name }
+        let(:file_path) { @file_path }
+
+        let(:reference_file) { 'fixture' }
+        let(:reference_file_content) { 'foo bar baz' }
+
+        before :each do
+          @aruba.write_file(reference_file, reference_file_content)
         end
 
-        it "succeeds if file content does not match" do
-          @aruba.write_file("wrong_fixture", "bar")
-          @aruba.check_binary_file_content(@file_name, "wrong_fixture", false)
+        context 'when files are the same' do
+          context 'and this is expected' do
+            it { @aruba.check_binary_file_content(file_name, reference_file) }
+            it { @aruba.check_binary_file_content(file_name, reference_file, true) }
+          end
+
+          context 'and this is not expected' do
+            it { expect { @aruba.check_binary_file_content(file_name, reference_file, false) }.to raise_error }
+          end
         end
 
-        it "raises if file does not exist" do
-          expect{@aruba.check_binary_file_content(@file_name, "non_existing", false)}.to raise_error
+        context 'when files are not the same' do
+          let(:reference_file_content) { 'bar' }
+
+          context 'and this is expected' do
+            it { @aruba.check_binary_file_content(file_name, reference_file, false) }
+          end
+
+          context 'and this is not expected' do
+            it { expect { @aruba.check_binary_file_content(file_name, reference_file, true) }.to raise_error }
+          end
         end
       end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -115,6 +115,12 @@ describe Aruba::Api  do
           expect(File.exist?(File.expand_path(file_path))).to eq true
         end
       end
+
+      it "sets mtime if given" do
+        time = Time.parse('2014-01-01 10:00:00')
+        @aruba.touch_file(@file_name, mtime: time)
+        expect(File.mtime(@file_path)).to eq time
+      end
     end
 
     context '#absolute_path' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,3 +11,5 @@ RSpec.configure do |config|
   config.include Aruba::Api
   config.before(:each) { clean_current_dir }
 end
+
+Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }

--- a/spec/support/shared_examples/directory.rb
+++ b/spec/support/shared_examples/directory.rb
@@ -1,0 +1,7 @@
+shared_examples 'an existing directory' do
+  it { Array(directory_path).each { |p| expect(File).to be_directory(p) } }
+end
+
+shared_examples 'a non-existing directory' do
+  it { Array(directory_path).each { |p| expect(File).not_to be_exist(p) } }
+end

--- a/spec/support/shared_examples/file.rb
+++ b/spec/support/shared_examples/file.rb
@@ -1,3 +1,7 @@
 shared_examples 'an existing file' do
   it { Array(file_path).each { |p| expect(File).to be_exist(p) } }
 end
+
+shared_examples 'a non-existing file' do
+  it { Array(file_path).each { |p| expect(File).not_to be_exist(p) } }
+end

--- a/spec/support/shared_examples/file.rb
+++ b/spec/support/shared_examples/file.rb
@@ -1,5 +1,5 @@
 shared_examples 'an existing file' do
-  it { Array(file_path).each { |p| expect(File).to be_exist(p) } }
+  it { Array(file_path).each { |p| expect(File).to be_file(p) } }
 end
 
 shared_examples 'a non-existing file' do

--- a/spec/support/shared_examples/file.rb
+++ b/spec/support/shared_examples/file.rb
@@ -1,0 +1,3 @@
+shared_examples 'an existing file' do
+  it { Array(file_path).each { |p| expect(File).to be_exist(p) } }
+end


### PR DESCRIPTION
@jarl-dk 

When creating a fixture using `touch_file` it can be quite handy to set the timestamp to a fixed time. This PR makes this possible by passing through options to `FileUtils`.

This

```ruby
touch_file 'file.txt', mtime: Time.parse('2014-01-01 10:00:00')
```

works like that

```bash
#/bin/bash
touch -d '2014-01-01 10:00:00' file.txt
```
This also speeds up tests, because you do not need to do something nasty like this:

```ruby
touch_file 'file.1.txt'
sleep 1
touch_file 'file2.txt'
```