### PR TITLE
Add matcher to check if file exists

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -388,6 +388,8 @@ module Aruba
       remove_directory(*args)
     end
 
+    # @deprecated
+    #
     # Check if paths are present
     #
     # @param [#each] paths
@@ -396,22 +398,20 @@ module Aruba
     # @param [true,false] expect_presence
     #   Should the given paths be present (true) or absent (false)
     def check_file_presence(paths, expect_presence = true)
-      prep_for_fs_check do
-        Array(paths).each do |path|
-          if path.kind_of? Regexp
-            if expect_presence
-              expect(Dir.glob('**/*')).to include_regexp(path)
-            else
-              expect(Dir.glob('**/*')).not_to include_regexp(path)
-            end
-          else
-            path = File.expand_path(path)
+      warn('The use of "check_file_presence" is deprecated. Use "expect().to be_existing_file or expect(all_paths).to match_path_pattern() instead" ')
 
-            if expect_presence
-              expect(File).to be_file(path)
-            else
-              expect(File).not_to be_file(path)
-            end
+      Array(paths).each do |path|
+        if path.kind_of? Regexp
+          if expect_presence
+            expect(all_paths).to match_path_pattern(path)
+          else
+            expect(all_paths).not_to match_path_pattern(path)
+          end
+        else
+          if expect_presence
+            expect(path).to be_existing_file
+          else
+            expect(path).not_to be_existing_file
           end
         end
       end

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -68,6 +68,14 @@ module Aruba
       Dir.chdir(current_directory, &block)
     end
 
+    # Check if file or directory exist
+    #
+    # @param [String] file_or_directory
+    #   The file/directory which should exist
+    def exist?(file_or_directory)
+      File.exist? expand_path(file_or_directory)
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -84,6 +84,14 @@ module Aruba
       File.file? expand_path(file)
     end
 
+    # Check if directory exist and is directory
+    #
+    # @param [String] file
+    #   The file/directory which should exist
+    def directory?(file)
+      File.directory? expand_path(file)
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -92,6 +92,14 @@ module Aruba
       File.directory? expand_path(file)
     end
 
+    # Return all existing paths (directories, files) in current dir
+    #
+    # @return [Array]
+    #   List of files and directories
+    def all_paths
+      Dir.glob(expand_path('**/*'))
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -76,6 +76,14 @@ module Aruba
       File.exist? expand_path(file_or_directory)
     end
 
+    # Check if file exist and is file
+    #
+    # @param [String] file
+    #   The file/directory which should exist
+    def file?(file)
+      File.file? expand_path(file)
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -293,31 +293,31 @@ Then /^the stderr from "([^"]*)" should not contain "([^"]*)"$/ do |cmd, unexpec
 end
 
 Then /^the file "([^"]*)" should not exist$/ do |file_name|
-  check_file_presence([file_name], false)
+  expect(file_name).not_to be_existing_file
 end
 
 Then /^the following files should exist:$/ do |files|
-  check_file_presence(files.raw.map{|file_row| file_row[0]}, true)
+  files.raw.map { |file_row| expect(file_row[0]).to be_existing_file }
 end
 
 Then /^the following files should not exist:$/ do |files|
-  check_file_presence(files.raw.map{|file_row| file_row[0]}, false)
+  files.raw.map { |file_row| expect(file_row[0]).not_to be_existing_file }
 end
 
-Then /^a file named "([^"]*)" should exist$/ do |file|
-  check_file_presence([file], true)
+Then /^a file named "([^"]*)" should exist$/ do |file_name|
+  expect(file_name).to be_existing_file
 end
 
-Then /^a file named "([^"]*)" should not exist$/ do |file|
-  check_file_presence([file], false)
+Then /^a file named "([^"]*)" should not exist$/ do |file_name|
+  expect(file_name).not_to be_existing_file
 end
 
-Then /^a file matching %r<(.*?)> should exist$/ do |regex|
-  check_file_presence([ Regexp.new( regex ) ], true )
+Then /^a file matching %r<(.*?)> should exist$/ do |pattern|
+  expect(all_paths).to match_path_pattern(Regexp.new(pattern))
 end
 
-Then /^a file matching %r<(.*?)> should not exist$/ do |regex|
-  check_file_presence([ Regexp.new( regex ) ], false )
+Then /^a file matching %r<(.*?)> should not exist$/ do |pattern|
+  expect(all_paths).not_to match_path_pattern(Regexp.new(pattern))
 end
 
 Then /^a (\d+) byte file named "([^"]*)" should exist$/ do |file_size, file_name|

--- a/lib/aruba/matchers/directory.rb
+++ b/lib/aruba/matchers/directory.rb
@@ -1,0 +1,14 @@
+
+RSpec::Matchers.define :be_existing_directory do |_|
+  match do |actual|
+    directory?(actual)
+  end
+
+  failure_message do |actual|
+    format("expected that directory \"%s\" exists", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that directory \"%s\" does not exist", actual)
+  end
+end

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -18,7 +18,7 @@ end
 
 RSpec::Matchers.define :be_existing_file do |_|
   match do |actual|
-    exist?(actual)
+    file?(actual)
   end
 
   failure_message do |actual|

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -15,3 +15,17 @@ RSpec::Matchers.define :have_same_file_content_like do |expected|
     format("expected that file \"%s\" differs from file \"%s\".", actual, expected)
   end
 end
+
+RSpec::Matchers.define :be_existing_file do |_|
+  match do |actual|
+    exist?(actual)
+  end
+
+  failure_message do |actual|
+    format("expected that file \"%s\" exists", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that file \"%s\" does not exist", actual)
+  end
+end

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -37,3 +37,33 @@ RSpec::Matchers.define :match_path_pattern do |_|
     format("expected that path \"%s\" does not match pattern \"%s\".", actual.join(", "), expected)
   end
 end
+
+# @!method be_existing_path
+#   This matchers checks if <path> exists in filesystem
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if path does not exist
+#     true:
+#     * if path exists
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect(file).to be_existing_path }
+#       it { expect(directory).to be_existing_path }
+#     end
+RSpec::Matchers.define :be_existing_path do |_|
+  match do |actual|
+    exist?(actual)
+  end
+
+  failure_message do |actual|
+    format("expected that path \"%s\" exists", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that path \"%s\" does not exist", actual)
+  end
+end

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -1,0 +1,39 @@
+# @!method match_path_pattern(pattern)
+#   This matchers checks if <files>/directories match <pattern>
+#
+#   @param [String, Regexp] pattern
+#     The pattern to use.
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if there are no files/directories which match the pattern
+#     true:
+#     * if there are files/directories which match the pattern
+#
+#   @example Use matcher with regex
+#
+#     RSpec.describe do
+#       it { expect(Dir.glob(**/*)).to match_file_pattern(/.txt$/) }
+#     end
+#
+#   @example Use matcher with string
+#
+#     RSpec.describe do
+#       it { expect(Dir.glob(**/*)).to match_file_pattern('.txt$') }
+#     end
+RSpec::Matchers.define :match_path_pattern do |_|
+  match do |actual|
+    next  !actual.select { |a| a == expected }.empty? if expected.is_a? String
+
+    !actual.grep(expected).empty?
+  end
+
+  failure_message do |actual|
+    format("expected that path \"%s\" matches pattern \"%s\".", actual.join(", "), expected)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that path \"%s\" does not match pattern \"%s\".", actual.join(", "), expected)
+  end
+end

--- a/lib/aruba/matchers/rspec_matcher_include_regexp.rb
+++ b/lib/aruba/matchers/rspec_matcher_include_regexp.rb
@@ -1,5 +1,7 @@
 RSpec::Matchers.define :include_regexp do |expected|
   match do |actual|
-    ! actual.grep(expected).empty?
+    warn('The use of "include_regexp"-matchers is deprecated. It will be removed soon.')
+
+    !actual.grep(expected).empty?
   end
 end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -213,6 +213,42 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#directory?' do
+      context 'when is file' do
+        let(:name) { @file_name }
+        let(:path) { @file_path }
+
+        context 'when exists' do
+          before :each do
+            File.write(path, '')
+          end
+
+          it { expect(@aruba).not_to be_directory(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_directory(name) }
+        end
+      end
+
+      context 'when is directory' do
+        let(:name) { 'test.d' }
+        let(:path) { File.join(@aruba.current_directory, name) }
+
+        context 'when exists' do
+          before :each do
+            FileUtils.mkdir_p path
+          end
+
+          it { expect(@aruba).to be_directory(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_directory(name) }
+        end
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -2,37 +2,7 @@ require 'spec_helper'
 require 'securerandom'
 
 describe Aruba::Api  do
-
-  def random_string(options = {})
-    options[:prefix].to_s + SecureRandom.hex + options[:suffix].to_s
-  end
-
-  before(:each) do
-    klass = Class.new {
-      include Aruba::Api
-
-      def set_tag(tag_name, value)
-        self.instance_variable_set "@#{tag_name}", value
-      end
-
-      def announce_or_puts(*args)
-        p caller[0..2]
-      end
-    }
-    @aruba = klass.new
-
-    @file_name = "test.txt"
-    @file_size = 256
-    @file_path = File.join(@aruba.current_directory, @file_name)
-
-    (@aruba.dirs.length - 1).times do |depth| #Ensure all parent dirs exists
-      dir = File.join(*@aruba.dirs[0..depth])
-      Dir.mkdir(dir) unless File.exist?(dir)
-    end
-    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.current_directory[0]
-    FileUtils.rm_rf(@aruba.current_directory)
-    Dir.mkdir(@aruba.current_directory)
-  end
+  include_context 'uses aruba API'
 
   describe 'current_directory' do
     it "should return the current dir as 'tmp/aruba'" do

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -177,6 +177,42 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#file?' do
+      context 'when is file' do
+        let(:name) { @file_name }
+        let(:path) { @file_path }
+
+        context 'when exists' do
+          before :each do
+            File.write(path, '')
+          end
+
+          it { expect(@aruba).to be_file(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_file(name) }
+        end
+      end
+
+      context 'when is directory' do
+        let(:name) { 'test.d' }
+        let(:path) { File.join(@aruba.current_directory, name) }
+
+        context 'when exists' do
+          before :each do
+            FileUtils.mkdir_p path
+          end
+
+          it { expect(@aruba).not_to be_file(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_file(name) }
+        end
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -141,6 +141,42 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#exist?' do
+      context 'when is file' do
+        let(:name) { @file_name }
+        let(:path) { @file_path }
+
+        context 'when exists' do
+          before :each do
+            File.write(path, '')
+          end
+
+          it { expect(@aruba).to be_exist(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_exist(name) }
+        end
+      end
+
+      context 'when is directory' do
+        let(:name) { 'test.d' }
+        let(:path) { File.join(@aruba.current_directory, name) }
+
+        context 'when exists' do
+          before :each do
+            FileUtils.mkdir_p path
+          end
+
+          it { expect(@aruba).to be_exist(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_exist(name) }
+        end
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -25,6 +25,34 @@ describe Aruba::Api  do
     end
   end
 
+  describe '#all_paths' do
+    let(:name) { @file_name }
+    let(:path) { @file_path }
+
+    context 'when file exist' do
+      before :each do
+        File.write(path, '')
+      end
+
+      it { expect(all_paths).to include expand_path(name) }
+    end
+
+    context 'when directory exist' do
+      let(:name) { 'test_dir' }
+      let(:path) { File.join(@aruba.current_directory, name) }
+
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      it { expect(all_paths).to include expand_path(name) }
+    end
+
+    context 'when nothing exist' do
+      it { expect(all_paths).to eq [] }
+    end
+  end
+
   describe 'directories' do
     before(:each) do
       @directory_name = 'test_dir'

--- a/spec/aruba/matchers/directory_spec.rb
+++ b/spec/aruba/matchers/directory_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe 'Directory Matchers' do
+  include_context 'uses aruba API'
+
+  def expand_path(*args)
+    @aruba.expand_path(*args)
+  end
+
+  describe 'to_be_existing_directory' do
+    let(:name) { 'test.d' }
+    let(:path) { File.join(@aruba.current_directory, name) }
+
+    context 'when directory exists' do
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      it { expect(name).to be_existing_directory }
+    end
+
+    context 'when directory does not exist' do
+      it { expect(name).not_to be_existing_directory }
+    end
+  end
+end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'File Matchers' do
+  include_context 'uses aruba API'
+
+  def expand_path(*args)
+    @aruba.expand_path(*args)
+  end
+
+  describe 'to_be_existing_file' do
+    context 'when file exists' do
+      before :each do
+        File.write(@file_path, '')
+      end
+
+      it { expect(@file_name).to be_existing_file }
+    end
+
+    context 'when file does not exist' do
+      it { expect(@file_name).not_to be_existing_file }
+    end
+  end
+end

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe 'Path Matchers' do
+  include_context 'uses aruba API'
+
+  def expand_path(*args)
+    @aruba.expand_path(*args)
+  end
+
+  describe 'to_match_path_pattern' do
+    context 'when pattern is string' do
+      context 'when there is file which matches path pattern' do
+        before :each do
+          File.write(@file_path, '')
+        end
+
+        it { expect(all_paths).to match_path_pattern(expand_path(@file_name)) }
+      end
+
+      context 'when there is not file which matches path pattern' do
+        it { expect(all_paths).not_to match_path_pattern('test') }
+      end
+    end
+
+    context 'when pattern is regex' do
+      context 'when there is file which matches path pattern' do
+        before :each do
+          File.write(@file_path, '')
+        end
+
+        it { expect(all_paths).to match_path_pattern(/test/) }
+      end
+
+      context 'when there is not file which matches path pattern' do
+        it { expect(all_paths).not_to match_path_pattern(/test/) }
+      end
+    end
+  end
+end

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -36,4 +36,37 @@ RSpec.describe 'Path Matchers' do
       end
     end
   end
+
+  describe 'to_be_existing_path' do
+    context 'when file' do
+      context 'exists' do
+        before :each do
+          File.write(@file_path, '')
+        end
+
+        it { expect(@file_name).to be_existing_path }
+      end
+
+      context 'does not exist' do
+        it { expect(@file_name).not_to be_existing_path }
+      end
+    end
+
+    context 'when directory' do
+      let(:name) { 'test.d' }
+      let(:path) { File.join(@aruba.current_directory, name) }
+
+      context 'exists' do
+        before :each do
+          FileUtils.mkdir_p path
+        end
+
+        it { expect(name).to be_existing_path }
+      end
+
+      context 'does not exist' do
+        it { expect(name).not_to be_existing_path }
+      end
+    end
+  end
 end

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -1,0 +1,32 @@
+RSpec.shared_context 'uses aruba API' do
+  def random_string(options = {})
+    options[:prefix].to_s + SecureRandom.hex + options[:suffix].to_s
+  end
+
+  before(:each) do
+    klass = Class.new {
+      include Aruba::Api
+
+      def set_tag(tag_name, value)
+        self.instance_variable_set "@#{tag_name}", value
+      end
+
+      def announce_or_puts(*args)
+        p caller[0..2]
+      end
+    }
+    @aruba = klass.new
+
+    @file_name = "test.txt"
+    @file_size = 256
+    @file_path = File.join(@aruba.current_directory, @file_name)
+
+    (@aruba.dirs.length - 1).times do |depth| #Ensure all parent dirs exists
+      dir = File.join(*@aruba.dirs[0..depth])
+      Dir.mkdir(dir) unless File.exist?(dir)
+    end
+    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.current_directory[0]
+    FileUtils.rm_rf(@aruba.current_directory)
+    Dir.mkdir(@aruba.current_directory)
+  end
+end


### PR DESCRIPTION
This adds a helper to check if a file exists in filesystem. This also resolves the full path. ~~This PR needs to be rebased if #224 is merged (absolute_path -> expand_path).~~

I added a separate spec file. This spec file uses the aruba api as well. To make the "aruba api object" `@aruba` re-usable I added a shared context for that.