### PR TITLE
Add disk usage

### DIFF
--- a/features/api/filesystem/disk_usage.feature
+++ b/features/api/filesystem/disk_usage.feature
@@ -1,0 +1,151 @@
+Feature: Report disk usage
+
+  Sometimes you need to check, what amount of disk space a file consumes. We do
+  NOT support "directories" with `#disk_usage`. This does not work reliably
+  over different systems. Here can help `'#disk_usage`. But be careful, by
+  default it uses a block size of "512" (physical block size) to calculate the
+  usage. You may need to adjust this by using `Aruba.configure { |config|
+  config.physical_block_size = 4_096 }`. Don't get confused, if you check the
+  block size by using `File::Stat` (in ruby). It reports the block size of your
+  filesystem, which can be "4_096" for example.
+
+  We're gonna use the (correct) IEC-notation
+  (https://en.wikipedia.org/wiki/Binary_prefix) here:
+
+    \* kilo => kibi
+    \* mega => mebi
+    \* giga => gibi
+
+  Background:
+    Given I use a fixture named "cli-app"
+
+  Scenario: Show disk usage for file
+    Given a file named "spec/disk_usage_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'disk usage', :type => :aruba do
+      let(:file) { 'file.txt' }
+
+      before(:each) do 
+        write_file file, 'a'
+      end
+
+      let(:size_of_single_block) { File::Stat.new(expand_path(file)).blksize }
+
+      it { expect(disk_usage(file)).to eq size_of_single_block }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Show disk usage for multiple files
+
+    `#disk_usage` creates the sum of all given objects' sizes.
+
+    Given a file named "spec/disk_usage_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'disk usage', :type => :aruba do
+      let(:file1) { 'file1.txt' }
+      let(:file2) { 'file2.txt' }
+
+      before(:each) do 
+        write_file file1, 'a'
+        write_file file2, 'a'
+      end
+
+      let(:size_of_single_block) { File::Stat.new(expand_path(file1)).blksize }
+
+      it { expect(disk_usage(file1, file2)).to eq size_of_single_block * 2 }
+      it { expect(disk_usage([file1, file2])).to eq size_of_single_block * 2 }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Convert reported disk usage to KibiByte
+    Given a file named "spec/disk_usage_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'disk usage', :type => :aruba do
+      let(:file) { 'file.txt' }
+
+      before(:each) do 
+        write_file file, 'a'
+      end
+
+      let(:converted_size) { File::Stat.new(expand_path(file)).blksize.to_f / 1_024 }
+
+      it { expect(disk_usage(file).to_kibi_byte).to eq converted_size }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Convert reported disk usage to MebiByte
+    Given a file named "spec/disk_usage_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'disk usage', :type => :aruba do
+      let(:file) { 'file.txt' }
+
+      before(:each) do 
+        write_file file, 'a'
+      end
+
+      let(:converted_size) { File::Stat.new(expand_path(file)).blksize.to_f / 1_024 / 1024 }
+
+      it { expect(disk_usage(file).to_mebi_byte).to eq converted_size }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Convert reported disk usage to GibiByte
+    Given a file named "spec/disk_usage_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'disk usage', :type => :aruba do
+      let(:file) { 'file.txt' }
+
+      before(:each) do 
+        write_file file, 'a'
+      end
+
+      let(:converted_size) { File::Stat.new(expand_path(file)).blksize.to_f / 1_024 / 1_024 / 1_024 }
+
+      it { expect(disk_usage(file).to_gibi_byte).to eq converted_size }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Compare two repored disk usages
+    Given a file named "spec/disk_usage_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'disk usage', :type => :aruba do
+      let(:file1) { 'file1.txt' }
+      let(:file2) { 'file2.txt' }
+
+      before(:each) do 
+        write_file file1, 'a' * 10_000
+        write_file file2, 'a'
+      end
+
+      before :each do
+        @size1 = disk_usage(file1)
+        @size2 = disk_usage(file2)
+      end
+
+      it { expect(@size1).to be > @size2 }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass

--- a/features/configuration/physical_block_size.feature
+++ b/features/configuration/physical_block_size.feature
@@ -1,0 +1,53 @@
+Feature: Configure the phsical block size of disk
+
+  As a developer
+  I want to configure the physical block size
+  In order to make the disk usage work for my application's setup
+
+  Background:
+    Given I use the fixture "cli-app"
+
+  Scenario: Default value
+    Given a file named "features/support/aruba.rb" with:
+    """
+    Aruba.configure do |config|
+      puts %(The default value is "#{config.physical_block_size}")
+    end
+    """
+    When I successfully run `cucumber`
+    Then the output should contain:
+    """
+    The default value is "512"
+    """
+
+  Scenario: Set the block size to something else which is a power of two
+    Given a file named "features/support/aruba.rb" with:
+    """
+    Aruba.configure do |config|
+      # use current working directory
+      config.physical_block_size = 4096
+    end
+
+    Aruba.configure do |config|
+      puts %(The default value is "#{config.physical_block_size}")
+    end
+    """
+    When I successfully run `cucumber`
+    Then the output should contain:
+    """
+    The default value is "4096"
+    """
+
+  Scenario: The value needs to be a power of two, otherwise it will fail
+    Given a file named "features/support/aruba.rb" with:
+    """
+    Aruba.configure do |config|
+      config.physical_block_size = 3
+    end
+    """
+    When I run `cucumber`
+    Then the output should contain:
+    """
+    Contract violation for argument
+    """
+    

--- a/lib/aruba/aruba_path.rb
+++ b/lib/aruba/aruba_path.rb
@@ -1,6 +1,8 @@
 require 'pathname'
 require 'delegate'
 
+require 'aruba/file_size'
+
 module Aruba
   class ArubaPath < Delegator
     def initialize(path)
@@ -85,6 +87,16 @@ module Aruba
       else
         to_s[index]
       end
+    end
+
+    # Report count of blocks allocated on disk
+    #
+    # This reports the amount of blocks which are allocated by the path.
+    #
+    # @return [Integer]
+    #   The count of blocks on disk
+    def blocks
+      File::Stat.new(to_s).blocks
     end
   end
 end

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -4,9 +4,12 @@ require 'aruba/version'
 require 'aruba/basic_configuration'
 require 'aruba/config_wrapper'
 require 'aruba/hooks'
+
 require 'aruba/contracts/relative_path'
 require 'aruba/contracts/absolute_path'
 require 'aruba/contracts/enum'
+
+require 'aruba/contracts/is_power_of_two'
 
 module Aruba
   # Aruba Configuration
@@ -52,6 +55,8 @@ module Aruba
     # rubocop:disable Metrics/LineLength
     option_accessor :log_level, :contract => { Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] => Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] }, :default => :info
     # rubocop:enable Metrics/LineLength
+
+    option_accessor :physical_block_size, :contract => { Aruba::Contracts::IsPowerOfTwo => Aruba::Contracts::IsPowerOfTwo }, :default => 512
   end
 end
 

--- a/lib/aruba/contracts/is_power_of_two.rb
+++ b/lib/aruba/contracts/is_power_of_two.rb
@@ -1,0 +1,15 @@
+require 'aruba/aruba_path'
+
+module Aruba
+  module Contracts
+    class IsPowerOfTwo
+      def self.valid?(x)
+        # explanation for algorithm can be found here:
+        # http://www.exploringbinary.com/ten-ways-to-check-if-an-integer-is-a-power-of-two-in-c/
+        x != 0 && (x & (x - 1)) == 0 ? true : false
+      rescue
+        false
+      end
+    end
+  end
+end

--- a/lib/aruba/disk_usage_calculator.rb
+++ b/lib/aruba/disk_usage_calculator.rb
@@ -1,0 +1,7 @@
+module Aruba
+  class DiskUsageCalculator
+    def calc(blocks, block_size)
+      FileSize.new(blocks * block_size)
+    end
+  end
+end

--- a/lib/aruba/file_size.rb
+++ b/lib/aruba/file_size.rb
@@ -1,0 +1,52 @@
+require 'delegate'
+
+module Aruba
+  class FileSize
+    include Comparable
+
+    private
+
+    attr_reader :bytes, :divisor
+
+    public
+
+    def initialize(bytes)
+      @bytes   = bytes
+      @divisor = 1024
+    end
+
+    def to_byte
+      bytes
+    end
+    alias_method :to_i, :to_byte
+
+    def to_f
+      to_i.to_f
+    end
+
+    def to_s
+      to_i.to_s
+    end
+    alias_method :inspect, :to_s
+
+    def coerce(other)
+      [bytes, other]
+    end
+
+    def to_kibi_byte
+      to_byte.to_f / divisor
+    end
+
+    def to_mebi_byte
+      to_kibi_byte.to_f / divisor
+    end
+
+    def to_gibi_byte
+      to_mebi_byte.to_f / divisor
+    end
+
+    def <=>(other)
+      to_i <=> other.to_i
+    end
+  end
+end


### PR DESCRIPTION
This adds a method to report the disk usage for files and directories. It's different from `File.size`as this uses the amount of blocks really allocated on disk and reports a different value for `Sparse Files` (http://prefetch.net/blog/index.php/2009/07/05/creating-sparse-files-on-linux-hosts-with-dd/).