### PR TITLE
Added matcher for file content

### DIFF
--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -115,3 +115,36 @@ RSpec::Matchers.define :have_file_content do |expected|
     format("expected that file \"%s\" does not contains exactly:\n%s", actual, expected)
   end
 end
+
+# @!method have_file_size(size)
+#   This matchers checks if path has file size
+#
+#   @param [Fixnum] size
+#     The size to check
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if path does not have size
+#     true:
+#     * if path has size
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect('file.txt').to have_file_size(0) }
+#     end
+RSpec::Matchers.define :have_file_size do |expected|
+  match do |actual|
+    next false unless File.file? expand_path(actual)
+    File.size(expand_path(actual)) == expected
+  end
+
+  failure_message do |actual|
+    format("expected that file \"%s\" has size \"%s\"", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that file \"%s\" does not have size \"%s\"", actual)
+  end
+end

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -1,4 +1,3 @@
-# @private
 RSpec::Matchers.define :have_same_file_content_like do |expected|
   match do |actual|
     FileUtils.compare_file(

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -15,3 +15,17 @@ RSpec::Matchers.define :have_same_file_content_like do |expected|
     format("expected that file \"%s\" differs from file \"%s\".", actual, expected)
   end
 end
+
+RSpec::Matchers.define :be_existing_file do |_|
+  match do |actual|
+    File.file?(absolute_path(actual))
+  end
+
+  failure_message do |actual|
+    format("expected that file \"%s\" exists", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that file \"%s\" does not exist", actual)
+  end
+end

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -29,3 +29,28 @@ RSpec::Matchers.define :be_existing_file do |_|
     format("expected that file \"%s\" does not exist", actual)
   end
 end
+
+RSpec::Matchers.define :have_content do |expected|
+  match do |actual|
+    path = absolute_path(actual)
+
+    next false unless File.file? path
+
+    content = File.read(path).chomp
+    next expected === content if expected.is_a? Regexp
+
+    content == expected.chomp
+  end
+
+  failure_message do |actual|
+    next format("expected that file \"%s\" contains:\n%s", actual, expected) if expected.is_a? Regexp
+
+    format("expected that file \"%s\" contains exactly:\n%s", actual, expected)
+  end
+
+  failure_message_when_negated do |actual|
+    next format("expected that file \"%s\" does not contain:\n%s", actual, expected) if expected.is_a? Regexp
+
+    format("expected that file \"%s\" does not contains exactly:\n%s", actual, expected)
+  end
+end

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -63,7 +63,7 @@ RSpec::Matchers.define :be_existing_file do |_|
   end
 end
 
-# @!method have_content(content)
+# @!method have_file_content(content)
 #   This matchers checks if <file> has content. It checks exactly if `'string'`
 #   is given and does a substring check if `/regexp/` is given.
 #
@@ -83,15 +83,15 @@ end
 #   @example Use matcher with string
 #
 #     RSpec.describe do
-#       it { expect(file1).to have_content('a') }
+#       it { expect(file1).to have_file_content('a') }
 #     end
 #
 #   @example Use matcher with regexp
 #
 #     RSpec.describe do
-#       it { expect(file1).to have_content(/a/) }
+#       it { expect(file1).to have_file_content(/a/) }
 #     end
-RSpec::Matchers.define :have_content do |expected|
+RSpec::Matchers.define :have_file_content do |expected|
   match do |actual|
     path = absolute_path(actual)
 

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -1,3 +1,22 @@
+# @!method have_same_file_content_like(file_name)
+#   This matchers checks if <file1> has the same content like <file2>
+#
+#   @param [String] file_name
+#     The name of the file which should be compared with the file in the
+#     `expect()`-call.
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if file1 is not equal file2
+#     true:
+#     * if file1 is equal file2
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_same_file_content_like(file2) }
+#     end
 RSpec::Matchers.define :have_same_file_content_like do |expected|
   match do |actual|
     FileUtils.compare_file(
@@ -15,6 +34,21 @@ RSpec::Matchers.define :have_same_file_content_like do |expected|
   end
 end
 
+# @!method be_existing_file
+#   This matchers checks if <file> exists in filesystem
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if file does not exist
+#     true:
+#     * if file exists
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect(file1).to be_existing_file(file2) }
+#     end
 RSpec::Matchers.define :be_existing_file do |_|
   match do |actual|
     File.file?(absolute_path(actual))
@@ -29,6 +63,34 @@ RSpec::Matchers.define :be_existing_file do |_|
   end
 end
 
+# @!method have_content(content)
+#   This matchers checks if <file> has content. It checks exactly if `'string'`
+#   is given and does a substring check if `/regexp/` is given.
+#
+#   @param [String, Regexp] content
+#     The content of the file
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if file does not exist
+#     * if file content is not equal string
+#     * if file content does not include regexp
+#     true:
+#     * if file content includes regexp
+#     * if file content is equal string
+#
+#   @example Use matcher with string
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_content('a') }
+#     end
+#
+#   @example Use matcher with regexp
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_content(/a/) }
+#     end
 RSpec::Matchers.define :have_content do |expected|
   match do |actual|
     path = absolute_path(actual)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -2,37 +2,7 @@ require 'spec_helper'
 require 'securerandom'
 
 describe Aruba::Api  do
-
-  def random_string(options = {})
-    options[:prefix].to_s + SecureRandom.hex + options[:suffix].to_s
-  end
-
-  before(:each) do
-    klass = Class.new {
-      include Aruba::Api
-
-      def set_tag(tag_name, value)
-        self.instance_variable_set "@#{tag_name}", value
-      end
-
-      def announce_or_puts(*args)
-        p caller[0..2]
-      end
-    }
-    @aruba = klass.new
-
-    @file_name = "test.txt"
-    @file_size = 256
-    @file_path = File.join(@aruba.current_directory, @file_name)
-
-    (@aruba.dirs.length - 1).times do |depth| #Ensure all parent dirs exists
-      dir = File.join(*@aruba.dirs[0..depth])
-      Dir.mkdir(dir) unless File.exist?(dir)
-    end
-    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.current_directory[0]
-    FileUtils.rm_rf(@aruba.current_directory)
-    Dir.mkdir(@aruba.current_directory)
-  end
+  include_context 'uses aruba API'
 
   describe 'current_directory' do
     it "should return the current dir as 'tmp/aruba'" do

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -20,4 +20,32 @@ RSpec.describe 'File Matchers' do
       it { expect(@file_name).not_to be_existing_file }
     end
   end
+
+  describe 'to_have_content' do
+    context 'when file exists' do
+      before :each do
+        File.write(@file_path, 'aba')
+      end
+
+      context 'and file content is exactly equal string ' do
+        it { expect(@file_name).to have_content('aba') }
+      end
+
+      context 'and file content contains string' do
+        it { expect(@file_name).to have_content(/b/) }
+      end
+
+      context 'and file content is not exactly equal string' do
+        it { expect(@file_name).not_to have_content('c') }
+      end
+
+      context 'and file content not contains string' do
+        it { expect(@file_name).not_to have_content(/c/) }
+      end
+    end
+
+    context 'when file does not exist' do
+      it { expect(@file_name).not_to have_content('a') }
+    end
+  end
 end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -21,31 +21,31 @@ RSpec.describe 'File Matchers' do
     end
   end
 
-  describe 'to_have_content' do
+  describe 'to_have_file_content' do
     context 'when file exists' do
       before :each do
         File.write(@file_path, 'aba')
       end
 
       context 'and file content is exactly equal string ' do
-        it { expect(@file_name).to have_content('aba') }
+        it { expect(@file_name).to have_file_content('aba') }
       end
 
       context 'and file content contains string' do
-        it { expect(@file_name).to have_content(/b/) }
+        it { expect(@file_name).to have_file_content(/b/) }
       end
 
       context 'and file content is not exactly equal string' do
-        it { expect(@file_name).not_to have_content('c') }
+        it { expect(@file_name).not_to have_file_content('c') }
       end
 
       context 'and file content not contains string' do
-        it { expect(@file_name).not_to have_content(/c/) }
+        it { expect(@file_name).not_to have_file_content(/c/) }
       end
     end
 
     context 'when file does not exist' do
-      it { expect(@file_name).not_to have_content('a') }
+      it { expect(@file_name).not_to have_file_content('a') }
     end
   end
 end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+RSpec.describe 'File Matchers' do
+  include_context 'uses aruba API'
+
+  def absolute_path(*args)
+    @aruba.absolute_path(*args)
+  end
+
+  describe 'to_be_exsting_file' do
+    context 'when file exists' do
+      before :each do
+        File.write(@file_path, '')
+      end
+
+      it { expect(@file_name).to be_existing_file }
+    end
+
+    context 'when file does not exist' do
+      it { expect(@file_name).not_to be_existing_file }
+    end
+  end
+end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -48,4 +48,24 @@ RSpec.describe 'File Matchers' do
       it { expect(@file_name).not_to have_file_content('a') }
     end
   end
+
+  describe 'to_have_file_size' do
+    context 'when file exists' do
+      before :each do
+        File.write(@file_path, '')
+      end
+
+      context 'and file size is equal' do
+        it { expect(@file_name).to have_file_size(0) }
+      end
+
+      context 'and file size is not equal' do
+        it { expect(@file_name).not_to have_file_size(1) }
+      end
+    end
+
+    context 'when file does not exist' do
+      it { expect(@file_name).not_to have_file_size(0) }
+    end
+  end
 end

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -1,0 +1,32 @@
+RSpec.shared_context 'uses aruba API' do
+  def random_string(options = {})
+    options[:prefix].to_s + SecureRandom.hex + options[:suffix].to_s
+  end
+
+  before(:each) do
+    klass = Class.new {
+      include Aruba::Api
+
+      def set_tag(tag_name, value)
+        self.instance_variable_set "@#{tag_name}", value
+      end
+
+      def announce_or_puts(*args)
+        p caller[0..2]
+      end
+    }
+    @aruba = klass.new
+
+    @file_name = "test.txt"
+    @file_size = 256
+    @file_path = File.join(@aruba.current_directory, @file_name)
+
+    (@aruba.dirs.length - 1).times do |depth| #Ensure all parent dirs exists
+      dir = File.join(*@aruba.dirs[0..depth])
+      Dir.mkdir(dir) unless File.exist?(dir)
+    end
+    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.current_directory[0]
+    FileUtils.rm_rf(@aruba.current_directory)
+    Dir.mkdir(@aruba.current_directory)
+  end
+end


### PR DESCRIPTION
I added a matcher to match string to file content. This might be useful for aruba internals as well, but is itended to be part of the public API.

This PR is based on a refactoring done in #237, that's why there are some more commits added here. I will rebase this PR.