### PR TITLE
use expand path everywhere

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -474,12 +474,12 @@ module Aruba
     # @yield
     #   Pass the content of the given file to this block
     def with_file_content(file, &block)
-      prep_for_fs_check do
-        file = File.expand_path(file)
+      stop_processes!
 
-        content = IO.read(file)
-        yield(content)
-      end
+      file = expand_path(file)
+      content = IO.read(file)
+
+      yield(content)
     end
 
     # Check the content of file

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -410,9 +410,9 @@ module Aruba
     # @param [true,false] expect_presence
     #   Should the given paths be present (true) or absent (false)
     def check_file_presence(paths, expect_presence = true)
-      stop_processes!
-
       warn('The use of "check_file_presence" is deprecated. Use "expect().to be_existing_file or expect(all_paths).to match_path_pattern() instead" ')
+
+      stop_processes!
 
       Array(paths).each do |path|
         if path.kind_of? Regexp
@@ -550,15 +550,15 @@ module Aruba
     # @param [true, false] expect_presence
     #   Should the directory be there or should the directory not be there
     def check_directory_presence(paths, expect_presence)
-      prep_for_fs_check do
-        paths.each do |path|
-          path = File.expand_path(path)
+      stop_processes!
 
-          if expect_presence
-            expect(File).to be_directory(path)
-          else
-            expect(File).not_to be_directory(path)
-          end
+      paths.each do |path|
+        path = expand_path(path)
+
+        if expect_presence
+          expect(File).to be_directory(path)
+        else
+          expect(File).not_to be_directory(path)
         end
       end
     end

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -565,6 +565,8 @@ module Aruba
 
     # @private
     def prep_for_fs_check(&block)
+      warn('The use of "prep_for_fs_check" is deprecated. It will be removed soon.')
+
       stop_processes!
       in_current_directory { block.call }
     end

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -45,6 +45,11 @@ module Aruba
     #   expand_path('%/file')
     #
     def expand_path(file_name, dir_string = nil)
+      message = "Filename cannot be nil or empty. Please use `expand_path('.')` if you want the current directory to be expanded."
+      # rubocop:disable Style/RaiseArgs
+      fail ArgumentError, message if file_name.nil? || file_name.empty?
+      # rubocop:enable Style/RaiseArgs
+
       if FIXTURES_PATH_PREFIX == file_name[0]
         File.join fixtures_directory, file_name[1..-1]
       else

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -498,19 +498,21 @@ module Aruba
     # @param [true, false] expect_match
     #   Must the content be in the file or not
     def check_file_content(file, content, expect_match = true)
+      stop_processes!
+
       match_content =
         if(Regexp === content)
           match(content)
         else
           eq(content)
         end
-      prep_for_fs_check do
-        content = IO.read(File.expand_path(file))
-        if expect_match
-          expect(content).to match_content
-        else
-          expect(content).not_to match_content
-        end
+
+      content = IO.read(expand_path(file))
+
+      if expect_match
+        expect(content).to match_content
+      else
+        expect(content).not_to match_content
       end
     end
 

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -355,9 +355,7 @@ module Aruba
     # @param [String] directory_name
     #   The name of the directory which should be created
     def create_directory(directory_name)
-      in_current_directory do
-        _mkdir(directory_name)
-      end
+      FileUtils.mkdir_p expand_path(directory_name)
 
       self
     end

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -410,6 +410,8 @@ module Aruba
     # @param [true,false] expect_presence
     #   Should the given paths be present (true) or absent (false)
     def check_file_presence(paths, expect_presence = true)
+      stop_processes!
+
       warn('The use of "check_file_presence" is deprecated. Use "expect().to be_existing_file or expect(all_paths).to match_path_pattern() instead" ')
 
       Array(paths).each do |path|

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -562,7 +562,7 @@ module Aruba
     # @private
     def prep_for_fs_check(&block)
       stop_processes!
-      in_current_directory{ block.call }
+      in_current_directory { block.call }
     end
 
     # @private

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -55,9 +55,9 @@ module Aruba
     # @private
     # @deprecated
     def absolute_path(*args)
-      warn('The use of "absolute_path" is deprecated. Use "expand_path" instead')
+      warn('The use of "absolute_path" is deprecated. Use "expand_path" instead. But be aware that "expand_path" uses a different implementation.')
 
-      expand_path(*args)
+      in_current_directory { File.expand_path File.join(*args) }
     end
 
     # Execute block in current directory

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -457,12 +457,12 @@ module Aruba
     #   check_file_size(paths_and_sizes)
     #
     def check_file_size(paths_and_sizes)
-      prep_for_fs_check do
-        paths_and_sizes.each do |path, size|
-          path = File.expand_path(path)
+      stop_processes!
 
-          expect(File.size(path)).to eq size
-        end
+      paths_and_sizes.each do |path, size|
+        path = expand_path(path)
+
+        expect(File.size(path)).to eq size
       end
     end
 

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -226,14 +226,12 @@ module Aruba
 
     # @private
     def _create_file(file_name, file_content, check_presence)
-      in_current_directory do
-        file_name = File.expand_path(file_name)
+      file_name = expand_path(file_name)
 
-        raise "expected #{file_name} to be present" if check_presence && !File.file?(file_name)
+      raise "expected #{file_name} to be present" if check_presence && !File.file?(file_name)
 
-        _mkdir(File.dirname(file_name))
-        File.open(file_name, 'w') { |f| f << file_content }
-      end
+      _mkdir(File.dirname(file_name))
+      File.open(file_name, 'w') { |f| f << file_content }
 
       self
     end
@@ -314,13 +312,11 @@ module Aruba
 
     # @private
     def _create_fixed_size_file(file_name, file_size, check_presence)
-      in_current_directory do
-        file_name = File.expand_path(file_name)
+      file_name = expand_path(file_name)
 
-        raise "expected #{file_name} to be present" if check_presence && !File.file?(file_name)
-        _mkdir(File.dirname(file_name))
-        File.open(file_name, "wb"){ |f| f.seek(file_size - 1); f.write("\0") }
-      end
+      raise "expected #{file_name} to be present" if check_presence && !File.file?(file_name)
+      _mkdir(File.dirname(file_name))
+      File.open(file_name, "wb"){ |f| f.seek(file_size - 1); f.write("\0") }
     end
 
     # @private
@@ -343,12 +339,10 @@ module Aruba
     # @param [String] file_content
     #   The content which should be appended to file
     def append_to_file(file_name, file_content)
-      in_current_directory do
-        file_name = File.expand_path(file_name)
+      file_name = expand_path(file_name)
 
-        _mkdir(File.dirname(file_name))
-        File.open(file_name, 'a') { |f| f << file_content }
-      end
+      _mkdir(File.dirname(file_name))
+      File.open(file_name, 'a') { |f| f << file_content }
     end
 
     # Create a directory in current directory
@@ -440,12 +434,10 @@ module Aruba
     # @param [String] file_name
     #   The file which should be used to pipe in data
     def pipe_in_file(file_name)
-      in_current_directory do
-        file_name = File.expand_path(file_name)
+      file_name = expand_path(file_name)
 
-        File.open(file_name, 'r').each_line do |line|
-          _write_interactive(line)
-        end
+      File.open(file_name, 'r').each_line do |line|
+        _write_interactive(line)
       end
     end
 

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -367,7 +367,7 @@ Then /^the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)"$/ d
 end
 
 Before '@mocked_home_directory' do
-  set_env 'HOME', File.expand_path(current_dir)
+  set_env 'HOME', expand_path('.')
 end
 
 After do

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -354,36 +354,39 @@ describe Aruba::Api  do
     end
 
     context '#expand_path' do
-      it 'expands and returns path' do
-        expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)
+      context 'when file_name is given' do
+        it { expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path) }
       end
 
-      it 'removes "."' do
-        expect(@aruba.expand_path('.')).to eq File.expand_path(current_directory)
+      context 'when path contains "."' do
+        it { expect(@aruba.expand_path('.')).to eq File.expand_path(current_directory) }
       end
 
-      it 'removes ".."' do
-        expect(@aruba.expand_path('..')).to eq File.expand_path(File.join(current_directory, '..'))
+      context 'when path contains ".."' do
+        it { expect(@aruba.expand_path('..')).to eq File.expand_path(File.join(current_directory, '..')) }
       end
 
-      it 'expands from another directory' do
-        expect(@aruba.expand_path(@file_name, 'path')).to eq File.expand_path(File.join(current_directory, 'path', @file_name))
+      context 'when dir_path is given similar to File.expand_path ' do
+        it { expect(@aruba.expand_path(@file_name, 'path')).to eq File.expand_path(File.join(current_directory, 'path', @file_name)) }
       end
 
-      it 'resolves fixtures path' do
-        klass = Class.new do
-          include Aruba::Api
+      context 'when file_name contains fixtures "%" string' do
+        let(:klass) do
+          Class.new do
+            include Aruba::Api
 
-          def root_directory
-            File.expand_path(current_directory)
+            def root_directory
+              File.expand_path(current_directory)
+            end
           end
         end
 
-        aruba = klass.new
+        before :each do
+          @aruba = klass.new
+          @aruba.touch_file 'spec/fixtures/file1'
+        end
 
-        aruba.touch 'spec/fixtures/file1'
-
-        expect(aruba.expand_path('%/file1')).to eq File.expand_path(File.join(current_directory, 'spec', 'fixtures', 'file1'))
+        it { expect(@aruba.expand_path('%/file1')).to eq File.expand_path(File.join(current_directory, 'spec', 'fixtures', 'file1')) }
       end
     end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -347,6 +347,12 @@ describe Aruba::Api  do
       end
     end
 
+    context '#absolute_path' do
+      context 'when file_name is array of path names' do
+        it { silence(:stderr) { expect(@aruba.absolute_path(['path', @file_name])).to eq File.expand_path(File.join(current_directory, 'path', @file_name)) } }
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -363,7 +363,15 @@ describe Aruba::Api  do
       end
 
       context 'when path contains ".."' do
-        it { expect(@aruba.expand_path('..')).to eq File.expand_path(File.join(current_directory, '..')) }
+        it { expect(@aruba.expand_path('path/..')).to eq File.expand_path(File.join(current_directory)) }
+      end
+
+      context 'when path is nil' do
+        it { expect { @aruba.expand_path(nil) }.to raise_error ArgumentError }
+      end
+
+      context 'when path is empty' do
+        it { expect { @aruba.expand_path('') }.to raise_error ArgumentError }
       end
 
       context 'when dir_path is given similar to File.expand_path ' do

--- a/spec/support/helpers/reporting.rb
+++ b/spec/support/helpers/reporting.rb
@@ -1,0 +1,43 @@
+module SpecHelper
+  module Reporting
+    # Captures the given stream and returns it:
+    #
+    #   stream = capture(:stdout) { puts 'notice' }
+    #   stream # => "notice\n"
+    #
+    #   stream = capture(:stderr) { warn 'error' }
+    #   stream # => "error\n"
+    #
+    # even for subprocesses:
+    #
+    #   stream = capture(:stdout) { system('echo notice') }
+    #   stream # => "notice\n"
+    #
+    #   stream = capture(:stderr) { system('echo error 1>&2') }
+    #   stream # => "error\n"
+    def capture(stream)
+      stream = stream.to_s
+      captured_stream = Tempfile.new(stream)
+      # rubocop:disable Lint/Eval
+      stream_io = eval("$#{stream}")
+      # rubocop:enable Lint/Eval
+      origin_stream = stream_io.dup
+      stream_io.reopen(captured_stream)
+
+      yield
+
+      stream_io.rewind
+      return captured_stream.read
+    ensure
+      captured_stream.close
+      captured_stream.unlink
+      stream_io.reopen(origin_stream)
+    end
+    alias_method :silence, :capture
+
+  end
+end
+
+RSpec.configure do |config|
+  config.include SpecHelper::Reporting
+end


### PR DESCRIPTION
Follow up to #224.

@jarl-dk 

You changed the public API of `#absolute_path`. I think we should deprecate that API properly first. To make the switch easier for us I added the old implementation of `absolute_path` and left the new one to `expand_path`. What do you think?

To make it possible to use `expand_path` everywhere I removed the `prep_for_fs`-call, because otherwise we would have doubled the `tmp/aruba`-path in the expanded path.

Do you see any reason to keep the method as part of `aruba`. I mark it as deprecated.

I added single commits for the changes to make review easier. I will squash them after the review.

I also added a spec for the `absolute_path` as long as it is part of `aruba`. The deprecation warning is silenced.