### PR TITLE
Do not trigger Announcer API deprecation warning

### DIFF
--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -115,8 +115,8 @@ module Aruba
         close_and_cache_err
 
         if reader
-          reader.stdout stdout
-          reader.stderr stderr
+          reader.announce :stdout, stdout
+          reader.announce :stderr, stderr
         end
 
         @exit_status

--- a/spec/aruba/spawn_process_spec.rb
+++ b/spec/aruba/spawn_process_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Aruba::Processes::SpawnProcess do
     before(:each) { process.run! }
 
     before :each do
-      allow(reader).to receive(:stderr)
-      expect(reader).to receive(:stdout).with("yo\n")
+      allow(reader).to receive(:announce).with(:stderr, '')
+      expect(reader).to receive(:announce).with(:stdout, "yo\n")
     end
 
     context 'when stopped successfully' do


### PR DESCRIPTION
`Processes::SpawnProcess#stop` calls `Announcer::PutsAnnouncer#stderr` and `#stdout`, triggering [these](https://github.com/cucumber/aruba/blob/abd78e67237e5951bb3256d9235bfc6597db22c9/lib/aruba/announcer.rb#L137) [two](https://github.com/cucumber/aruba/blob/abd78e67237e5951bb3256d9235bfc6597db22c9/lib/aruba/announcer.rb#L142) deprecation warnings in third party projects that use Aruba.

This fixes the problem. :)