### PR TITLE
Try to fix problem with scopes

### DIFF
--- a/features/step_definitions/aruba_dev_steps.rb
+++ b/features/step_definitions/aruba_dev_steps.rb
@@ -26,7 +26,9 @@ Then /^the following step should fail with Spec::Expectations::ExpectationNotMet
 end
 
 Then /^the output should be (\d+) bytes long$/ do |length|
-  expect(all_output.length).to eq length.to_i
+  aruba_scope do
+    expect(all_output.length).to eq length.to_i
+  end
 end
 
 Then /^the feature(?:s)? should( not)?(?: all)? pass$/ do |negated|

--- a/features/steps/commands/in_process.feature
+++ b/features/steps/commands/in_process.feature
@@ -45,12 +45,16 @@ Feature: Run commands in ruby process
     require 'aruba/cucumber'
 
     Before('@in-process') do
-      aruba.config.command_launcher = :in_process
-      aruba.config.main_class = Cli::App::Runner
+      aruba_scope do
+        aruba.config.command_launcher = :in_process
+        aruba.config.main_class = Cli::App::Runner
+      end
     end
 
     After('@in-process') do
-      aruba.config.command_launcher = :spawn
+      aruba_scope do
+        aruba.config.command_launcher = :spawn
+      end
     end
     """
 
@@ -207,12 +211,16 @@ Feature: Run commands in ruby process
     require 'aruba/processes/in_process'
 
     Before('@in-process') do
-      Aruba.process = Aruba::Processes::InProcess
-      Aruba.process.main_class = Cli::App::Runner
+      aruba_scope do
+        Aruba.process = Aruba::Processes::InProcess
+        Aruba.process.main_class = Cli::App::Runner
+      end
     end
 
     After('@in-process') do
-      Aruba.process = Aruba::Processes::SpawnProcess
+      aruba_scope do
+        Aruba.process = Aruba::Processes::SpawnProcess
+      end
     end
     """
     Given a file named "lib/cli/app/runner.rb" with:

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -250,7 +250,13 @@ module Aruba
       #   Run block with process
       #
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity
       def run(cmd, timeout = nil)
+        unless directory? '.'
+          Aruba::Platform.deprecated('The use of "run" without an existing working directory is deprecated. This will be an error from 1.0.0 on.')
+          create_directory '.'
+        end
+
         timeout ||= exit_timeout
         @commands ||= []
         @commands << cmd
@@ -279,6 +285,7 @@ module Aruba
                      else
                        aruba.config.main_class
                      end
+
         command = Command.new(
           cmd,
           :mode              => mode,
@@ -306,6 +313,7 @@ module Aruba
         block_given? ? yield(command) : command
       end
       # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       # Default exit timeout for running commands with aruba
       #

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -1,4 +1,5 @@
 require 'rspec/expectations'
+
 require 'aruba/announcer'
 require 'aruba/runtime'
 require 'aruba/errors'

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -3,6 +3,9 @@ require 'aruba/version'
 require 'aruba/api'
 World(Aruba::Api)
 
+require 'aruba/scope'
+World(Aruba::Scope)
+
 require 'aruba/cucumber/hooks'
 require 'aruba/reporting'
 
@@ -13,198 +16,280 @@ if Aruba::VERSION >= '1.0.0'
 end
 
 Given /the default aruba timeout is (\d+) seconds/ do |seconds|
-  aruba.config.exit_timeout = seconds.to_i
+  aruba_scope do
+    aruba.config.exit_timeout = seconds.to_i
+  end
 end
 
 Given /I use (?:a|the) fixture(?: named)? "([^"]*)"/ do |name|
-  copy File.join(aruba.config.fixtures_path_prefix, name), name
-  cd name
+  aruba_scope do
+    copy File.join(aruba.config.fixtures_path_prefix, name), name
+    cd name
+  end
 end
 
 Given /The default aruba timeout is (\d+) seconds/ do |seconds|
   warn(%{\e[35m    The  /^The default aruba timeout is (\d+) seconds/ step definition is deprecated. Please use the one with `the` and not `The` at the beginning.\e[0m})
-  aruba.config.exit_timeout = seconds.to_i
+  aruba_scope do
+    aruba.config.exit_timeout = seconds.to_i
+  end
 end
 
 Given /^I'm using a clean gemset "([^"]*)"$/ do |gemset|
-  use_clean_gemset(gemset)
+  aruba_scope do
+    use_clean_gemset(gemset)
+  end
 end
 
 Given /^(?:a|the) directory(?: named)? "([^"]*)"$/ do |dir_name|
-  create_directory(dir_name)
+  aruba_scope do
+    create_directory(dir_name)
+  end
 end
 
 Given /^(?:a|the) directory(?: named)? "([^"]*)" with mode "([^"]*)"$/ do |dir_name, dir_mode|
-  create_directory(dir_name)
-  chmod(dir_mode, dir_name)
+  aruba_scope do
+    create_directory(dir_name)
+    chmod(dir_mode, dir_name)
+  end
 end
 
 Given /^(?:a|the) file(?: named)? "([^"]*)" with:$/ do |file_name, file_content|
-  write_file(file_name, file_content)
+  aruba_scope do
+    write_file(file_name, file_content)
+  end
 end
 
 Given /^(?:a|the) file(?: named)? "([^"]*)" with mode "([^"]*)" and with:$/ do |file_name, file_mode, file_content|
-  write_file(file_name, file_content)
-  chmod(file_mode, file_name)
+  aruba_scope do
+    write_file(file_name, file_content)
+    chmod(file_mode, file_name)
+  end
 end
 
 Given /^(?:a|the) (\d+) byte file(?: named)? "([^"]*)"$/ do |file_size, file_name|
-  write_fixed_size_file(file_name, file_size.to_i)
+  aruba_scope do
+    write_fixed_size_file(file_name, file_size.to_i)
+  end
 end
 
 Given /^(?:an|the) empty file(?: named)? "([^"]*)"$/ do |file_name|
-  write_file(file_name, "")
+  aruba_scope do
+    write_file(file_name, "")
+  end
 end
 
 Given /^(?:an|the) empty file(?: named)? "([^"]*)" with mode "([^"]*)"$/ do |file_name, file_mode|
-  write_file(file_name, "")
-  chmod(file_mode, file_name)
+  aruba_scope do
+    write_file(file_name, "")
+    chmod(file_mode, file_name)
+  end
 end
 
 Given /^a mocked home directory$/ do
-  set_environment_variable 'HOME', expand_path('.')
+  aruba_scope do
+    set_environment_variable 'HOME', expand_path('.')
+  end
 end
 
 Given /^(?:a|the) directory(?: named)? "([^"]*)" does not exist$/ do |directory_name|
-  remove(directory_name, :force => true)
+  aruba_scope do
+    remove(directory_name, :force => true)
+  end
 end
 
 When /^I write to "([^"]*)" with:$/ do |file_name, file_content|
-  write_file(file_name, file_content)
+  aruba_scope do
+    write_file(file_name, file_content)
+  end
 end
 
 When /^I overwrite "([^"]*)" with:$/ do |file_name, file_content|
-  overwrite_file(file_name, file_content)
+  aruba_scope do
+    overwrite_file(file_name, file_content)
+  end
 end
 
 When /^I append to "([^"]*)" with:$/ do |file_name, file_content|
-  append_to_file(file_name, file_content)
+  aruba_scope do
+    append_to_file(file_name, file_content)
+  end
 end
 
 When /^I append to "([^"]*)" with "([^"]*)"$/ do |file_name, file_content|
-  append_to_file(file_name, file_content)
+  aruba_scope do
+    append_to_file(file_name, file_content)
+  end
 end
 
 When /^I remove (?:a|the) file(?: named)? "([^"]*)"$/ do |file_name|
-  remove(file_name)
+  aruba_scope do
+    remove(file_name)
+  end
 end
 
 Given /^(?:a|the) file(?: named)? "([^"]*)" does not exist$/ do |file_name|
-  remove(file_name, :force => true)
+  aruba_scope do
+    remove(file_name, :force => true)
+  end
 end
 
 When(/^I remove (?:a|the) directory(?: named)? "(.*?)"$/) do |directory_name|
-  remove(directory_name)
+  aruba_scope do
+    remove(directory_name)
+  end
 end
 
 When /^I cd to "([^"]*)"$/ do |dir|
-  cd(dir)
+  aruba_scope do
+    cd(dir)
+  end
 end
 
 Given /^I set the environment variables to:/ do |table|
-  table.hashes.each do |row|
-    variable = row['variable'].to_s.upcase
-    value = row['value'].to_s
+  aruba_scope do
+    table.hashes.each do |row|
+      variable = row['variable'].to_s.upcase
+      value = row['value'].to_s
 
-    set_environment_variable(variable, value)
+      set_environment_variable(variable, value)
+    end
   end
 end
 
 Given /^I append the value to the environment variable:/ do |table|
-  table.hashes.each do |row|
-    variable = row['variable'].to_s.upcase
-    value = row['value'].to_s
+  aruba_scope do
+    table.hashes.each do |row|
+      variable = row['variable'].to_s.upcase
+      value = row['value'].to_s
 
-    append_environment_variable(variable, value)
+      append_environment_variable(variable, value)
+    end
   end
 end
 
 When /^I run "(.*)"$/ do |cmd|
   warn(%{\e[35m    The /^I run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), false)
+  aruba_scope do
+    run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), false)
+  end
 end
 
 When /^I run `([^`]*)`$/ do |cmd|
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), false)
+  aruba_scope do
+    run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), false)
+  end
 end
 
 When /^I successfully run "(.*)"$/ do |cmd|
   warn(%{\e[35m    The  /^I successfully run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi))
+  aruba_scope do
+    run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi))
+  end
 end
 
 ## I successfully run `echo -n "Hello"`
 ## I successfully run `sleep 29` for up to 30 seconds
 When /^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/ do |cmd, secs|
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), true, secs && secs.to_i)
+  aruba_scope do
+    run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), true, secs && secs.to_i)
+  end
 end
 
 When /^I run "([^"]*)" interactively$/ do |cmd|
-  warn(%{\e[35m    The /^I run "([^"]*)" interactively$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-  step %(I run `#{cmd}` interactively)
+  aruba_scope do
+    warn(%{\e[35m    The /^I run "([^"]*)" interactively$/ step definition is deprecated. Please use the `backticks` version\e[0m})
+    step %(I run `#{cmd}` interactively)
+  end
 end
 
 When /^I run `([^`]*)` interactively$/ do |cmd|
-  @interactive = run(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi))
+  aruba_scope do
+    @interactive = run(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi))
+  end
 end
 
 When /^I type "([^"]*)"$/ do |input|
-  type(input)
+  aruba_scope do
+    type(input)
+  end
 end
 
 When /^I close the stdin stream$/ do
-  close_input
+  aruba_scope do
+    close_input
+  end
 end
 
 When /^I pipe in (?:a|the) file(?: named)? "([^"]*)"$/ do |file|
-  pipe_in_file(file)
+  aruba_scope do
+    pipe_in_file(file)
 
-  close_input
+    close_input
+  end
 end
 
 When /^I wait for (?:output|stdout) to contain "([^"]*)"$/ do |expected|
-  Timeout.timeout(exit_timeout) do
-    loop do
-      break if assert_partial_output_interactive(expected)
-      sleep 0.1
+  aruba_scope do
+    Timeout.timeout(exit_timeout) do
+      loop do
+        break if assert_partial_output_interactive(expected)
+        sleep 0.1
+      end
     end
   end
 end
 
 Then /^the output should contain "([^"]*)"$/ do |expected|
-  assert_partial_output(expected, all_output)
+  aruba_scope do
+    assert_partial_output(expected, all_output)
+  end
 end
 
 Then /^the output from "([^"]*)" should contain "([^"]*)"$/ do |cmd, expected|
-  assert_partial_output(expected, output_from(cmd))
+  aruba_scope do
+    assert_partial_output(expected, output_from(cmd))
+  end
 end
 
 Then /^the output from "([^"]*)" should not contain "([^"]*)"$/ do |cmd, unexpected|
-  assert_no_partial_output(unexpected, output_from(cmd))
+  aruba_scope do
+    assert_no_partial_output(unexpected, output_from(cmd))
+  end
 end
 
 Then /^the output should not contain "([^"]*)"$/ do |unexpected|
-  assert_no_partial_output(unexpected, all_output)
+  aruba_scope do
+    assert_no_partial_output(unexpected, all_output)
+  end
 end
 
 Then /^the output should contain:$/ do |expected|
-  assert_partial_output(expected, all_output)
+  aruba_scope do
+    assert_partial_output(expected, all_output)
+  end
 end
 
 Then /^the output should not contain:$/ do |unexpected|
-  assert_no_partial_output(unexpected, all_output)
+  aruba_scope do
+    assert_no_partial_output(unexpected, all_output)
+  end
 end
 
 ## the output should contain exactly "output"
 ## the output from `echo -n "Hello"` should contain exactly "Hello"
 Then /^the output(?: from "(.*?)")? should contain exactly "(.*?)"$/ do |cmd, expected|
-  assert_exact_output(expected, cmd ? output_from(cmd) : all_output)
+  aruba_scope do
+    assert_exact_output(expected, cmd ? output_from(cmd) : all_output)
+  end
 end
 
 ## the output should contain exactly:
 ## the output from `echo -n "Hello"` should contain exactly:
 Then /^the output(?: from "(.*?)")? should contain exactly:$/ do |cmd, expected|
-  assert_exact_output(expected, cmd ? output_from(cmd) : all_output)
+  aruba_scope do
+    assert_exact_output(expected, cmd ? output_from(cmd) : all_output)
+  end
 end
 
 # "the output should match" allows regex in the partial_output, if
@@ -212,45 +297,65 @@ end
 # that way, you don't have to escape regex characters that
 # appear naturally in the output
 Then /^the output should match \/([^\/]*)\/$/ do |expected|
-  assert_matching_output(expected, all_output)
+  aruba_scope do
+    assert_matching_output(expected, all_output)
+  end
 end
 
 Then /^the output should match %r<([^>]*)>$/ do |expected|
-  assert_matching_output(expected, all_output)
+  aruba_scope do
+    assert_matching_output(expected, all_output)
+  end
 end
 
 Then /^the output should match:$/ do |expected|
-  assert_matching_output(expected, all_output)
+  aruba_scope do
+    assert_matching_output(expected, all_output)
+  end
 end
 
 # The previous two steps antagonists
 Then /^the output should not match \/([^\/]*)\/$/ do |expected|
-  assert_not_matching_output(expected, all_output)
+  aruba_scope do
+    assert_not_matching_output(expected, all_output)
+  end
 end
 
 Then /^the output should not match:$/ do |expected|
-  assert_not_matching_output(expected, all_output)
+  aruba_scope do
+    assert_not_matching_output(expected, all_output)
+  end
 end
 
 Then /^the exit status should be (\d+)$/ do |exit_status|
-  assert_exit_status(exit_status.to_i)
+  aruba_scope do
+    assert_exit_status(exit_status.to_i)
+  end
 end
 
 Then /^the exit status should not be (\d+)$/ do |exit_status|
-  assert_not_exit_status(exit_status.to_i)
+  aruba_scope do
+    assert_not_exit_status(exit_status.to_i)
+  end
 end
 
 Then /^it should (pass|fail) with:$/ do |pass_fail, partial_output|
-  self.__send__("assert_#{pass_fail}ing_with", partial_output)
+  aruba_scope do
+    self.__send__("assert_#{pass_fail}ing_with", partial_output)
+  end
 end
 
 Then /^it should (pass|fail) with exactly:$/ do |pass_fail, exact_output|
-  assert_exit_status_and_output(pass_fail == "pass", exact_output, true)
+  aruba_scope do
+    assert_exit_status_and_output(pass_fail == "pass", exact_output, true)
+  end
 end
 
 Then /^it should (pass|fail) with regexp?:$/ do |pass_fail, expected|
-  assert_matching_output(expected, all_output)
-  assert_success(pass_fail == 'pass')
+  aruba_scope do
+    assert_matching_output(expected, all_output)
+    assert_success(pass_fail == 'pass')
+  end
 end
 
 ## the stderr should contain "hello"
@@ -258,10 +363,12 @@ end
 ## the stderr should contain exactly:
 ## the stderr from "echo -n 'Hello'" should contain exactly:
 Then /^the stderr(?: from "(.*?)")? should contain( exactly)? "(.*?)"$/ do |cmd, exact, expected|
-  if exact
-    assert_exact_output(expected, cmd ? stderr_from(cmd) : all_stderr)
-  else
-    assert_partial_output(expected, cmd ? stderr_from(cmd) : all_stderr)
+  aruba_scope do
+    if exact
+      assert_exact_output(expected, cmd ? stderr_from(cmd) : all_stderr)
+    else
+      assert_partial_output(expected, cmd ? stderr_from(cmd) : all_stderr)
+    end
   end
 end
 
@@ -270,10 +377,12 @@ end
 ## the stderr should contain exactly:
 ## the stderr from "echo -n 'Hello'" should contain exactly:
 Then /^the stderr(?: from "(.*?)")? should contain( exactly)?:$/ do |cmd, exact, expected|
-  if exact
-    assert_exact_output(expected, cmd ? stderr_from(cmd) : all_stderr)
-  else
-    assert_partial_output(expected, cmd ? stderr_from(cmd) : all_stderr)
+  aruba_scope do
+    if exact
+      assert_exact_output(expected, cmd ? stderr_from(cmd) : all_stderr)
+    else
+      assert_partial_output(expected, cmd ? stderr_from(cmd) : all_stderr)
+    end
   end
 end
 
@@ -282,10 +391,12 @@ end
 ## the stdout should contain exactly:
 ## the stdout from "echo -n 'Hello'" should contain exactly:
 Then /^the stdout(?: from "(.*?)")? should contain( exactly)? "(.*?)"$/ do |cmd, exact, expected|
-  if exact
-    assert_exact_output(expected, cmd ? stdout_from(cmd) : all_stdout)
-  else
-    assert_partial_output(expected, cmd ? stdout_from(cmd) : all_stdout)
+  aruba_scope do
+    if exact
+      assert_exact_output(expected, cmd ? stdout_from(cmd) : all_stdout)
+    else
+      assert_partial_output(expected, cmd ? stdout_from(cmd) : all_stdout)
+    end
   end
 end
 
@@ -294,146 +405,188 @@ end
 ## the stdout should contain exactly:
 ## the stdout from "echo -n 'Hello'" should contain exactly:
 Then /^the stdout(?: from "(.*?)")? should contain( exactly)?:$/ do |cmd, exact, expected|
-  if exact
-    assert_exact_output(expected, cmd ? stdout_from(cmd) : all_stdout)
-  else
-    assert_partial_output(expected, cmd ? stdout_from(cmd) : all_stdout)
+  aruba_scope do
+    if exact
+      assert_exact_output(expected, cmd ? stdout_from(cmd) : all_stdout)
+    else
+      assert_partial_output(expected, cmd ? stdout_from(cmd) : all_stdout)
+    end
   end
 end
 
 Then /^the stderr should not contain "([^"]*)"$/ do |unexpected|
-  assert_no_partial_output(unexpected, all_stderr)
+  aruba_scope do
+    assert_no_partial_output(unexpected, all_stderr)
+  end
 end
 
 Then /^the stderr should not contain:$/ do |unexpected|
-  assert_no_partial_output(unexpected, all_stderr)
+  aruba_scope do
+    assert_no_partial_output(unexpected, all_stderr)
+  end
 end
 
 Then /^the (stderr|stdout) should not contain anything$/ do |stream_name|
-  stream = self.send("all_#{stream_name}")
-  expect(stream).to be_empty
+  aruba_scope do
+    stream = self.send("all_#{stream_name}")
+    expect(stream).to be_empty
+  end
 end
 
 Then /^the stdout should not contain "([^"]*)"$/ do |unexpected|
-  assert_no_partial_output(unexpected, all_stdout)
+  aruba_scope do
+    assert_no_partial_output(unexpected, all_stdout)
+  end
 end
 
 Then /^the stdout should not contain:$/ do |unexpected|
-  assert_no_partial_output(unexpected, all_stdout)
+  aruba_scope do
+    assert_no_partial_output(unexpected, all_stdout)
+  end
 end
 
 Then /^the stdout from "([^"]*)" should not contain "([^"]*)"$/ do |cmd, unexpected|
-  assert_no_partial_output(unexpected, stdout_from(cmd))
+  aruba_scope do
+    assert_no_partial_output(unexpected, stdout_from(cmd))
+  end
 end
 
 Then /^the stderr from "([^"]*)" should not contain "([^"]*)"$/ do |cmd, unexpected|
-  assert_no_partial_output(unexpected, stderr_from(cmd))
+  aruba_scope do
+    assert_no_partial_output(unexpected, stderr_from(cmd))
+  end
 end
 
 Then /^the following files should (not )?exist:$/ do |negated, files|
   files = files.rows.flatten
 
-  if negated
-    expect(files).not_to include an_existing_file
-  else
-    expect(files).to all be_an_existing_file
+  aruba_scope do
+    if negated
+      expect(files).not_to include an_existing_file
+    else
+      expect(files).to all be_an_existing_file
+    end
   end
 end
 
 Then /^(?:a|the) file(?: named)? "([^"]*)" should (not )?exist$/ do |file, expect_match|
-  if expect_match
-    expect(file).not_to be_an_existing_file
-  else
-    expect(file).to be_an_existing_file
+  aruba_scope do
+    if expect_match
+      expect(file).not_to be_an_existing_file
+    else
+      expect(file).to be_an_existing_file
+    end
   end
 end
 
 Then /^(?:a|the) file matching %r<(.*?)> should (not )?exist$/ do |pattern, expect_match|
-  if expect_match
-    expect(all_paths).not_to include match Regexp.new(pattern)
-  else
-    expect(all_paths).to include match Regexp.new(pattern)
+  aruba_scope do
+    if expect_match
+      expect(all_paths).not_to include match Regexp.new(pattern)
+    else
+      expect(all_paths).to include match Regexp.new(pattern)
+    end
   end
 end
 
 Then /^(?:a|the) (\d+) byte file(?: named)? "([^"]*)" should (not )?exist$/ do |size, file, negated|
-  if negated
-    expect(file).not_to have_file_size(size)
-  else
-    expect(file).to have_file_size(size)
+  aruba_scope do
+    if negated
+      expect(file).not_to have_file_size(size)
+    else
+      expect(file).to have_file_size(size)
+    end
   end
 end
 
 Then /^the following directories should (not )?exist:$/ do |negated, directories|
   directories = directories.rows.flatten
 
-  if negated
-    expect(directories).not_to include an_existing_directory
-  else
-    expect(directories).to all be_an_existing_directory
+  aruba_scope do
+    if negated
+      expect(directories).not_to include an_existing_directory
+    else
+      expect(directories).to all be_an_existing_directory
+    end
   end
 end
 
 Then /^(?:a|the) directory(?: named)? "([^"]*)" should (not )?exist$/ do |directory, negated|
-  if negated
-    expect(directory).not_to be_an_existing_directory
-  else
-    expect(directory).to be_an_existing_directory
+  aruba_scope do
+    if negated
+      expect(directory).not_to be_an_existing_directory
+    else
+      expect(directory).to be_an_existing_directory
+    end
   end
 end
 
 Then /^(?:a|the) file "([^"]*)" should (not )?contain "([^"]*)"$/ do |file, negated, content|
-  if negated
-    expect(file).not_to have_file_content Regexp.new(Regexp.escape(content))
-  else
-    expect(file).to have_file_content Regexp.new(Regexp.escape(content))
+  aruba_scope do
+    if negated
+      expect(file).not_to have_file_content Regexp.new(Regexp.escape(content))
+    else
+      expect(file).to have_file_content Regexp.new(Regexp.escape(content))
+    end
   end
 end
 
 Then /^(?:a|the) file "([^"]*)" should (not )?contain:$/ do |file, negated, content|
-  if negated
-    expect(file).not_to have_file_content Regexp.new(Regexp.escape(content.chomp))
-  else
-    expect(file).to have_file_content Regexp.new(Regexp.escape(content.chomp))
+  aruba_scope do
+    if negated
+      expect(file).not_to have_file_content Regexp.new(Regexp.escape(content.chomp))
+    else
+      expect(file).to have_file_content Regexp.new(Regexp.escape(content.chomp))
+    end
   end
 end
 
 Then /^(?:a|the) file "([^"]*)" should (not )?contain exactly:$/ do |file, negated, content|
-  if negated
-    expect(file).not_to have_file_content content
-  else
-    expect(file).to have_file_content content
+  aruba_scope do
+    if negated
+      expect(file).not_to have_file_content content
+    else
+      expect(file).to have_file_content content
+    end
   end
 end
 
 Then /^(?:a|the) file "([^"]*)" should (not )?match %r<([^\/]*)>$/ do |file, negated, content|
-  if negated
-    expect(file).not_to have_file_content Regexp.new(content)
-  else
-    expect(file).to have_file_content Regexp.new(content)
+  aruba_scope do
+    if negated
+      expect(file).not_to have_file_content Regexp.new(content)
+    else
+      expect(file).to have_file_content Regexp.new(content)
+    end
   end
 end
 
 Then /^(?:a|the) file "([^"]*)" should (not )?match \/([^\/]*)\/$/ do |file, negated, content|
-  if negated
-    expect(file).not_to have_file_content Regexp.new(content)
-  else
-    expect(file).to have_file_content Regexp.new(content)
+  aruba_scope do
+    if negated
+      expect(file).not_to have_file_content Regexp.new(content)
+    else
+      expect(file).to have_file_content Regexp.new(content)
+    end
   end
 end
 
 Then /^(?:a|the) file "([^"]*)" should (not )?be equal to file "([^"]*)"/ do |file, negated, reference_file|
-  if negated
-    expect(file).not_to have_same_file_content_like(reference_file)
-  else
-    expect(file).to have_same_file_content_like(reference_file)
+  aruba_scope do
+    if negated
+      expect(file).not_to have_same_file_content_like(reference_file)
+    else
+      expect(file).to have_same_file_content_like(reference_file)
+    end
   end
 end
 
 Then /^the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)"$/ do |file, negated, permissions|
-  if negated
-    expect(file).not_to have_permissions(permissions)
-  else
-    expect(file).to have_permissions(permissions)
+  aruba_scope do
+    if negated
+      expect(file).not_to have_permissions(permissions)
+    else
+      expect(file).to have_permissions(permissions)
+    end
   end
 end

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -148,7 +148,17 @@ end
 # end
 
 Before('@ansi') do
-  @aruba_keep_ansi = true
+  aruba_scope do
+    if defined? @aruba_keep_ansi
+      # rubocop:disable Metrics/LineLength
+      Aruba::Platform.deprecated('The use of "@aruba_keep_ansi" is deprecated. Use "Aruba.configure do |config| config.keep_ansi = true" or "aruba.config.keep_ansi" instead')
+      # rubocop:enable Metrics/LineLength
+
+      aruba.config.keep_ansi = true
+    else
+      aruba.config.keep_ansi = false
+    end
+  end
 end
 
 Before '@mocked_home_directory' do

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -20,93 +20,127 @@ if Aruba::VERSION >= '1.0.0'
 end
 
 Before do
-  # this is ENV by default ...
-  aruba.environment.update aruba.config.command_runtime_environment
+  aruba_scope do
+    # this is ENV by default ...
+    aruba.environment.update aruba.config.command_runtime_environment
 
-  # ... so every change needs to be done later
-  prepend_environment_variable 'PATH', aruba.config.command_search_paths.join(':') + ':'
-  set_environment_variable 'HOME', aruba.config.home_directory
+    # ... so every change needs to be done later
+    prepend_environment_variable 'PATH', aruba.config.command_search_paths.join(':') + ':'
+    set_environment_variable 'HOME', aruba.config.home_directory
+  end
 end
 
 After do
-  restore_env
-  process_monitor.stop_processes!
-  process_monitor.clear
+  aruba_scope do
+    restore_env
+    process_monitor.stop_processes!
+    process_monitor.clear
+  end
 end
 
 Before('~@no-clobber') do
-  setup_aruba
+  aruba_scope do
+    setup_aruba
+  end
 end
 
 Before('@puts') do
-  announcer.mode = :puts
+  aruba_scope do
+    announcer.mode = :puts
+  end
 end
 
 Before('@announce-command') do
-  announcer.activate :command
+  aruba_scope do
+    announcer.activate :command
+  end
 end
 
 Before('@announce-cmd') do
   Aruba::Platform.deprecated 'The use of "@announce-cmd"-hook is deprecated. Please use "@announce-command"'
 
-  announcer.activate :command
+  aruba_scope do
+    announcer.activate :command
+  end
 end
 
 Before('@announce-stdout') do
-  announcer.activate :stdout
+  aruba_scope do
+    announcer.activate :stdout
+  end
 end
 
 Before('@announce-stderr') do
-  announcer.activate :stderr
+  aruba_scope do
+    announcer.activate :stderr
+  end
 end
 
 Before('@announce-dir') do
   Aruba::Platform.deprecated 'The use of "@announce-dir"-hook is deprecated. Please use "@announce-directory"'
 
-  announcer.activate :directory
+  aruba_scope do
+    announcer.activate :directory
+  end
 end
 
 Before('@announce-directory') do
-  announcer.activate :directory
+  aruba_scope do
+    announcer.activate :directory
+  end
 end
 
 Before('@announce-env') do
   Aruba::Platform.deprecated 'The use of "@announce-env"-hook is deprecated. Please use "@announce-modified-environment"'
 
-  announcer.activate :environment
+  aruba_scope do
+    announcer.activate :environment
+  end
 end
 
 Before('@announce-environment') do
   Aruba::Platform.deprecated '@announce-environment is deprecated. Use @announce-modified-environment instead'
 
-  announcer.activate :modified_environment
+  aruba_scope do
+    announcer.activate :modified_environment
+  end
 end
 
 Before('@announce-full-environment') do
-  announcer.activate :full_environment
+  aruba_scope do
+    announcer.activate :full_environment
+  end
 end
 
 Before('@announce-modified-environment') do
-  announcer.activate :modified_environment
+  aruba_scope do
+    announcer.activate :modified_environment
+  end
 end
 
 Before('@announce-timeout') do
-  announcer.activate :timeout
+  aruba_scope do
+    announcer.activate :timeout
+  end
 end
 
 Before('@announce') do
-  announcer.activate :command
-  announcer.activate :stdout
-  announcer.activate :stderr
-  announcer.activate :directory
-  announcer.activate :modified_environment
-  announcer.activate :full_environment
-  announcer.activate :environment
-  announcer.activate :timeout
+  aruba_scope do
+    announcer.activate :command
+    announcer.activate :stdout
+    announcer.activate :stderr
+    announcer.activate :directory
+    announcer.activate :modified_environment
+    announcer.activate :full_environment
+    announcer.activate :environment
+    announcer.activate :timeout
+  end
 end
 
 Before('@debug') do
-  aruba.config.command_launcher = :debug
+  aruba_scope do
+    aruba.config.command_launcher = :debug
+  end
 end
 
 # After('@debug') do
@@ -120,13 +154,19 @@ end
 Before '@mocked_home_directory' do
   Aruba::Platform.deprecated('The use of "@mocked_home_directory" is deprecated. Use "@mocked-home-directory" instead')
 
-  set_environment_variable 'HOME', expand_path('.')
+  aruba_scope do
+    set_environment_variable 'HOME', expand_path('.')
+  end
 end
 
 Before '@mocked-home-directory' do
-  set_environment_variable 'HOME', expand_path('.')
+  aruba_scope do
+    set_environment_variable 'HOME', expand_path('.')
+  end
 end
 
 Before('@disable-bundler') do
-  unset_bundler_env_vars
+  aruba_scope do
+    unset_bundler_env_vars
+  end
 end

--- a/lib/aruba/scope.rb
+++ b/lib/aruba/scope.rb
@@ -1,0 +1,25 @@
+require 'rspec/expectations'
+require 'aruba/api'
+require 'thread'
+
+module Aruba
+  module Scope
+    class LocalScope
+      include RSpec::Matchers
+      include Aruba::Api
+    end
+  end
+end
+
+module Aruba
+  module Scope
+    SCOPE_SEMAPHONE = Mutex.new
+
+    def aruba_scope(&block)
+      SCOPE_SEMAPHONE.synchronize do
+        @scope ||= LocalScope.new
+        @scope.instance_eval(&block) if block_given?
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first try to fix the problem with concurrent implementations of methods within `cucumber`. 

Known conflicts:
* all, within: `rspec`, `capybara` (jnicklas/capybara#1396, jnicklas/capybara#1547, jnicklas/capybara#1526)

Unfortunately this will break the existing API if someone wrote custom steps using the aruba-API. Now they also need to wrap their code within `aruba_scope {}`.

Outstanding: Real World Test with `middleman` (middleman/middleman#1562) if this really works.

This PR also includes some fixes, we need to merge separately if this PR does not solve the problem at all and is therefor dropped.