### PR TITLE
Path Content

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,7 +90,8 @@ Style/PercentLiteralDelimiters:
 
 # Configuration parameters: SupportedStyles.
 Style/RaiseArgs:
-  EnforcedStyle: compact
+  # EnforcedStyle: compact
+  Enabled: false
 
 # Cop supports --auto-correct.
 Style/RedundantSelf:

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'childprocess', '>= 0.3.6'
   s.add_runtime_dependency 'rspec-expectations', '>= 2.7.0'
 
-  s.add_development_dependency 'bundler', '~> 1.9.6'
+  s.add_development_dependency 'bundler', '~> 1.10.2'
 
   s.rubygems_version = ">= 1.6.1"
   # s.required_ruby_version = '>= 2.0'

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -122,6 +122,22 @@ module Aruba
       list('.').map { |p| expand_path(p) }
     end
 
+    # Return all existing files in current directory
+    #
+    # @return [Array]
+    #   List of files
+    def all_files
+      list('.').select { |p| file? p }.map { |p| expand_path(p) }
+    end
+
+    # Return all existing directories in current directory
+    #
+    # @return [Array]
+    #   List of files
+    def all_directories
+      list('.').select { |p| directory? p }.map { |p| expand_path(p) }
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -98,6 +98,22 @@ module Aruba
       File.directory? expand_path(file)
     end
 
+    # Check if path is absolute
+    #
+    # @return [TrueClass, FalseClass]
+    #   Result of check
+    def absolute?(path)
+      Pathname.new(path).absolute?
+    end
+
+    # Check if path is relative
+    #
+    # @return [TrueClass, FalseClass]
+    #   Result of check
+    def relative?(path)
+      Pathname.new(path).relative?
+    end
+
     # Return all existing paths (directories, files) in current dir
     #
     # @return [Array]

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -103,7 +103,7 @@ module Aruba
     # @return [Array]
     #   List of files and directories
     def all_paths
-      Dir.glob(expand_path('**/*'))
+      read('.').map { |p| expand_path(p) }
     end
 
     # @deprecated

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -171,7 +171,7 @@ module Aruba
     # Return content of directory
     #
     # @return [Array]
-    #   The content of file or directory
+    #   The content of directory
     def list(name)
       fail ArgumentError, %(Path "#{name}" does not exist.) unless exist? name
       fail ArgumentError, %(Only directories are supported. Path "#{name}" is not a directory.) unless directory? name
@@ -185,7 +185,7 @@ module Aruba
     # Return content of file
     #
     # @return [Array]
-    #   The content of file or directory
+    #   The content of file
     def read(name)
       fail ArgumentError, %(Path "#{name}" does not exist.) unless exist? name
       fail ArgumentError, %(Only files are supported. Path "#{name}" is not a file.) unless file? name

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -126,6 +126,19 @@ module Aruba
       clean_current_directory(*args, &block)
     end
 
+    # Return content of file or directory
+    #
+    # @return [Array]
+    #   The content of file or directory
+    def read(name)
+      fail ArgumentError, %(Path "#{name}" does not exist.) unless exist? name
+      fail ArgumentError, %(Only files and directories are supported. Path "#{name}" is neither a directory nor a file.) unless file?(name) || directory?(name)
+
+      return Dir.glob(expand_path(File.join(name, '**', '*'))).map { |d| Pathname.new(d).relative_path_from(Pathname.new(expand_path('.'))).to_s } if directory? name
+
+      File.readlines(expand_path(name))
+    end
+
     # Get access to current dir
     #
     # @return

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -138,6 +138,16 @@ module Aruba
       list('.').select { |p| directory? p }.map { |p| expand_path(p) }
     end
 
+    # Create directory object
+    #
+    # @return [Dir]
+    #   The directory object
+    def directory(path)
+      fail ArgumentError, %(Path "#{name}" does not exist.) unless exist? name
+
+      Dir.new(expand_path(path))
+    end
+
     # @deprecated
     # @private
     def in_current_dir(*args, &block)

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -153,7 +153,7 @@ module Aruba
       existing_files            = Dir.glob(expand_path(File.join(name, '**', '*')))
       current_working_directory = Pathname.new(expand_path('.'))
 
-      return existing_files.map { |d| Pathname.new(d).relative_path_from(current_working_directory).to_s }
+      existing_files.map { |d| Pathname.new(d).relative_path_from(current_working_directory).to_s }
     end
 
     # Return content of file

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -103,7 +103,7 @@ module Aruba
     # @return [Array]
     #   List of files and directories
     def all_paths
-      read('.').map { |p| expand_path(p) }
+      list('.').map { |p| expand_path(p) }
     end
 
     # @deprecated
@@ -126,15 +126,27 @@ module Aruba
       clean_current_directory(*args, &block)
     end
 
-    # Return content of file or directory
+    # Return content of directory
+    #
+    # @return [Array]
+    #   The content of file or directory
+    def list(name)
+      fail ArgumentError, %(Path "#{name}" does not exist.) unless exist? name
+      fail ArgumentError, %(Only directories are supported. Path "#{name}" is not a directory.) unless directory? name
+
+      existing_files            = Dir.glob(expand_path(File.join(name, '**', '*')))
+      current_working_directory = Pathname.new(expand_path('.'))
+
+      return existing_files.map { |d| Pathname.new(d).relative_path_from(current_working_directory).to_s }
+    end
+
+    # Return content of file
     #
     # @return [Array]
     #   The content of file or directory
     def read(name)
       fail ArgumentError, %(Path "#{name}" does not exist.) unless exist? name
-      fail ArgumentError, %(Only files and directories are supported. Path "#{name}" is neither a directory nor a file.) unless file?(name) || directory?(name)
-
-      return Dir.glob(expand_path(File.join(name, '**', '*'))).map { |d| Pathname.new(d).relative_path_from(Pathname.new(expand_path('.'))).to_s } if directory? name
+      fail ArgumentError, %(Only files are supported. Path "#{name}" is not a file.) unless file? name
 
       File.readlines(expand_path(name))
     end

--- a/lib/aruba/matchers/directory.rb
+++ b/lib/aruba/matchers/directory.rb
@@ -42,7 +42,7 @@ RSpec::Matchers.define :have_sub_directory do |expected|
     next false unless directory?(actual)
 
     expected_files = Array(expected).map { |p| File.join(actual, p) }
-    existing_files = read(actual)
+    existing_files = list(actual)
 
     (expected_files - existing_files).empty?
   end

--- a/lib/aruba/matchers/directory.rb
+++ b/lib/aruba/matchers/directory.rb
@@ -12,3 +12,48 @@ RSpec::Matchers.define :be_existing_directory do |_|
     format("expected that directory \"%s\" does not exist", actual)
   end
 end
+
+# @!method have_sub_directory(sub_directory)
+#   This matchers checks if <directory> has given sub-directory
+#
+#   @param [Array] sub_directory
+#      A list of sub-directory relative to current directory
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if directory does not have sub-directory
+#     true:
+#     * if directory has sub-directory
+#
+#   @example Use matcher with single directory
+#
+#     RSpec.describe do
+#       it { expect('dir1.d').to have_sub_directory('subdir.1.d') }
+#     end
+#
+#   @example Use matcher with multiple directories
+#
+#     RSpec.describe do
+#       it { expect('dir1.d').to have_sub_directory(['subdir.1.d', 'subdir.2.d']) }
+#     end
+RSpec::Matchers.define :have_sub_directory do |expected|
+  match do |actual|
+    next false unless directory?(actual)
+
+    expected_files = Array(expected).map { |p| File.join(actual, p) }
+    existing_files = read(actual)
+
+    (expected_files - existing_files).empty?
+  end
+
+  diffable
+
+  failure_message do |actual|
+    format("expected that directory \"%s\" has the following sub-directories: %s.", actual, Array(expected).join(', '))
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that directory \"%s\" does not have the following sub-directories: %s.", actual, Array(expected).join(', '))
+  end
+end

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -93,7 +93,7 @@ end
 #     end
 RSpec::Matchers.define :have_file_content do |expected|
   match do |actual|
-    path = absolute_path(actual)
+    path = expand_path(actual)
 
     next false unless File.file? path
 

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -67,3 +67,33 @@ RSpec::Matchers.define :be_existing_path do |_|
     format("expected that path \"%s\" does not exist", actual)
   end
 end
+
+# @!method be_absolute_path
+#   This matchers checks if <path> exists in filesystem
+#
+#   @return [TrueClass, FalseClass] The result
+#
+#     false:
+#     * if path is not absolute
+#     true:
+#     * if path is absolute
+#
+#   @example Use matcher
+#
+#     RSpec.describe do
+#       it { expect(file).to be_absolute_path }
+#       it { expect(directory).to be_absolute_path }
+#     end
+RSpec::Matchers.define :be_absolute_path do |_|
+  match do |actual|
+    absolute?(actual)
+  end
+
+  failure_message do |actual|
+    format("expected that path \"%s\" is absolute, but it's not", actual)
+  end
+
+  failure_message_when_negated do |actual|
+    format("expected that path \"%s\" is not absolute, but it is", actual)
+  end
+end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -52,6 +52,62 @@ describe Aruba::Api  do
     end
   end
 
+  describe '#all_files' do
+    let(:name) { @file_name }
+    let(:path) { @file_path }
+
+    context 'when file exist' do
+      before :each do
+        File.write(path, '')
+      end
+
+      it { expect(all_files).to include expand_path(name) }
+    end
+
+    context 'when directory exist' do
+      let(:name) { 'test_dir' }
+      let(:path) { File.join(@aruba.current_directory, name) }
+
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      it { expect(all_files).to eq [] }
+    end
+
+    context 'when nothing exist' do
+      it { expect(all_files).to eq [] }
+    end
+  end
+
+  describe '#all_directories' do
+    let(:name) { @file_name }
+    let(:path) { @file_path }
+
+    context 'when file exist' do
+      before :each do
+        File.write(path, '')
+      end
+
+      it { expect(all_directories).to eq [] }
+    end
+
+    context 'when directory exist' do
+      let(:name) { 'test_dir' }
+      let(:path) { File.join(@aruba.current_directory, name) }
+
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      it { expect(all_directories).to include expand_path(name) }
+    end
+
+    context 'when nothing exist' do
+      it { expect(all_directories).to eq [] }
+    end
+  end
+
   describe 'directories' do
     before(:each) do
       @directory_name = 'test_dir'

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -355,6 +355,32 @@ describe Aruba::Api  do
       end
     end
 
+    describe '#absolute?' do
+      let(:name) { @file_name }
+      let(:path) { File.expand_path(File.join(@aruba.current_directory, name)) }
+
+      context 'when is absolute path' do
+        it { expect(@aruba).to be_absolute(path) }
+      end
+
+      context 'when is relative path' do
+        it { expect(@aruba).not_to be_absolute(name) }
+      end
+    end
+
+    describe '#relative?' do
+      let(:name) { @file_name }
+      let(:path) { File.expand_path(File.join(@aruba.current_directory, name)) }
+
+      context 'when is absolute path' do
+        it { expect(@aruba).not_to be_relative(path) }
+      end
+
+      context 'when is relative path' do
+        it { expect(@aruba).to be_relative(name) }
+      end
+    end
+
     describe '#exist?' do
       context 'when is file' do
         let(:name) { @file_name }

--- a/spec/aruba/matchers/directory_spec.rb
+++ b/spec/aruba/matchers/directory_spec.rb
@@ -23,4 +23,36 @@ RSpec.describe 'Directory Matchers' do
       it { expect(name).not_to be_existing_directory }
     end
   end
+
+  describe 'to_have_sub_directory' do
+    let(:name) { 'test.d' }
+    let(:path) { File.join(@aruba.current_directory, name) }
+    let(:content) { %w(subdir.1.d subdir.2.d) }
+
+    context 'when directory exists' do
+      before :each do
+        FileUtils.mkdir_p path
+      end
+
+      before :each do
+        Array(content).each { |p| Dir.mkdir File.join(path, p) }
+      end
+
+      context 'when single directory' do
+        it { expect(name).to have_sub_directory('subdir.1.d') }
+      end
+
+      context 'when multiple directories' do
+        it { expect(name).to have_sub_directory(['subdir.1.d', 'subdir.2.d']) }
+      end
+
+      context 'when non existing directory' do
+        it { expect(name).not_to have_sub_directory('subdir.3.d') }
+      end
+    end
+
+    context 'when directory does not exist' do
+      it { expect(name).not_to have_sub_directory('subdir') }
+    end
+  end
 end

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -37,6 +37,19 @@ RSpec.describe 'Path Matchers' do
     end
   end
 
+  describe 'to_be_absolute_path' do
+    let(:name) { @file_name }
+    let(:path) { File.expand_path(File.join(@aruba.current_directory, name)) }
+
+    context 'when is absolute path' do
+      it { expect(path).to be_absolute_path }
+    end
+
+    context 'when is relative path' do
+      it { expect(name).not_to be_absolute_path }
+    end
+  end
+
   describe 'to_be_existing_path' do
     context 'when file' do
       context 'exists' do


### PR DESCRIPTION
This reads content from
* directory
* file

And returns an array of content. Next step would be to use it "everywhere" in the code. `rubcop` complains if I use `ArgumentError` although that should be ok. For now I disabled the check.