### PR TITLE
Methods for testing the OS (ex: on_windows? on_unix?)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,21 @@ gemspec
 group :debug do
   gem 'pry', '~> 0.10.1'
 
+  if RUBY_VERSION >= '1.9'
+    if RUBY_VERSION >= '2.0' || defined?(JRUBY) || defined?(RUBINIUS)
+      gem 'byebug', '~> 4.0.5'
+      gem 'pry-byebug', '~> 3.1.0'
+      gem 'pry-stack_explorer', '~> 0.4.9'
+
+    elsif RUBY_VERSION == '1.9'
+      gem 'debugger', '~> 1.6.8'
+      gem 'pry-debugger', '~> 0.2.3'
+    end
+  end
+
+  gem 'pry-doc', '~> 0.8.0'
+
+=begin
   platform :ruby_20, :ruby_21, :ruby_22, :jruby, :rbx do
     gem 'byebug', '~> 4.0.5'
     gem 'pry-byebug', '~> 3.1.0'
@@ -22,13 +37,44 @@ group :debug do
   end
 
   gem 'pry-doc', '~> 0.8.0'
+
+=end
+
 end
 
 group :development, :test do
   # Run development tasks
   gem 'rake', '~> 10.4.2'
 
-  platform :ruby_19, :ruby_20, :ruby_21, :ruby_22, :jruby, :rbx do
+  # Code Coverage
+  gem 'simplecov', '~> 0.10'
+
+  # Test api
+  gem 'rspec', '~> 3.3.0'
+  gem 'fuubar', '~> 2.0.0'
+
+  if RUBY_VERSION >= '1.9' || defined?(JRUBY) || defined?(RUBINIUS)
+    gem 'cucumber', '~> 2.0'
+
+    gem 'rubocop', '~> 0.32.0'
+
+    gem 'cucumber-pro', '~> 0.0'
+
+    # License compliance
+    gem 'license_finder', '~> 2.0.4'
+
+    # Upload documentation
+    gem 'relish', '~> 0.7.1'
+    # Reporting
+    gem 'bcat', '~> 0.6.2'
+    gem 'kramdown', '~> 1.7.0'
+
+  elsif RUBY_VERSION < '1.9'
+    gem 'cucumber', '~> 1.3.20'
+  end
+
+=begin
+      platform :ruby_19, :ruby_20, :ruby_21, :ruby_22, :jruby, :rbx do
     # Reporting
     gem 'bcat', '~> 0.6.2'
     gem 'kramdown', '~> 1.7.0'
@@ -67,6 +113,7 @@ group :development, :test do
     # Upload documentation
     gem 'relish', '~> 0.7.1'
   end
+=end
 end
 
 platforms :rbx do

--- a/lib/aruba/platform.rb
+++ b/lib/aruba/platform.rb
@@ -1,5 +1,6 @@
 require 'rbconfig'
 require 'pathname'
+require 'ffi'
 
 module Aruba
   # WARNING:
@@ -222,6 +223,31 @@ module Aruba
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity
+
+    # return true if the OS running is Windows according to FFI
+    def on_windows?
+      FFI::Platform.windows?
+    end
+
+    # return true if the OS running is Unix according to FFI
+    def on_unix?
+      FFI::Platform.unix?
+    end
+
+    # return true if the OS running is Mac according to FFI
+    def on_mac?
+      FFI::Platform.mac?
+    end
+
+    # return true if the OS running is BSD according to FFI
+    def on_bsd?
+      FFI::Platform.bsd?
+    end
+
+    # return true if the OS running is Solaris according to FFI
+    def on_solaris?
+      FFI::Platform.solaris
+    end
 
     module_function :detect_ruby, \
       :current_ruby, \


### PR DESCRIPTION
**Dang.  Included the wrong commits.  Closing this and will try again.**

I've added some methods into <code>(lib)/api/platform.rb</code> to query which OS is running.  Since FFI is already being included by the project and FFI already has excellent methods for querying the OS, the methods are essentially pass-thru's to what FFI does.  
If it's somehow not good to use ffi (it did require a <code>require 'ffi'</code> in platform.rb) I can use the already required rbconfig.  (Tho I'll likely be re-writing what FFI has done.)


