### PR TITLE
Make matcher have_permisions public and add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ cucumber-pro.log
 
 ## Ruby versioniser
 .ruby-version
+
+# Temp files of yar
+.yardoc

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,8 @@
+--output doc/yard
+--exclude features/
+--verbose
+--markup-provider kramdown
+--markup markdown
+-
+LICENSE
+README.md

--- a/lib/aruba/matchers/mode.rb
+++ b/lib/aruba/matchers/mode.rb
@@ -1,3 +1,27 @@
+# @!method have_permissions(permissions)
+#   This matchers checks if <file> has <perm> permissions
+#
+#   @param [Fixnum, String] permissions
+#     The permissions as octal number, e.g. `0700`, or String, e.g. `'0700'`
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if file has permissions
+#     true:
+#     * if file does not have permissions
+#
+#   @example Use matcher with octal number
+#
+#     RSpec.describe do
+#       it { expect(file).to have_permissions(0700) }
+#     end
+#
+#   @example Use matcher with string
+#
+#     RSpec.describe do
+#       it { expect(file).to have_permissions('0700') }
+#     end
 RSpec::Matchers.define :have_permissions do |expected|
   expected_permissions = if expected.kind_of? Integer
                            expected.to_s(8)

--- a/lib/aruba/matchers/mode.rb
+++ b/lib/aruba/matchers/mode.rb
@@ -1,4 +1,3 @@
-# @private
 RSpec::Matchers.define :have_permissions do |expected|
   expected_permissions = if expected.kind_of? Integer
                            expected.to_s(8)

--- a/lib/aruba/matchers/rspec_matcher_include_regexp.rb
+++ b/lib/aruba/matchers/rspec_matcher_include_regexp.rb
@@ -1,3 +1,21 @@
+# @!method include_regexp(regexp)
+#   This matchers checks if items of an <array> matches regexp
+#
+#   @param [Regexp] regexp
+#     The regular expression to use
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if regexp does not match
+#     true:
+#     * if regexp matches
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect(%w(asdf qwert)).to include_regexp(/asdf/) }
+#     end
 RSpec::Matchers.define :include_regexp do |expected|
   match do |actual|
     ! actual.grep(expected).empty?


### PR DESCRIPTION
I think the `have_permissions`-matchers is usable for other people as well. I think we should remove the `@private`-flag.

```ruby
describe 'my feature' do
  it { expect('file.txt').to have_permissions(0700) }
end
```

I also added a configuration file for `yardoc` and the directory which is generated by `yardoc` during documentation generation is ignored now.

@mattwynne @jarl-dk Suggestions?