### PR TITLE
Remove _file/_directory in method names

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -168,11 +168,23 @@ module Aruba
       _create_file(file_name, file_content, false)
     end
 
+    # @private
+    # @deprecated
     # Create an empty file
     #
     # @param [String] file_name
     #   The name of the file
     def touch_file(*args)
+      warn('The use of "touch_file" is deprecated. Use "touch" instead')
+
+      touch(*args)
+    end
+
+    # Create an empty file
+    #
+    # @param [String] file_name
+    #   The name of the file
+    def touch(*args)
       args = args.flatten
 
       options = if args.last.kind_of? Hash

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -388,6 +388,8 @@ module Aruba
       remove_directory(*args)
     end
 
+    # @deprecated
+    #
     # Check if paths are present
     #
     # @param [#each] paths
@@ -396,22 +398,20 @@ module Aruba
     # @param [true,false] expect_presence
     #   Should the given paths be present (true) or absent (false)
     def check_file_presence(paths, expect_presence = true)
-      prep_for_fs_check do
-        Array(paths).each do |path|
-          if path.kind_of? Regexp
-            if expect_presence
-              expect(Dir.glob('**/*')).to include_regexp(path)
-            else
-              expect(Dir.glob('**/*')).not_to include_regexp(path)
-            end
-          else
-            path = File.expand_path(path)
+      warn('The use of "check_file_presence" is deprecated. Use "expect().to be_existing_file or expect(all_paths).to match_path_pattern() instead" ')
 
-            if expect_presence
-              expect(File).to be_file(path)
-            else
-              expect(File).not_to be_file(path)
-            end
+      Array(paths).each do |path|
+        if path.kind_of? Regexp
+          if expect_presence
+            expect(all_paths).to match_path_pattern(path)
+          else
+            expect(all_paths).not_to match_path_pattern(path)
+          end
+        else
+          if expect_presence
+            expect(path).to be_existing_file
+          else
+            expect(path).not_to be_existing_file
           end
         end
       end

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -68,6 +68,14 @@ module Aruba
       Dir.chdir(current_directory, &block)
     end
 
+    # Check if file or directory exist
+    #
+    # @param [String] file_or_directory
+    #   The file/directory which should exist
+    def exist?(file_or_directory)
+      File.exist? expand_path(file_or_directory)
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -3,6 +3,7 @@ require 'rbconfig'
 require 'rspec/expectations'
 require 'aruba'
 require 'aruba/config'
+require 'aruba/errors'
 require 'ostruct'
 require 'pathname'
 

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -84,6 +84,14 @@ module Aruba
       File.file? expand_path(file)
     end
 
+    # Check if directory exist and is directory
+    #
+    # @param [String] file
+    #   The file/directory which should exist
+    def directory?(file)
+      File.directory? expand_path(file)
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -92,6 +92,14 @@ module Aruba
       File.directory? expand_path(file)
     end
 
+    # Return all existing paths (directories, files) in current dir
+    #
+    # @return [Array]
+    #   List of files and directories
+    def all_paths
+      Dir.glob(expand_path('**/*'))
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -311,22 +311,16 @@ module Aruba
       end
     end
 
+    # @private
+    # @deprecated
     # Remove file
     #
     # @param [String] file_name
     #    The file which should be deleted in current directory
     def remove_file(*args)
-      args = args.flatten
+      warn('The use of "remove_file" is deprecated. Use "remove" instead')
 
-      options = if args.last.kind_of? Hash
-                  args.pop
-                else
-                  {}
-                end
-
-      args = args.map { |p| expand_path(p) }
-
-      FileUtils.rm(args, options)
+      remove(*args)
     end
 
     # Append data to file
@@ -364,11 +358,11 @@ module Aruba
       create_directory(*args)
     end
 
-    # Remove directory
+    # Remove file or directory
     #
-    # @param [String] directory_name
-    #   The name of the directory which should be removed
-    def remove_directory(*args)
+    # @param [Array, String] name
+    #   The name of the file / directory which should be removed
+    def remove(*args)
       args = args.flatten
 
       options = if args.last.kind_of? Hash
@@ -384,9 +378,20 @@ module Aruba
 
     # @private
     # @deprecated
+    # Remove directory
+    #
+    # @param [String] directory_name
+    #   The name of the directory which should be removed
+    def remove_directory(*args)
+      warn('The use of "remove_directory" is deprecated. Use "remove" instead')
+      remove(*args)
+    end
+
+    # @private
+    # @deprecated
     def remove_dir(*args)
-      warn('The use of "remove_dir" is deprecated. Use "remove_directory" instead')
-      remove_directory(*args)
+      warn('The use of "remove_dir" is deprecated. Use "remove" instead')
+      remove(*args)
     end
 
     # @deprecated

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -76,6 +76,14 @@ module Aruba
       File.exist? expand_path(file_or_directory)
     end
 
+    # Check if file exist and is file
+    #
+    # @param [String] file
+    #   The file/directory which should exist
+    def file?(file)
+      File.file? expand_path(file)
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -305,15 +305,29 @@ Then /^the stderr from "([^"]*)" should not contain "([^"]*)"$/ do |cmd, unexpec
 end
 
 Then /^the following files should (not )?exist:$/ do |expect_match, files|
-  check_file_presence(files.raw.map{|file_row| file_row[0]}, !expect_match)
+  files.raw.each do |row|
+    if expect_match
+      expect(row[0]).not_to be_existing_file
+    else
+      expect(row[0]).to be_existing_file
+    end
+  end
 end
 
 Then /^(?:a|the) file(?: named)? "([^"]*)" should (not )?exist$/ do |file, expect_match|
-  check_file_presence([file], !expect_match)
+  if expect_match
+    expect(file).not_to be_existing_file
+  else
+    expect(file).to be_existing_file
+  end
 end
 
-Then /^(?:a|the) file matching %r<(.*?)> should (not )?exist$/ do |regex, expect_match|
-  check_file_presence([ Regexp.new( regex ) ], !expect_match)
+Then /^(?:a|the) file matching %r<(.*?)> should (not )?exist$/ do |pattern, expect_match|
+  if expect_match
+    expect(all_paths).not_to match_path_pattern(Regexp.new(pattern))
+  else
+    expect(all_paths).to match_path_pattern(Regexp.new(pattern))
+  end
 end
 
 Then /^(?:a|the) (\d+) byte file(?: named)? "([^"]*)" should exist$/ do |file_size, file_name|

--- a/lib/aruba/errors.rb
+++ b/lib/aruba/errors.rb
@@ -1,4 +1,10 @@
 module Aruba
+  # Standard error
   class Error < StandardError; end
+
+  # An error because a user of the API did something wrong
+  class UserError < StandardError; end
+
+  # Raised on launch error
   class LaunchError < Error; end
 end

--- a/lib/aruba/matchers/directory.rb
+++ b/lib/aruba/matchers/directory.rb
@@ -1,0 +1,14 @@
+
+RSpec::Matchers.define :be_existing_directory do |_|
+  match do |actual|
+    directory?(actual)
+  end
+
+  failure_message do |actual|
+    format("expected that directory \"%s\" exists", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that directory \"%s\" does not exist", actual)
+  end
+end

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -51,7 +51,7 @@ end
 #     end
 RSpec::Matchers.define :be_existing_file do |_|
   match do |actual|
-    File.file?(absolute_path(actual))
+    exist?(actual)
   end
 
   failure_message do |actual|

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -51,7 +51,7 @@ end
 #     end
 RSpec::Matchers.define :be_existing_file do |_|
   match do |actual|
-    exist?(actual)
+    file?(actual)
   end
 
   failure_message do |actual|

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -37,3 +37,33 @@ RSpec::Matchers.define :match_path_pattern do |_|
     format("expected that path \"%s\" does not match pattern \"%s\".", actual.join(", "), expected)
   end
 end
+
+# @!method be_existing_path
+#   This matchers checks if <path> exists in filesystem
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if path does not exist
+#     true:
+#     * if path exists
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect(file).to be_existing_path }
+#       it { expect(directory).to be_existing_path }
+#     end
+RSpec::Matchers.define :be_existing_path do |_|
+  match do |actual|
+    exist?(actual)
+  end
+
+  failure_message do |actual|
+    format("expected that path \"%s\" exists", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that path \"%s\" does not exist", actual)
+  end
+end

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -1,0 +1,39 @@
+# @!method match_path_pattern(pattern)
+#   This matchers checks if <files>/directories match <pattern>
+#
+#   @param [String, Regexp] pattern
+#     The pattern to use.
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if there are no files/directories which match the pattern
+#     true:
+#     * if there are files/directories which match the pattern
+#
+#   @example Use matcher with regex
+#
+#     RSpec.describe do
+#       it { expect(Dir.glob(**/*)).to match_file_pattern(/.txt$/) }
+#     end
+#
+#   @example Use matcher with string
+#
+#     RSpec.describe do
+#       it { expect(Dir.glob(**/*)).to match_file_pattern('.txt$') }
+#     end
+RSpec::Matchers.define :match_path_pattern do |_|
+  match do |actual|
+    next  !actual.select { |a| a == expected }.empty? if expected.is_a? String
+
+    !actual.grep(expected).empty?
+  end
+
+  failure_message do |actual|
+    format("expected that path \"%s\" matches pattern \"%s\".", actual.join(", "), expected)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that path \"%s\" does not match pattern \"%s\".", actual.join(", "), expected)
+  end
+end

--- a/lib/aruba/matchers/rspec_matcher_include_regexp.rb
+++ b/lib/aruba/matchers/rspec_matcher_include_regexp.rb
@@ -18,6 +18,8 @@
 #     end
 RSpec::Matchers.define :include_regexp do |expected|
   match do |actual|
-    ! actual.grep(expected).empty?
+    warn('The use of "include_regexp"-matchers is deprecated. It will be removed soon.')
+
+    !actual.grep(expected).empty?
   end
 end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -166,52 +166,75 @@ describe Aruba::Api  do
   end
 
   describe 'files' do
-    describe '#touch_file' do
-      let(:file_name) { @file_name }
-      let(:file_path) { @file_path }
+    describe '#touch' do
+      let(:name) { @file_name }
+      let(:path) { @file_path }
       let(:options) { {} }
 
       before :each do
         set_env 'HOME',  File.expand_path(@aruba.current_directory)
       end
 
-      before :each do
-        @aruba.touch_file(file_name, options)
+      context 'when file' do
+        before :each do
+          @aruba.touch(name, options)
+        end
+
+        context 'when does not exist' do
+          context 'and should be created in existing directory' do
+            it { expect(File.size(path)).to eq 0 }
+            it_behaves_like 'an existing file'
+          end
+
+          context 'and should be created in non-existing directory' do
+            let(:name) { 'directory/test' }
+            let(:path) { File.join(@aruba.current_directory, 'directory/test') }
+
+            it_behaves_like 'an existing file'
+          end
+
+          context 'and path includes ~' do
+            let(:string) { random_string }
+            let(:name) { File.join('~', string) }
+            let(:path) { File.join(@aruba.current_directory, string) }
+
+            it_behaves_like 'an existing file'
+          end
+
+          context 'and the mtime should be set statically' do
+            let(:time) { Time.parse('2014-01-01 10:00:00') }
+            let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
+
+            it_behaves_like 'an existing file'
+            it { expect(File.mtime(path)).to eq time }
+          end
+
+          context 'and multiple file names are given' do
+            let(:name) { %w(file1 file2 file3) }
+            let(:path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_directory, p) } }
+            it_behaves_like 'an existing file'
+          end
+        end
       end
 
-      context 'when file does not exist' do
-        context 'and should be created in existing directory' do
-          it { expect(File.size(file_path)).to eq 0 }
-          it_behaves_like 'an existing file'
-        end
+      context 'when directory' do
+        let(:name) { %w(directory1) }
+        let(:path) { Array(name).map { |p| File.join(@aruba.current_directory, p) } }
 
-        context 'and should be created in non-existing directory' do
-          let(:file_name) { 'directory/test' }
-          let(:file_path) { File.join(@aruba.current_directory, 'directory/test') }
+        context 'when exist' do
+          before(:each) { Array(path).each { |p| FileUtils.mkdir_p p } }
 
-          it_behaves_like 'an existing file'
-        end
+          before :each do
+            @aruba.touch(name, options)
+          end
 
-        context 'and path includes ~' do
-          let(:string) { random_string }
-          let(:file_name) { File.join('~', string) }
-          let(:file_path) { File.join(@aruba.current_directory, string) }
+          context 'and the mtime should be set statically' do
+            let(:time) { Time.parse('2014-01-01 10:00:00') }
+            let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
 
-          it_behaves_like 'an existing file'
-        end
-
-        context 'and the mtime should be set statically' do
-          let(:time) { Time.parse('2014-01-01 10:00:00') }
-          let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
-
-          it_behaves_like 'an existing file'
-          it { expect(File.mtime(file_path)).to eq time }
-        end
-
-        context 'and multiple file names are given' do
-          let(:file_name) { %w(file1 file2 file3) }
-          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_directory, p) } }
-          it_behaves_like 'an existing file'
+            it_behaves_like 'an existing directory'
+            it { Array(path).each { |p| expect(File.mtime(p)).to eq time } }
+          end
         end
       end
     end
@@ -352,7 +375,7 @@ describe Aruba::Api  do
 
         aruba = klass.new
 
-        aruba.touch_file 'spec/fixtures/file1'
+        aruba.touch 'spec/fixtures/file1'
 
         expect(aruba.expand_path('%/file1')).to eq File.expand_path(File.join(current_directory, 'spec', 'fixtures', 'file1'))
       end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -65,23 +65,70 @@ describe Aruba::Api  do
         expect(File.exist?(File.expand_path(@directory_path))).to be_truthy
       end
     end
+  end
 
-    describe '#remove_directory' do
-      let(:directory_name) { @directory_name }
-      let(:directory_path) { @directory_path }
-      let(:options) { {} }
+  describe '#remove' do
+    let(:name) { 'test.txt'}
+    let(:path) { File.join(@aruba.current_directory, name) }
+    let(:options) { {} }
 
-      before :each do
-        set_env 'HOME',  File.expand_path(@aruba.current_directory)
-      end
+    before :each do
+      set_env 'HOME',  File.expand_path(@aruba.current_directory)
+    end
 
-      context 'when directory exists' do
+    context 'when file' do
+      context 'when exists' do
         before :each do
-          Array(directory_path).each { |p| Dir.mkdir p }
+          Array(path).each { |p| File.open(File.expand_path(p), 'w') { |f| f << "" } }
         end
 
         before :each do
-          @aruba.remove_directory(directory_name, options)
+          @aruba.remove(name, options)
+        end
+
+        context 'when is a single file' do
+          it_behaves_like 'a non-existing file'
+        end
+
+        context 'when are multiple files' do
+          let(:file_name) { %w(file1 file2 file3) }
+          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_directory, p) } }
+
+          it_behaves_like 'a non-existing file'
+        end
+
+        context 'when path contains ~' do
+          let(:string) { random_string }
+          let(:file_name) { File.join('~', string) }
+          let(:file_path) { File.join(@aruba.current_directory, string) }
+
+          it_behaves_like 'a non-existing file'
+        end
+      end
+
+      context 'when does not exist' do
+        before :each do
+          @aruba.remove(name, options)
+        end
+
+        context 'when is forced to delete file' do
+          let(:options) { { force: true } }
+
+          it_behaves_like 'a non-existing file'
+        end
+      end
+    end
+
+    context 'when is directory' do
+      let(:name) { 'test.d' }
+
+      context 'when exists' do
+        before :each do
+          Array(path).each { |p| Dir.mkdir p }
+        end
+
+        before :each do
+          @aruba.remove(name, options)
         end
 
         context 'when is a single directory' do
@@ -104,9 +151,9 @@ describe Aruba::Api  do
         end
       end
 
-      context 'when directory does not exist' do
+      context 'when does not exist' do
         before :each do
-          @aruba.remove_directory(directory_name, options)
+          @aruba.remove(name, options)
         end
 
         context 'when is forced to delete directory' do
@@ -458,57 +505,6 @@ describe Aruba::Api  do
 
             it { expect { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }.to raise_error }
           end
-        end
-      end
-    end
-
-    describe '#remove_file' do
-      let(:file_name) { @file_name }
-      let(:file_path) { @file_path }
-      let(:options) { {} }
-
-      before :each do
-        set_env 'HOME',  File.expand_path(@aruba.current_directory)
-      end
-
-      context 'when file exists' do
-        before :each do
-          Array(file_path).each { |p| File.open(File.expand_path(p), 'w') { |f| f << "" } }
-        end
-
-        before :each do
-          @aruba.remove_file(file_name, options)
-        end
-
-        context 'when is a single file' do
-          it_behaves_like 'a non-existing file'
-        end
-
-        context 'when are multiple files' do
-          let(:file_name) { %w(file1 file2 file3) }
-          let(:file_path) { %w(file1 file2 file3).map { |p| File.join(@aruba.current_directory, p) } }
-
-          it_behaves_like 'a non-existing file'
-        end
-
-        context 'when path contains ~' do
-          let(:string) { random_string }
-          let(:file_name) { File.join('~', string) }
-          let(:file_path) { File.join(@aruba.current_directory, string) }
-
-          it_behaves_like 'a non-existing file'
-        end
-      end
-
-      context 'when file does not exist' do
-        before :each do
-          @aruba.remove_file(file_name, options)
-        end
-
-        context 'when is forced to delete file' do
-          let(:options) { { force: true } }
-
-          it_behaves_like 'a non-existing file'
         end
       end
     end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -213,6 +213,42 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#directory?' do
+      context 'when is file' do
+        let(:name) { @file_name }
+        let(:path) { @file_path }
+
+        context 'when exists' do
+          before :each do
+            File.write(path, '')
+          end
+
+          it { expect(@aruba).not_to be_directory(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_directory(name) }
+        end
+      end
+
+      context 'when is directory' do
+        let(:name) { 'test.d' }
+        let(:path) { File.join(@aruba.current_directory, name) }
+
+        context 'when exists' do
+          before :each do
+            FileUtils.mkdir_p path
+          end
+
+          it { expect(@aruba).to be_directory(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_directory(name) }
+        end
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -177,6 +177,42 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#file?' do
+      context 'when is file' do
+        let(:name) { @file_name }
+        let(:path) { @file_path }
+
+        context 'when exists' do
+          before :each do
+            File.write(path, '')
+          end
+
+          it { expect(@aruba).to be_file(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_file(name) }
+        end
+      end
+
+      context 'when is directory' do
+        let(:name) { 'test.d' }
+        let(:path) { File.join(@aruba.current_directory, name) }
+
+        context 'when exists' do
+          before :each do
+            FileUtils.mkdir_p path
+          end
+
+          it { expect(@aruba).not_to be_file(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_file(name) }
+        end
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -141,6 +141,42 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#exist?' do
+      context 'when is file' do
+        let(:name) { @file_name }
+        let(:path) { @file_path }
+
+        context 'when exists' do
+          before :each do
+            File.write(path, '')
+          end
+
+          it { expect(@aruba).to be_exist(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_exist(name) }
+        end
+      end
+
+      context 'when is directory' do
+        let(:name) { 'test.d' }
+        let(:path) { File.join(@aruba.current_directory, name) }
+
+        context 'when exists' do
+          before :each do
+            FileUtils.mkdir_p path
+          end
+
+          it { expect(@aruba).to be_exist(name) }
+        end
+
+        context 'when does not exist' do
+          it { expect(@aruba).not_to be_exist(name) }
+        end
+      end
+    end
+
     context '#expand_path' do
       it 'expands and returns path' do
         expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -25,6 +25,34 @@ describe Aruba::Api  do
     end
   end
 
+  describe '#all_paths' do
+    let(:name) { @file_name }
+    let(:path) { @file_path }
+
+    context 'when file exist' do
+      before :each do
+        File.write(path, '')
+      end
+
+      it { expect(all_paths).to include expand_path(name) }
+    end
+
+    context 'when directory exist' do
+      let(:name) { 'test_dir' }
+      let(:path) { File.join(@aruba.current_directory, name) }
+
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      it { expect(all_paths).to include expand_path(name) }
+    end
+
+    context 'when nothing exist' do
+      it { expect(all_paths).to eq [] }
+    end
+  end
+
   describe 'directories' do
     before(:each) do
       @directory_name = 'test_dir'

--- a/spec/aruba/matchers/directory_spec.rb
+++ b/spec/aruba/matchers/directory_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe 'Directory Matchers' do
+  include_context 'uses aruba API'
+
+  def expand_path(*args)
+    @aruba.expand_path(*args)
+  end
+
+  describe 'to_be_existing_directory' do
+    let(:name) { 'test.d' }
+    let(:path) { File.join(@aruba.current_directory, name) }
+
+    context 'when directory exists' do
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      it { expect(name).to be_existing_directory }
+    end
+
+    context 'when directory does not exist' do
+      it { expect(name).not_to be_existing_directory }
+    end
+  end
+end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -3,11 +3,11 @@ require 'spec_helper'
 RSpec.describe 'File Matchers' do
   include_context 'uses aruba API'
 
-  def absolute_path(*args)
-    @aruba.absolute_path(*args)
+  def expand_path(*args)
+    @aruba.expand_path(*args)
   end
 
-  describe 'to_be_exsting_file' do
+  describe 'to_be_existing_file' do
     context 'when file exists' do
       before :each do
         File.write(@file_path, '')

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe 'Path Matchers' do
+  include_context 'uses aruba API'
+
+  def expand_path(*args)
+    @aruba.expand_path(*args)
+  end
+
+  describe 'to_match_path_pattern' do
+    context 'when pattern is string' do
+      context 'when there is file which matches path pattern' do
+        before :each do
+          File.write(@file_path, '')
+        end
+
+        it { expect(all_paths).to match_path_pattern(expand_path(@file_name)) }
+      end
+
+      context 'when there is not file which matches path pattern' do
+        it { expect(all_paths).not_to match_path_pattern('test') }
+      end
+    end
+
+    context 'when pattern is regex' do
+      context 'when there is file which matches path pattern' do
+        before :each do
+          File.write(@file_path, '')
+        end
+
+        it { expect(all_paths).to match_path_pattern(/test/) }
+      end
+
+      context 'when there is not file which matches path pattern' do
+        it { expect(all_paths).not_to match_path_pattern(/test/) }
+      end
+    end
+  end
+end

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -36,4 +36,37 @@ RSpec.describe 'Path Matchers' do
       end
     end
   end
+
+  describe 'to_be_existing_path' do
+    context 'when file' do
+      context 'exists' do
+        before :each do
+          File.write(@file_path, '')
+        end
+
+        it { expect(@file_name).to be_existing_path }
+      end
+
+      context 'does not exist' do
+        it { expect(@file_name).not_to be_existing_path }
+      end
+    end
+
+    context 'when directory' do
+      let(:name) { 'test.d' }
+      let(:path) { File.join(@aruba.current_directory, name) }
+
+      context 'exists' do
+        before :each do
+          FileUtils.mkdir_p path
+        end
+
+        it { expect(name).to be_existing_path }
+      end
+
+      context 'does not exist' do
+        it { expect(name).not_to be_existing_path }
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples/directory.rb
+++ b/spec/support/shared_examples/directory.rb
@@ -1,7 +1,7 @@
 shared_examples 'an existing directory' do
-  it { Array(directory_path).each { |p| expect(File).to be_directory(p) } }
+  it { Array(path).each { |p| expect(File).to be_directory(p) } }
 end
 
 shared_examples 'a non-existing directory' do
-  it { Array(directory_path).each { |p| expect(File).not_to be_exist(p) } }
+  it { Array(path).each { |p| expect(File).not_to be_exist(p) } }
 end

--- a/spec/support/shared_examples/file.rb
+++ b/spec/support/shared_examples/file.rb
@@ -1,7 +1,7 @@
 shared_examples 'an existing file' do
-  it { Array(file_path).each { |p| expect(File).to be_file(p) } }
+  it { Array(path).each { |p| expect(File).to be_file(p) } }
 end
 
 shared_examples 'a non-existing file' do
-  it { Array(file_path).each { |p| expect(File).not_to be_exist(p) } }
+  it { Array(path).each { |p| expect(File).not_to be_exist(p) } }
 end


### PR DESCRIPTION
When we have `file?` and `directory?` in place, I see no need to have `remove_file`, `remove_directory`   and `touch_file` anymore.

Be stating `_file` and `_directory` in the name we mix a test and an action. I think users should use the `file?` and `directory?`-methods for tests and `remove` and `touch` for actions.

I changed the implementation of the given methods to work both on files and directories. All relevant changes are from the 2nd of May.

This PR is based on #237.