### PR TITLE
Use 1.x for cucumber to work around bug

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email       = 'cukes@googlegroups.com'
   s.homepage    = 'http://github.com/cucumber/aruba'
 
-  s.add_runtime_dependency 'cucumber', '>= 1.1.1'
+  s.add_runtime_dependency 'cucumber', '~> 1.0'
   s.add_runtime_dependency 'childprocess', '>= 0.3.6'
   s.add_runtime_dependency 'rspec-expectations', '>= 2.7.0'
   s.add_development_dependency 'bcat', '>= 0.6.1'


### PR DESCRIPTION
Using `cucumber` "2.x" make tests fail for aruba. It looks like `cucumber` 2.x + `gherkin` 2.x doesn't work for the test suite of aruba. It looks like we should wait for `gherkin` 3 (see @aslakhellesoy [comment](https://github.com/cucumber/cucumber/issues/827#issuecomment-90483021) on this. This PR pins `aruba` to `cucumber` 1.x. The commit should be reverted when `gherkin` 3 is out.