### PR TITLE
Matcher improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@ pkg
 
 ## PROJECT::SPECIFIC
 tmp
+bin
+bundle
 .bundle
 doc
 Gemfile.lock

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -64,21 +64,19 @@ RSpec::Matchers.define :be_existing_file do |_|
 end
 
 # @!method have_file_content(content)
-#   This matchers checks if <file> has content. It checks exactly if `'string'`
-#   is given and does a substring check if `/regexp/` is given.
+#   This matchers checks if <file> has content. `content` can be a
+#   string, regexp or an RSpec matcher.
 #
-#   @param [String, Regexp] content
-#     The content of the file
+#   @param [String, Regexp, Matcher] content
+#     Specifies the content of the file
 #
 #   @return [TrueClass, FalseClass] The result
 #
 #     false:
 #     * if file does not exist
-#     * if file content is not equal string
-#     * if file content does not include regexp
+#     * if file content does not match the content specification
 #     true:
-#     * if file content includes regexp
-#     * if file content is equal string
+#     * if file content matches the content specification
 #
 #   @example Use matcher with string
 #
@@ -91,29 +89,20 @@ end
 #     RSpec.describe do
 #       it { expect(file1).to have_file_content(/a/) }
 #     end
+#
+#   @example Use matcher with an RSpec matcher
+#
+#     RSpec.describe do
+#       it { expect(file1).to have_file_content(a_string_starting_with "a") }
+#     end
 RSpec::Matchers.define :have_file_content do |expected|
   match do |actual|
     path = absolute_path(actual)
-
-    next false unless File.file? path
-
-    content = File.read(path).chomp
-    next expected === content if expected.is_a? Regexp
-
-    content == expected.chomp
+    return false unless File.file?(path)
+    values_match?(expected, File.read(path).chomp)
   end
 
-  failure_message do |actual|
-    next format("expected that file \"%s\" contains:\n%s", actual, expected) if expected.is_a? Regexp
-
-    format("expected that file \"%s\" contains exactly:\n%s", actual, expected)
-  end
-
-  failure_message_when_negated do |actual|
-    next format("expected that file \"%s\" does not contain:\n%s", actual, expected) if expected.is_a? Regexp
-
-    format("expected that file \"%s\" does not contains exactly:\n%s", actual, expected)
-  end
+  description { "have file content: #{description_of expected}" }
 end
 
 # @!method have_file_size(size)

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'securerandom'
+require 'time'
 
 describe Aruba::Api  do
   include_context 'uses aruba API'

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -42,6 +42,48 @@ RSpec.describe 'File Matchers' do
       context 'and file content not contains string' do
         it { expect(@file_name).not_to have_file_content(/c/) }
       end
+
+      it 'supports composable matchers' do
+        expect(@file_name).to have_file_content(a_string_starting_with("a"))
+      end
+
+      describe "description" do
+        example "for a string" do
+          expect(have_file_content("a").description).to eq('have file content: "a"')
+        end
+
+        example "for a regexp" do
+          expect(have_file_content(/a/).description).to eq('have file content: /a/')
+        end
+
+        example "for a matcher" do
+          expect(have_file_content(a_string_starting_with "a").description).to eq('have file content: a string starting with "a"')
+        end
+      end
+
+      describe "failure messages" do
+        def fail_with(message)
+          raise_error(RSpec::Expectations::ExpectationNotMetError, message)
+        end
+
+        example "for a string" do
+          expect {
+            expect(@file_name).to have_file_content("z")
+          }.to fail_with('expected "test.txt" to have file content: "z"')
+        end
+
+        example "for a string" do
+          expect {
+            expect(@file_name).to have_file_content(/z/)
+          }.to fail_with('expected "test.txt" to have file content: /z/')
+        end
+
+        example "for a matcher" do
+          expect {
+            expect(@file_name).to have_file_content(a_string_starting_with "z")
+          }.to fail_with('expected "test.txt" to have file content: a string starting with "z"')
+        end
+      end
     end
 
     context 'when file does not exist' do


### PR DESCRIPTION
This is an alternative to #248.  It uses RSpec 3's support for composable matchers via `values_match?` and `description_of` for the description/failure messages.  The failure messages are derived from the description so we can just set that.  By using `values_match?` there's no need to treat the regexp, string or any other case as special.

Docs:

http://rspec.info/documentation/3.2/rspec-expectations/RSpec/Matchers/Composable.html#values_match%3F-instance_method

http://rspec.info/documentation/3.2/rspec-expectations/RSpec/Matchers/Composable.html#description_of-instance_method

Bear in mind that this will only work on RSpec 3+.  What versions of RSpec is aruba designed to support?  It may need to be rejiggered to support older versions of RSpec.