### PR TITLE
Add rspec integrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,23 @@ well. One might want to use it together with `rspec`.
 1. Create a directory named `spec/support`
 2. Create a file named `spec/support/aruba.rb` with:
 
+  ```ruby
+  require 'aruba/rspec'
   ```
-  require 'aruba/api'
-  require 'aruba/reporting'
 
-  RSpec.configure do |config|
-    config.include Aruba::Api
-
-    config.before(:each) do
-      restore_env
-      clean_current_dir
-    end
-  end
-  ```
 3. Add the following to your `spec/spec_helper.rb`
 
-  ```
+  ```ruby
   Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
   ```
 
+4. Add a type to your specs
+
+  ```ruby
+  RSpec.describe 'My feature', type: :aruba do
+    # [...]
+  end
+  ```
 
 ## API
 

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -1,0 +1,26 @@
+require 'rspec/core'
+require 'aruba/api'
+require 'aruba/reporting'
+
+RSpec.configure do |config|
+  config.include Aruba::Api, type: :aruba
+
+  config.before :each do
+    next unless self.class.include?(Aruba::Api)
+
+    restore_env
+    clean_current_directory
+  end
+
+  # config.before do
+  #   next unless self.class.include?(Aruba::Api)
+
+  #   current_example = context.example
+
+  #   announcer.activate(:environment) if current_example.metadata[:announce_env]
+  #   announcer.activate(:command)     if current_example.metadata[:announce_cmd]
+  #   announcer.activate(:directory)     if current_example.metadata[:announce_dir]
+  #   announcer.activate(:stdout)      if current_example.metadata[:announce_stdout]
+  #   announcer.activate(:stderr)      if current_example.metadata[:announce_stderr]
+  # end
+end


### PR DESCRIPTION
Make it easier for others to integrate `aruba` with rspec.

BTW and as a reminder for me in the future:
This https://github.com/jnicklas/capybara/blob/master/lib/capybara/rspec.rb is a good example.

We may need to discuss the `type`. I'm open for suggestions. What about `type: :aruba` or `type: :cli`?