### PR TITLE
Introducing the Ports & Adapters to `aruba`'s codebase

### DIFF
--- a/features/step_definitions/aruba_dev_steps.rb
+++ b/features/step_definitions/aruba_dev_steps.rb
@@ -18,7 +18,7 @@ When /^I set env variable "(\w+)" to "([^"]*)"$/ do |var, value|
 end
 
 Then /^aruba should fail with "([^"]*)"$/ do |error_message|
-  expect(@aruba_exception.message).to include(Aruba::Platform.unescape(error_message))
+  expect(@aruba_exception.message).to include(Aruba.platform.unescape(error_message))
 end
 
 Then /^the following step should fail with Spec::Expectations::ExpectationNotMetError:$/ do |multiline_step|

--- a/lib/aruba/announcer.rb
+++ b/lib/aruba/announcer.rb
@@ -80,7 +80,7 @@ module Aruba
       output_format :command, '$ %s'
       output_format :environment, '$ export %s=%s"'
       output_format :modified_environment, '$ export %s=%s"'
-      output_format :full_environment, proc { |h| Aruba::Platform.simple_table(h) }
+      output_format :full_environment, proc { |h| Aruba.platform.simple_table(h) }
       output_format :timeout, '# %s-timeout: %s seconds'
 
       # rubocop:disable Metrics/LineLength

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -16,7 +16,7 @@ require 'aruba/api/environment'
 require 'aruba/api/filesystem'
 require 'aruba/api/rvm'
 
-Aruba::Platform.require_matching_files('../matchers/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../matchers/**/*.rb', __FILE__)
 
 module Aruba
   module Api

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -32,7 +32,7 @@ module Aruba
           # ENV is set within this block
           path = ENV['PATH'] if path.nil?
 
-          Aruba::Platform.which(program, path)
+          Aruba.platform.which(program, path)
         end
       end
 
@@ -102,7 +102,7 @@ module Aruba
       #   If arg1 is exactly the same as arg2 return true, otherwise false
       def assert_exact_output(expected, actual)
         actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-        expect(Aruba::Platform.unescape(actual, aruba.config.keep_ansi)).to eq Aruba::Platform.unescape(expected, aruba.config.keep_ansi)
+        expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).to eq Aruba.platform.unescape(expected, aruba.config.keep_ansi)
       end
 
       # Partial compare arg1 and arg2
@@ -111,7 +111,7 @@ module Aruba
       #   If arg2 contains arg1 return true, otherwise false
       def assert_partial_output(expected, actual)
         actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-        expect(Aruba::Platform.unescape(actual, aruba.config.keep_ansi)).to include(Aruba::Platform.unescape(expected, aruba.config.keep_ansi))
+        expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).to include(Aruba.platform.unescape(expected, aruba.config.keep_ansi))
       end
 
       # Regex Compare arg1 and arg2
@@ -120,7 +120,7 @@ module Aruba
       #   If arg2 matches arg1 return true, otherwise false
       def assert_matching_output(expected, actual)
         actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-        expect(Aruba::Platform.unescape(actual, aruba.config.keep_ansi)).to match(/#{Aruba::Platform.unescape(expected, aruba.config.keep_ansi)}/m)
+        expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).to match(/#{Aruba.platform.unescape(expected, aruba.config.keep_ansi)}/m)
       end
 
       # Negative regex compare arg1 and arg2
@@ -129,7 +129,7 @@ module Aruba
       #   If arg2 does not match arg1 return true, otherwise false
       def assert_not_matching_output(expected, actual)
         actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
-        expect(Aruba::Platform.unescape(actual, aruba.config.keep_ansi)).not_to match(/#{Aruba::Platform.unescape(expected, aruba.config.keep_ansi)}/m)
+        expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).not_to match(/#{Aruba.platform.unescape(expected, aruba.config.keep_ansi)}/m)
       end
 
       # Negative partial compare arg1 and arg2
@@ -139,9 +139,9 @@ module Aruba
       def assert_no_partial_output(unexpected, actual)
         actual.force_encoding(unexpected.encoding) if RUBY_VERSION >= "1.9"
         if Regexp === unexpected
-          expect(Aruba::Platform.unescape(actual, aruba.config.keep_ansi)).not_to match unexpected
+          expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).not_to match unexpected
         else
-          expect(Aruba::Platform.unescape(actual, aruba.config.keep_ansi)).not_to include(unexpected)
+          expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).not_to include(unexpected)
         end
       end
 
@@ -150,7 +150,7 @@ module Aruba
       # @return [TrueClass, FalseClass]
       #   If output of interactive command includes arg1 return true, otherwise false
       def assert_partial_output_interactive(expected)
-        Aruba::Platform.unescape(last_command.stdout, aruba.config.keep_ansi).include?(Aruba::Platform.unescape(expected, aruba.config.keep_ansi)) ? true : false
+        Aruba.platform.unescape(last_command.stdout, aruba.config.keep_ansi).include?(Aruba.platform.unescape(expected, aruba.config.keep_ansi)) ? true : false
       end
 
       # Check if command succeeded and if arg1 is included in output
@@ -255,7 +255,7 @@ module Aruba
         @commands ||= []
         @commands << cmd
 
-        cmd = Aruba::Platform.detect_ruby(cmd)
+        cmd = Aruba.platform.detect_ruby(cmd)
 
         announcer.announce(:directory, Dir.pwd)
         announcer.announce(:command, cmd)
@@ -264,7 +264,7 @@ module Aruba
 
         mode = if Aruba.process
                  # rubocop:disable Metrics/LineLength
-                 Aruba::Platform.deprecated('The use of "Aruba.process = <process>" and "Aruba.process.main_class" is deprecated. Use "Aruba.configure { |config| config.command_launcher = :in_process|:debug|:spawn }" and "Aruba.configure { |config| config.main_class = <klass> }" instead.')
+                 Aruba.platform.deprecated('The use of "Aruba.process = <process>" and "Aruba.process.main_class" is deprecated. Use "Aruba.configure { |config| config.command_launcher = :in_process|:debug|:spawn }" and "Aruba.configure { |config| config.main_class = <klass> }" instead.')
                  # rubocop:enable Metrics/LineLength
                  Aruba.process
                else
@@ -273,7 +273,7 @@ module Aruba
 
         main_class = if Aruba.process.respond_to?(:main_class) && Aruba.process.main_class
                        # rubocop:disable Metrics/LineLength
-                       Aruba::Platform.deprecated('The use of "Aruba.process = <process>" and "Aruba.process.main_class" is deprecated. Use "Aruba.configure { |config| config.command_launcher = :in_process|:debug|:spawn }" and "Aruba.configure { |config| config.main_class = <klass> }" instead.')
+                       Aruba.platform.deprecated('The use of "Aruba.process = <process>" and "Aruba.process.main_class" is deprecated. Use "Aruba.configure { |config| config.command_launcher = :in_process|:debug|:spawn }" and "Aruba.configure { |config| config.main_class = <klass> }" instead.')
                        # rubocop:enable Metrics/LineLength
                        Aruba.process.main_class
                      else
@@ -291,7 +291,7 @@ module Aruba
 
         if aruba.config.before? :cmd
           # rubocop:disable Metrics/LineLength
-          Aruba::Platform.deprecated('The use of "before"-hook" ":cmd" is deprecated. Use ":command" instead. Please be aware that this hook gets the command passed in not the cmdline itself. To get the commandline use "#cmd.commandline"')
+          Aruba.platform.deprecated('The use of "before"-hook" ":cmd" is deprecated. Use ":command" instead. Please be aware that this hook gets the command passed in not the cmdline itself. To get the commandline use "#cmd.commandline"')
           # rubocop:enable Metrics/LineLength
           aruba.config.before(:cmd, self, cmd)
         end

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -25,9 +25,9 @@ module Aruba
       # artifacts of your tests. This does NOT clean up the current working
       # directory.
       def setup_aruba
-        Aruba::Platform.rm File.join(Aruba.config.root_directory, Aruba.config.working_directory), :force => true
-        Aruba::Platform.mkdir File.join(Aruba.config.root_directory, Aruba.config.working_directory)
-        Aruba::Platform.chdir Aruba.config.root_directory
+        Aruba.platform.rm File.join(Aruba.config.root_directory, Aruba.config.working_directory), :force => true
+        Aruba.platform.mkdir File.join(Aruba.config.root_directory, Aruba.config.working_directory)
+        Aruba.platform.chdir Aruba.config.root_directory
 
         self
       end
@@ -50,23 +50,23 @@ module Aruba
       def cd(dir, &block)
         if block_given?
           begin
-            fail ArgumentError, "#{expand_path(dir)} is not a directory or does not exist." unless Aruba::Platform.directory? expand_path(dir)
+            fail ArgumentError, "#{expand_path(dir)} is not a directory or does not exist." unless Aruba.platform.directory? expand_path(dir)
 
             aruba.current_directory << dir
 
-            old_dir    = Aruba::Platform.getwd
+            old_dir    = Aruba.platform.getwd
             old_oldpwd = ENV['OLDPWD']
             old_pwd    = ENV['PWD']
 
-            ENV['OLDPWD'] = Aruba::Platform.getwd
+            ENV['OLDPWD'] = Aruba.platform.getwd
             ENV['PWD'] = File.join(aruba.root_directory, aruba.current_directory).sub(%r{/$}, '')
 
-            Aruba::Platform.chdir File.join(aruba.root_directory, aruba.current_directory)
+            Aruba.platform.chdir File.join(aruba.root_directory, aruba.current_directory)
 
             result = block.call
           ensure
             aruba.current_directory.pop
-            Aruba::Platform.chdir old_dir
+            Aruba.platform.chdir old_dir
             ENV['OLDPWD'] = old_oldpwd
             ENV['PWD']    = old_pwd
           end
@@ -74,7 +74,7 @@ module Aruba
           return result
         end
 
-        fail ArgumentError, "#{expand_path(dir)} is not a directory or does not exist." unless Aruba::Platform.directory? expand_path(dir)
+        fail ArgumentError, "#{expand_path(dir)} is not a directory or does not exist." unless Aruba.platform.directory? expand_path(dir)
 
         aruba.current_directory << dir
 
@@ -123,7 +123,7 @@ module Aruba
         fail ArgumentError, message unless file_name.is_a?(String) && !file_name.empty?
 
         # rubocop:disable Metrics/LineLength
-        aruba.logger.warn %(`aruba`'s working directory does not exist. Maybe you forgot to run `setup_aruba` before using it's API. This warning will be an error from 1.0.0) unless Aruba::Platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
+        aruba.logger.warn %(`aruba`'s working directory does not exist. Maybe you forgot to run `setup_aruba` before using it's API. This warning will be an error from 1.0.0) unless Aruba.platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
         # rubocop:enable Metrics/LineLength
 
         if RUBY_VERSION < '1.9'

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -8,8 +8,8 @@ module Aruba
       # @return [Array]
       #   The directory path: Each subdirectory is a member of an array
       def dirs
-        Aruba::Platform.deprecated('The use of "@dirs" is deprecated. Use "Aruba.configure { |c| c.current_directory = \'path/to/dir\' }" instead to set the "current_directory') if defined? @dirs
-        Aruba::Platform.deprecated('The use of "dirs" deprecated. Use "Aruba.configure { |c| c.current_directory = \'path/to/dir\' }" instead to set the "current_directory and "expand_path(".")" to get the current directory or use "#cd(\'.\') { # your code }" to run code in the current directory')
+        Aruba.platform.deprecated('The use of "@dirs" is deprecated. Use "Aruba.configure { |c| c.current_directory = \'path/to/dir\' }" instead to set the "current_directory') if defined? @dirs
+        Aruba.platform.deprecated('The use of "dirs" deprecated. Use "Aruba.configure { |c| c.current_directory = \'path/to/dir\' }" instead to set the "current_directory and "expand_path(".")" to get the current directory or use "#cd(\'.\') { # your code }" to run code in the current directory')
 
         @dirs ||= aruba.current_directory
       end
@@ -20,7 +20,7 @@ module Aruba
       # @return
       #   Current directory
       def current_directory
-        Aruba::Platform.deprecated(%(The use of "current_directory" deprecated. Use "expand_path(".")" to get the current directory or "#cd" to run code in the current directory. #{caller.first}))
+        Aruba.platform.deprecated(%(The use of "current_directory" deprecated. Use "expand_path(".")" to get the current directory or "#cd" to run code in the current directory. #{caller.first}))
 
         aruba.current_directory.to_s
       end
@@ -28,7 +28,7 @@ module Aruba
       # @deprecated
       # Clean the current directory
       def clean_current_directory
-        Aruba::Platform.deprecated('The use of "clean_current_directory" is deprecated. Either use "#setup_aruba" or `#remove(\'.\') to clean up aruba\'s working directory before your tests are run')
+        Aruba.platform.deprecated('The use of "clean_current_directory" is deprecated. Either use "#setup_aruba" or `#remove(\'.\') to clean up aruba\'s working directory before your tests are run')
 
         setup_aruba
       end
@@ -39,7 +39,7 @@ module Aruba
       # @yield
       #   The block which should be run in current directory
       def in_current_directory(&block)
-        Aruba::Platform.deprecated('The use of "in_current_directory" deprecated. Use "#cd(\'.\') { # your code }" instead. But be aware, `cd` requires a previously created directory')
+        Aruba.platform.deprecated('The use of "in_current_directory" deprecated. Use "#cd(\'.\') { # your code }" instead. But be aware, `cd` requires a previously created directory')
 
         create_directory '.' unless directory?('.')
         cd('.', &block)
@@ -47,42 +47,42 @@ module Aruba
 
       # @deprecated
       def detect_ruby(cmd)
-        Aruba::Platform.deprecated('The use of "#detect_ruby" is deprecated. Use "Aruba::Platform.detect_ruby" instead')
+        Aruba.platform.deprecated('The use of "#detect_ruby" is deprecated. Use "Aruba.platform.detect_ruby" instead')
 
-        Aruba::Platform.detect_ruby cmd
+        Aruba.platform.detect_ruby cmd
       end
 
       # @deprecated
       def current_ruby
-        Aruba::Platform.deprecated('The use of "#current_ruby" is deprecated. Use "Aruba::Platform.current_ruby" instead')
+        Aruba.platform.deprecated('The use of "#current_ruby" is deprecated. Use "Aruba.platform.current_ruby" instead')
 
-        Aruba::Platform.current_ruby cmd
+        Aruba.platform.current_ruby cmd
       end
 
       # @deprecated
       def _ensure_newline(str)
-        Aruba::Platform.deprecated('The use of "#_ensure_newline" is deprecated. Use "Aruba::Platform.ensure_newline" instead')
+        Aruba.platform.deprecated('The use of "#_ensure_newline" is deprecated. Use "Aruba.platform.ensure_newline" instead')
 
-        Aruba::Platform.ensure_newline cmd
+        Aruba.platform.ensure_newline cmd
       end
 
       # @deprecated
       def absolute_path(*args)
-        Aruba::Platform.deprecated('The use of "absolute_path" is deprecated. Use "expand_path" instead. But be aware that "expand_path" uses a different implementation')
+        Aruba.platform.deprecated('The use of "absolute_path" is deprecated. Use "expand_path" instead. But be aware that "expand_path" uses a different implementation')
 
         File.expand_path File.join(*args), aruba.current_directory
       end
 
       # @deprecated
       def _read_interactive
-        Aruba::Platform.deprecated('The use of "#_read_interactive" is deprecated. Please use "last_command.stdout" instead')
+        Aruba.platform.deprecated('The use of "#_read_interactive" is deprecated. Please use "last_command.stdout" instead')
 
         last_command.stdout
       end
 
       # @deprecated
       def announce_or_puts(msg)
-        Aruba::Platform.deprecated('The use of "#announce_or_puts" is deprecated. Please use "#announcer.mode = :kernel" or "#announcer.mode = :puts" instead')
+        Aruba.platform.deprecated('The use of "#announce_or_puts" is deprecated. Please use "#announcer.mode = :kernel" or "#announcer.mode = :puts" instead')
 
         if(@puts)
           Kernel.puts(msg)
@@ -93,14 +93,14 @@ module Aruba
 
       # @deprecated
       def _write_interactive(input)
-        Aruba::Platform.deprecated('The use of "#_write_interactive" is deprecated. Please use "#last_command.write()" instead')
+        Aruba.platform.deprecated('The use of "#_write_interactive" is deprecated. Please use "#last_command.write()" instead')
 
         last_command.write(input)
       end
 
       # @deprecated
       def eot
-        Aruba::Platform.deprecated(%{\e[35m    The \"#eot\"-method is deprecated. It will be deleted with the next major version. Please use \"#close_input\"-method instead.\e[0m})
+        Aruba.platform.deprecated(%{\e[35m    The \"#eot\"-method is deprecated. It will be deleted with the next major version. Please use \"#close_input\"-method instead.\e[0m})
 
         close_input
       end
@@ -113,7 +113,7 @@ module Aruba
       # @see #cmd
       # @deprectated
       def run_interactive(cmd)
-        Aruba::Platform.deprecated('The use of "#run_interactive" is deprecated. You can simply use "run" instead')
+        Aruba.platform.deprecated('The use of "#run_interactive" is deprecated. You can simply use "run" instead')
 
         run(cmd)
       end
@@ -124,14 +124,14 @@ module Aruba
       # @param [String] file_name
       #   The name of the file
       def touch_file(*args)
-        Aruba::Platform.deprecated('The use of "#touch_file" is deprecated. Use "#touch" instead')
+        Aruba.platform.deprecated('The use of "#touch_file" is deprecated. Use "#touch" instead')
 
         touch(*args)
       end
 
       # @deprecated
       def mod?(file, perms, &block)
-        Aruba::Platform.deprecated('The use of "#mod?" is deprecated. Use "expect().to have_permissions()" instead')
+        Aruba.platform.deprecated('The use of "#mod?" is deprecated. Use "expect().to have_permissions()" instead')
 
         expect(Array(file)).to all have_permissions(perms)
       end
@@ -142,14 +142,14 @@ module Aruba
       # @param [String] file_name
       #    The file which should be deleted in current directory
       def remove_file(*args)
-        Aruba::Platform.deprecated('The use of "#remove_file" is deprecated. Use "#remove" instead')
+        Aruba.platform.deprecated('The use of "#remove_file" is deprecated. Use "#remove" instead')
 
         remove(*args)
       end
 
       # @deprecated
       def create_dir(*args)
-        Aruba::Platform.deprecated('The use of "#create_dir" is deprecated. Use "#create_directory" instead')
+        Aruba.platform.deprecated('The use of "#create_dir" is deprecated. Use "#create_directory" instead')
         create_directory(*args)
       end
 
@@ -159,13 +159,13 @@ module Aruba
       # @param [String] directory_name
       #   The name of the directory which should be removed
       def remove_directory(*args)
-        Aruba::Platform.deprecated('The use of "remove_directory" is deprecated. Use "remove" instead')
+        Aruba.platform.deprecated('The use of "remove_directory" is deprecated. Use "remove" instead')
         remove(*args)
       end
 
       # @deprecated
       def remove_dir(*args)
-        Aruba::Platform.deprecated('The use of "remove_dir" is deprecated. Use "remove" instead')
+        Aruba.platform.deprecated('The use of "remove_dir" is deprecated. Use "remove" instead')
         remove(*args)
       end
 
@@ -179,7 +179,7 @@ module Aruba
       # @param [true,false] expect_presence
       #   Should the given paths be present (true) or absent (false)
       def check_file_presence(paths, expect_presence = true)
-        Aruba::Platform.deprecated('The use of "check_file_presence" is deprecated. Use "expect().to be_an_existing_file" or "expect(all_paths).to all match /pattern/" instead')
+        Aruba.platform.deprecated('The use of "check_file_presence" is deprecated. Use "expect().to be_an_existing_file" or "expect(all_paths).to all match /pattern/" instead')
 
         stop_processes!
 
@@ -215,7 +215,7 @@ module Aruba
       #   check_file_size(paths_and_sizes)
       #
       def check_file_size(paths_and_sizes)
-        Aruba::Platform.deprecated('The use of "#check_file_size" is deprecated. Use "expect(file).to have_file_size(size)", "expect(all_files).to all have_file_size(1)", "expect(all_files).to include a_file_with_size(1)" instead')
+        Aruba.platform.deprecated('The use of "#check_file_size" is deprecated. Use "expect(file).to have_file_size(size)", "expect(all_files).to all have_file_size(1)", "expect(all_files).to include a_file_with_size(1)" instead')
         stop_processes!
 
         paths_and_sizes.each do |path, size|
@@ -225,7 +225,7 @@ module Aruba
 
       # @deprecated
       def check_exact_file_content(file, exact_content, expect_match = true)
-        Aruba::Platform.deprecated('The use of "#check_exact_file_content" is deprecated. Use "expect(file).to have_file_content(content)" with a string')
+        Aruba.platform.deprecated('The use of "#check_exact_file_content" is deprecated. Use "expect(file).to have_file_content(content)" with a string')
 
         check_file_content(file, exact_content, expect_match)
       end
@@ -242,7 +242,7 @@ module Aruba
       # @param [true, false] expect_match
       #   Must the content be in the file or not
       def check_binary_file_content(file, reference_file, expect_match = true)
-        Aruba::Platform.deprecated('The use of "#check_binary_file_content" is deprecated. Use "expect(file).to have_same_file_content_like(file)"')
+        Aruba.platform.deprecated('The use of "#check_binary_file_content" is deprecated. Use "expect(file).to have_same_file_content_like(file)"')
 
         stop_processes!
 
@@ -262,7 +262,7 @@ module Aruba
       # @param [true, false] expect_presence
       #   Should the directory be there or should the directory not be there
       def check_directory_presence(paths, expect_presence)
-        Aruba::Platform.deprecated('The use of "#check_directory_presence" is deprecated. Use "expect(directory).to be_an_existing_directory"')
+        Aruba.platform.deprecated('The use of "#check_directory_presence" is deprecated. Use "expect(directory).to be_an_existing_directory"')
 
         stop_processes!
 
@@ -279,7 +279,7 @@ module Aruba
 
       # @deprecated
       def prep_for_fs_check(&block)
-        Aruba::Platform.deprecated('The use of "prep_for_fs_check" is deprecated. Use apropriate methods and the new rspec matchers instead')
+        Aruba.platform.deprecated('The use of "prep_for_fs_check" is deprecated. Use apropriate methods and the new rspec matchers instead')
 
         process_monitor.stop_processes!
         cd('') { block.call }
@@ -287,7 +287,7 @@ module Aruba
 
       # @deprecated
       def assert_exit_status_and_partial_output(expect_to_pass, expected)
-        Aruba::Platform.deprecated('The use of "assert_exit_status_and_partial_output" is deprecated. Use "#assert_access" and "#assert_partial_output" instead')
+        Aruba.platform.deprecated('The use of "assert_exit_status_and_partial_output" is deprecated. Use "#assert_access" and "#assert_partial_output" instead')
 
         assert_success(expect_to_pass)
         assert_partial_output(expected, all_output)
@@ -320,7 +320,7 @@ module Aruba
       # @param [true, false] expect_match
       #   Must the content be in the file or not
       def check_file_content(file, content, expect_match = true)
-        Aruba::Platform.deprecated('The use of "#check_file_content" is deprecated. Use "expect(file).to have_file_content(content)" instead. For eq match use string, for partial match use /regex/')
+        Aruba.platform.deprecated('The use of "#check_file_content" is deprecated. Use "expect(file).to have_file_content(content)" instead. For eq match use string, for partial match use /regex/')
 
         stop_processes!
 
@@ -333,35 +333,35 @@ module Aruba
 
       # @deprecated
       def _mkdir(dir_name)
-        Aruba::Platform.deprecated('The use of "#_mkdir" is deprecated')
+        Aruba.platform.deprecated('The use of "#_mkdir" is deprecated')
 
-        Aruba::Platform.mkdir(dir_name)
+        Aruba.platform.mkdir(dir_name)
       end
 
       # @deprecated
       def _rm(dir_name)
-        Aruba::Platform.deprecated('The use of "#_rm_rf" is deprecated')
+        Aruba.platform.deprecated('The use of "#_rm_rf" is deprecated')
 
-        Aruba::Platform.rm(dir_name)
+        Aruba.platform.rm(dir_name)
       end
 
       # @deprecated
       def current_dir(*args, &block)
-        Aruba::Platform.deprecated('The use of "#current_dir" is deprecated. Use "#current_directory" instead')
+        Aruba.platform.deprecated('The use of "#current_dir" is deprecated. Use "#current_directory" instead')
 
         current_directory(*args, &block)
       end
 
       # @deprecated
       def clean_current_dir(*args, &block)
-        Aruba::Platform.deprecated('The use of "clean_current_dir" is deprecated. Either use "#setup_aruba" or `#remove(\'.\') to clean up aruba\'s working directory before your tests are run')
+        Aruba.platform.deprecated('The use of "clean_current_dir" is deprecated. Either use "#setup_aruba" or `#remove(\'.\') to clean up aruba\'s working directory before your tests are run')
 
         setup_aruba
       end
 
       # @deprecated
       def in_current_dir(&block)
-        Aruba::Platform.deprecated('The use of "in_current_dir" is deprecated. Use "#cd(\'.\') { }" instead')
+        Aruba.platform.deprecated('The use of "in_current_dir" is deprecated. Use "#cd(\'.\') { }" instead')
 
         create_directory '.' unless directory?('.')
         cd('.', &block)
@@ -376,7 +376,7 @@ module Aruba
       # @yield
       #   The block of code which should be run with the modified environment variables
       def with_env(env = {}, &block)
-        Aruba::Platform.deprecated('The use of "#with_env" is deprecated. Use "#with_environment {}" instead. But be careful this uses a different implementation')
+        Aruba.platform.deprecated('The use of "#with_env" is deprecated. Use "#with_environment {}" instead. But be careful this uses a different implementation')
 
         env.each do |k,v|
           set_env k, v
@@ -389,7 +389,7 @@ module Aruba
       # Restore original process environment
       def restore_env
         # No output because we need to reset env on each scenario/spec run
-        # Aruba::Platform.deprecated('The use of "#restore_env" is deprecated. If you use "set_environment_variable" there\'s no need to restore the environment')
+        # Aruba.platform.deprecated('The use of "#restore_env" is deprecated. If you use "set_environment_variable" there\'s no need to restore the environment')
 
         original_env.each do |key, value|
           if value
@@ -409,7 +409,7 @@ module Aruba
       # @param [String] value
       #   The value of the environment variable. Needs to be a string.
       def set_env(key, value)
-        Aruba::Platform.deprecated('The use of "#set_env" is deprecated. Please use "set_environment_variable" instead. But be careful, this method uses a different kind of implementation')
+        Aruba.platform.deprecated('The use of "#set_env" is deprecated. Please use "set_environment_variable" instead. But be careful, this method uses a different kind of implementation')
 
         announcer.announce(:environment, key, value)
         original_env[key] = ENV.delete(key) unless original_env.key? key
@@ -418,14 +418,14 @@ module Aruba
 
       # @deprecated
       def original_env
-        # Aruba::Platform.deprecated('The use of "#original_env" is deprecated.')
+        # Aruba.platform.deprecated('The use of "#original_env" is deprecated.')
 
         @original_env ||= {}
       end
 
       # @deprecated
       def filesystem_permissions(*args)
-        Aruba::Platform.deprecated('The use of "#filesystem_permissions" is deprecated. Please use "#chmod" instead.')
+        Aruba.platform.deprecated('The use of "#filesystem_permissions" is deprecated. Please use "#chmod" instead.')
 
         chmod(*args)
       end
@@ -439,7 +439,7 @@ module Aruba
       # @param [Boolean] expected_result
       #   Are the permissions expected to be mode or are they expected not to be mode?
       def check_filesystem_permissions(*args)
-        Aruba::Platform.deprecated('The use of "#check_filesystem_permissions" is deprecated. Please use "expect().to have_permissions perms" instead.')
+        Aruba.platform.deprecated('The use of "#check_filesystem_permissions" is deprecated. Please use "expect().to have_permissions perms" instead.')
 
         args = args.flatten
 
@@ -459,7 +459,7 @@ module Aruba
 
       # @deprecated
       def _create_file(name, content, check_presence)
-        Aruba::Platform.deprecated('The use of "#_create_file" is deprecated. It will be removed soon.')
+        Aruba.platform.deprecated('The use of "#_create_file" is deprecated. It will be removed soon.')
 
         ArubaFileCreator.new.write(expand_path(name), content, check_presence)
 
@@ -468,7 +468,7 @@ module Aruba
 
       # @deprecated
       def _create_fixed_size_file(file_name, file_size, check_presence)
-        Aruba::Platform.deprecated('The use of "#_create_fixed_size_file" is deprecated. It will be removed soon.')
+        Aruba.platform.deprecated('The use of "#_create_fixed_size_file" is deprecated. It will be removed soon.')
 
         ArubaFixedSizeFileCreator.new.write(expand_path(name), size, check_presence)
 
@@ -484,15 +484,15 @@ module Aruba
       # @return
       #   The string stripped from escape sequences
       def unescape(string)
-        Aruba::Platform.deprecated('The use of "#unescape" is deprecated. Use "Aruba::Platform.unescape" instead')
+        Aruba.platform.deprecated('The use of "#unescape" is deprecated. Use "Aruba.platform.unescape" instead')
 
-        Aruba::Platform.unescape(string, aruba.config.keep_ansi)
+        Aruba.platform.unescape(string, aruba.config.keep_ansi)
       end
 
       # @deprecated
       # The root directory of aruba
       def root_directory
-        Aruba::Platform.deprecated('The use of "#root_directory" is deprecated. Use "aruba.root_directory" instead')
+        Aruba.platform.deprecated('The use of "#root_directory" is deprecated. Use "aruba.root_directory" instead')
 
         aruba.root_directory
       end
@@ -502,7 +502,7 @@ module Aruba
       # @return [String]
       #   The directory to where your fixtures are stored
       def fixtures_directory
-        Aruba::Platform.deprecated('The use of "#fixtures_directory" is deprecated. Use "aruba.fixtures_directory" instead')
+        Aruba.platform.deprecated('The use of "#fixtures_directory" is deprecated. Use "aruba.fixtures_directory" instead')
 
         aruba.fixtures_directory
       end
@@ -512,32 +512,32 @@ module Aruba
       # rubocop:disable Metrics/MethodLength
       def check_for_deprecated_variables
         if defined? @aruba_io_wait_seconds
-          Aruba::Platform.deprecated('The use of "@aruba_io_wait_seconds" is deprecated. Use "#aruba.config.io_wait_timeout = <numeric>" instead')
+          Aruba.platform.deprecated('The use of "@aruba_io_wait_seconds" is deprecated. Use "#aruba.config.io_wait_timeout = <numeric>" instead')
           aruba.config.io_wait_timeout = @aruba_io_wait_seconds
         end
 
         if root_directory != aruba.config.root_directory
-          Aruba::Platform.deprecated('Overwriting of methods for configuration is deprecated. Use "#aruba.config.root_directory = <string>" instead')
+          Aruba.platform.deprecated('Overwriting of methods for configuration is deprecated. Use "#aruba.config.root_directory = <string>" instead')
           aruba.config.root_directory = root_directory
         end
 
         if current_directory != aruba.config.current_directory
-          Aruba::Platform.deprecated('Overwriting of methods for configuration is deprecated. Use "#aruba.config.current_directory = <string>" instead')
+          Aruba.platform.deprecated('Overwriting of methods for configuration is deprecated. Use "#aruba.config.current_directory = <string>" instead')
           aruba.config.current_directory = current_directory
         end
 
         if defined? @keep_ansi
-          Aruba::Platform.deprecated('The use of "@aruba_keep_ansi" is deprecated. Use "#aruba.config.keep_ansi = <true|false>" instead')
+          Aruba.platform.deprecated('The use of "@aruba_keep_ansi" is deprecated. Use "#aruba.config.keep_ansi = <true|false>" instead')
           aruba.config.keep_ansi = @keep_ansi
         end
 
         if defined? @aruba_root_directory
-          Aruba::Platform.deprecated('The use of "@aruba_root_directory" is deprecated. Use "#aruba.config.root_directory = <string>" instead')
+          Aruba.platform.deprecated('The use of "@aruba_root_directory" is deprecated. Use "#aruba.config.root_directory = <string>" instead')
           aruba.config.keep_ansi = @aruba_root_directory
         end
 
         if root_directory != aruba.config.root_directory
-          Aruba::Platform.deprecated('Overwriting of methods for configuration of "root_directory" is deprecated.')
+          Aruba.platform.deprecated('Overwriting of methods for configuration of "root_directory" is deprecated.')
           aruba.config.root_directory = root_directory
         end
       end

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -1,15 +1,15 @@
 require 'aruba/platform'
 
 require 'aruba/extensions/string/strip'
-require 'aruba/creators/aruba_file_creator'
-require 'aruba/creators/aruba_fixed_size_file_creator'
 
+require 'aruba/platforms/aruba_file_creator'
+require 'aruba/platforms/aruba_fixed_size_file_creator'
 require 'aruba/disk_usage_calculator'
 require 'aruba/aruba_path'
 
-Aruba::Platform.require_matching_files('../matchers/file/*.rb', __FILE__)
-Aruba::Platform.require_matching_files('../matchers/directory/*.rb', __FILE__)
-Aruba::Platform.require_matching_files('../matchers/path/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../matchers/file/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../matchers/directory/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../matchers/path/*.rb', __FILE__)
 
 module Aruba
   module Api
@@ -19,7 +19,7 @@ module Aruba
       # @param [String] file_or_directory
       #   The file/directory which should exist
       def exist?(file_or_directory)
-        Aruba::Platform.exist? expand_path(file_or_directory)
+        Aruba.platform.exist? expand_path(file_or_directory)
       end
 
       # Check if file exist and is file
@@ -27,7 +27,7 @@ module Aruba
       # @param [String] file
       #   The file/directory which should exist
       def file?(file)
-        Aruba::Platform.file? expand_path(file)
+        Aruba.platform.file? expand_path(file)
       end
 
       # Check if directory exist and is directory
@@ -35,7 +35,7 @@ module Aruba
       # @param [String] file
       #   The file/directory which should exist
       def directory?(file)
-        Aruba::Platform.directory? expand_path(file)
+        Aruba.platform.directory? expand_path(file)
       end
 
       # Check if path is absolute
@@ -144,7 +144,7 @@ module Aruba
 
         args.each { |p| create_directory(File.dirname(p)) }
 
-        Aruba::Platform.touch(args.map { |p| expand_path(p) }, options)
+        Aruba.platform.touch(args.map { |p| expand_path(p) }, options)
 
         self
       end
@@ -178,13 +178,13 @@ module Aruba
         destination_path = expand_path(destination)
 
         if source_paths.count > 1
-          Aruba::Platform.mkdir(destination_path)
+          Aruba.platform.mkdir(destination_path)
         else
-          Aruba::Platform.mkdir(File.dirname(destination_path))
+          Aruba.platform.mkdir(File.dirname(destination_path))
           source_paths = source_paths.first
         end
 
-        Aruba::Platform.cp source_paths, destination_path
+        Aruba.platform.cp source_paths, destination_path
 
         self
       end
@@ -243,7 +243,7 @@ module Aruba
         args.each { |p| raise "Expected #{p} to be present" unless exist?(p) }
         paths = args.map { |p| expand_path(p) }
 
-        Aruba::Platform.chmod(mode, paths, options)
+        Aruba.platform.chmod(mode, paths, options)
 
         self
       end
@@ -258,7 +258,7 @@ module Aruba
       def append_to_file(file_name, file_content)
         file_name = expand_path(file_name)
 
-        Aruba::Platform.mkdir(File.dirname(file_name))
+        Aruba.platform.mkdir(File.dirname(file_name))
         File.open(file_name, 'a') { |f| f << file_content }
       end
 
@@ -267,7 +267,7 @@ module Aruba
       # @param [String] directory_name
       #   The name of the directory which should be created
       def create_directory(directory_name)
-        Aruba::Platform.mkdir expand_path(directory_name)
+        Aruba.platform.mkdir expand_path(directory_name)
 
         self
       end
@@ -287,7 +287,7 @@ module Aruba
 
         args = args.map { |p| expand_path(p) }
 
-        Aruba::Platform.rm(args, options)
+        Aruba.platform.rm(args, options)
       end
 
       # Read content of file and yield the content to block

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -94,7 +94,7 @@ module Aruba
     # Get access to hooks
     def hooks
       # rubocop:disable Metrics/LineLength
-      Aruba::Platform.deprecated 'The use of the "#aruba.config.hooks" is deprecated. Please use "#aruba.config.before(:name) {}" to define and "#aruba.config.before(:name, *args)" to run a hook. This method will become private in the next major version.'
+      Aruba.platform.deprecated 'The use of the "#aruba.config.hooks" is deprecated. Please use "#aruba.config.before(:name) {}" to define and "#aruba.config.before(:name, *args)" to run a hook. This method will become private in the next major version.'
       # rubocop:enable Metrics/LineLength
 
       @hooks
@@ -102,7 +102,7 @@ module Aruba
 
     # @deprecated
     def before_cmd(&block)
-      Aruba::Platform.deprecated 'The use of the "#before_cmd"-hook is deprecated. Please define with "#before(:command) {}" instead'
+      Aruba.platform.deprecated 'The use of the "#before_cmd"-hook is deprecated. Please define with "#before(:command) {}" instead'
 
       before(:command, &block)
     end

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -121,22 +121,22 @@ end
 
 When /^I run "(.*)"$/ do |cmd|
   warn(%{\e[35m    The /^I run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), false)
+  run_simple(Aruba.platform.unescape(cmd, aruba.config.keep_ansi), false)
 end
 
 When /^I run `([^`]*)`$/ do |cmd|
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), false)
+  run_simple(Aruba.platform.unescape(cmd, aruba.config.keep_ansi), false)
 end
 
 When /^I successfully run "(.*)"$/ do |cmd|
   warn(%{\e[35m    The  /^I successfully run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi))
+  run_simple(Aruba.platform.unescape(cmd, aruba.config.keep_ansi))
 end
 
 ## I successfully run `echo -n "Hello"`
 ## I successfully run `sleep 29` for up to 30 seconds
 When /^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/ do |cmd, secs|
-  run_simple(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi), true, secs && secs.to_i)
+  run_simple(Aruba.platform.unescape(cmd, aruba.config.keep_ansi), true, secs && secs.to_i)
 end
 
 When /^I run "([^"]*)" interactively$/ do |cmd|
@@ -145,7 +145,7 @@ When /^I run "([^"]*)" interactively$/ do |cmd|
 end
 
 When /^I run `([^`]*)` interactively$/ do |cmd|
-  @interactive = run(Aruba::Platform.unescape(cmd, aruba.config.keep_ansi))
+  @interactive = run(Aruba.platform.unescape(cmd, aruba.config.keep_ansi))
 end
 
 When /^I type "([^"]*)"$/ do |input|

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -47,7 +47,7 @@ Before('@announce-command') do
 end
 
 Before('@announce-cmd') do
-  Aruba::Platform.deprecated 'The use of "@announce-cmd"-hook is deprecated. Please use "@announce-command"'
+  Aruba.platform.deprecated 'The use of "@announce-cmd"-hook is deprecated. Please use "@announce-command"'
 
   announcer.activate :command
 end
@@ -61,7 +61,7 @@ Before('@announce-stderr') do
 end
 
 Before('@announce-dir') do
-  Aruba::Platform.deprecated 'The use of "@announce-dir"-hook is deprecated. Please use "@announce-directory"'
+  Aruba.platform.deprecated 'The use of "@announce-dir"-hook is deprecated. Please use "@announce-directory"'
 
   announcer.activate :directory
 end
@@ -71,13 +71,13 @@ Before('@announce-directory') do
 end
 
 Before('@announce-env') do
-  Aruba::Platform.deprecated 'The use of "@announce-env"-hook is deprecated. Please use "@announce-modified-environment"'
+  Aruba.platform.deprecated 'The use of "@announce-env"-hook is deprecated. Please use "@announce-modified-environment"'
 
   announcer.activate :environment
 end
 
 Before('@announce-environment') do
-  Aruba::Platform.deprecated '@announce-environment is deprecated. Use @announce-modified-environment instead'
+  Aruba.platform.deprecated '@announce-environment is deprecated. Use @announce-modified-environment instead'
 
   announcer.activate :modified_environment
 end
@@ -118,7 +118,7 @@ Before('@ansi') do
 end
 
 Before '@mocked_home_directory' do
-  Aruba::Platform.deprecated('The use of "@mocked_home_directory" is deprecated. Use "@mocked-home-directory" instead')
+  Aruba.platform.deprecated('The use of "@mocked_home_directory" is deprecated. Use "@mocked-home-directory" instead')
 
   set_environment_variable 'HOME', expand_path('.')
 end

--- a/lib/aruba/in_process.rb
+++ b/lib/aruba/in_process.rb
@@ -4,7 +4,7 @@ require 'aruba/platform'
 module Aruba
   class InProcess < Aruba::Processes::InProcess
     def initialize(*args)
-      Aruba::Platform.deprecated('The use of "Aruba::InProcess" is deprecated. Use "Aruba::Processes::InProcess" instead.')
+      Aruba.platform.deprecated('The use of "Aruba::InProcess" is deprecated. Use "Aruba::Processes::InProcess" instead.')
 
       super
     end

--- a/lib/aruba/jruby.rb
+++ b/lib/aruba/jruby.rb
@@ -1,4 +1,4 @@
 require 'aruba/platform'
-Aruba::Platform.deprecated('The use of "aruba/jruby" is deprecated. Use "aruba/config/jruby" instead')
+Aruba.platform.deprecated('The use of "aruba/jruby" is deprecated. Use "aruba/config/jruby" instead')
 
 require 'aruba/config/jruby'

--- a/lib/aruba/matchers/command.rb
+++ b/lib/aruba/matchers/command.rb
@@ -1,1 +1,1 @@
-Aruba::Platform.require_matching_files('../command/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../command/**/*.rb', __FILE__)

--- a/lib/aruba/matchers/directory.rb
+++ b/lib/aruba/matchers/directory.rb
@@ -1,1 +1,1 @@
-Aruba::Platform.require_matching_files('../directory/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../directory/**/*.rb', __FILE__)

--- a/lib/aruba/matchers/environment.rb
+++ b/lib/aruba/matchers/environment.rb
@@ -1,1 +1,1 @@
-Aruba::Platform.require_matching_files('../matchers/environment/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../matchers/environment/*.rb', __FILE__)

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -1,1 +1,1 @@
-Aruba::Platform.require_matching_files('../file/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../file/**/*.rb', __FILE__)

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -1,1 +1,1 @@
-Aruba::Platform.require_matching_files('../path/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files('../path/**/*.rb', __FILE__)

--- a/lib/aruba/matchers/path/match_path_pattern.rb
+++ b/lib/aruba/matchers/path/match_path_pattern.rb
@@ -24,7 +24,7 @@
 #     end
 RSpec::Matchers.define :match_path_pattern do |_|
   match do |actual|
-    Aruba::Platform.deprecated('The use of `expect().to match_path_pattern` is deprecated. Please use `expect().to include pattern /regex/` instead.')
+    Aruba.platform.deprecated('The use of `expect().to match_path_pattern` is deprecated. Please use `expect().to include pattern /regex/` instead.')
 
     next  !actual.select { |a| a == expected }.empty? if expected.is_a? String
 

--- a/lib/aruba/matchers/rspec_matcher_include_regexp.rb
+++ b/lib/aruba/matchers/rspec_matcher_include_regexp.rb
@@ -18,7 +18,7 @@
 #     end
 RSpec::Matchers.define :include_regexp do |expected|
   match do |actual|
-    Aruba::Platform.deprecated('The use of "include_regexp"-matchers is deprecated. It will be removed soon.')
+    Aruba.platform.deprecated('The use of "include_regexp"-matchers is deprecated. It will be removed soon.')
 
     !actual.grep(expected).empty?
   end

--- a/lib/aruba/platform.rb
+++ b/lib/aruba/platform.rb
@@ -1,257 +1,29 @@
-require 'rbconfig'
-require 'pathname'
-
-require 'aruba/platform/simple_table'
+require 'thread'
+require 'aruba/platforms/unix_platform'
+require 'aruba/platforms/windows_platform'
 
 module Aruba
-  # WARNING:
-  # All methods found here are not considered part of the public API of aruba.
-  #
-  # Those methods can be changed at any time in the feature or removed without
-  # any further notice.
-  module Platform
-    def detect_ruby(cmd)
-      if cmd =~ /^ruby\s/
-        cmd.gsub(/^ruby\s/, "#{current_ruby} ")
-      else
-        cmd
-      end
+  PLATFORM_MUTEX = Mutex.new
+end
+
+module Aruba
+  class Platform < SimpleDelegator
+    def initialize
+      @platforms = []
+      @platforms << Aruba::Platforms::WindowsPlatform
+      @platforms << Aruba::Platforms::UnixPlatform
+
+      super @platforms.find(&:match?).new
     end
+  end
+end
 
-    def deprecated(msg)
-      warn(format('%s. Called by %s', msg, caller[1]))
-    end
+module Aruba
+  PLATFORM_MUTEX.synchronize do
+    @platform = Platform.new
+  end
 
-    def current_ruby
-      ::File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
-    end
-
-    # @deprecated
-    # Add newline at the end
-    def ensure_newline(str)
-      deprecated('The use of "#ensure_newline" is deprecated. It will be removed soon')
-
-      str.chomp << "\n"
-    end
-
-    def require_matching_files(pattern, base)
-      if RUBY_VERSION < '1.9.3'
-        ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-      else
-        ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require_relative f }
-      end
-    end
-
-    # Create directory and subdirectories
-    def mkdir(dir_name)
-      dir_name = ::File.expand_path(dir_name)
-
-      ::FileUtils.mkdir_p(dir_name) unless ::File.directory?(dir_name)
-    end
-
-    # Remove file, directory + sub-directories
-    def rm(paths, options = {})
-      paths = Array(paths).map { |p| ::File.expand_path(p) }
-
-      FileUtils.rm_r(paths, options)
-    end
-
-    # Get current working directory
-    def getwd
-      Dir.getwd
-    end
-
-    # Change to directory
-    def chdir(dir_name, &block)
-      dir_name = ::File.expand_path(dir_name.to_s)
-
-      begin
-        if RUBY_VERSION <= '1.9.3'
-          old_env = ENV.to_hash.dup
-        else
-          old_env = ENV.to_h.dup
-        end
-
-        ENV['OLDPWD'] = getwd
-        ENV['PWD'] = dir_name
-        ::Dir.chdir(dir_name, &block)
-      ensure
-        ENV.clear
-        ENV.update old_env
-      end
-    end
-
-    # Touch file, directory
-    def touch(args, options)
-      FileUtils.touch(args, options)
-    end
-
-    # Copy file/directory
-    def cp(args, options)
-      FileUtils.cp_r(args, options)
-    end
-
-    # Change mode of file/directory
-    def chmod(mode, args, options)
-      FileUtils.chmod_R(mode, args, options)
-    end
-
-    # Exists and is file
-    def file?(f)
-      File.file? f
-    end
-
-    # Exists and is directory
-    def directory?(f)
-      File.directory? f
-    end
-
-    # Path Exists
-    def exist?(f)
-      File.exist? f
-    end
-
-    # Path is executable
-    def executable_file?(f)
-      File.file?(f) && File.executable?(f)
-    end
-
-    # Expand path
-    def expand_path(path, base)
-      File.expand_path(path, base)
-    end
-
-    def absolute_path?(path)
-      Pathname.new(path).absolute?
-    end
-
-    # Check if command is relative
-    #
-    # @return [TrueClass, FalseClass]
-    #   true
-    #     * bin/command.sh
-    #
-    #   false
-    #     * /bin/command.sh
-    #     * command.sh
-    def relative_command?(path)
-      p = Pathname.new(path)
-      p.relative? && p.basename != p
-    end
-
-    # Write to file
-    def write_file(path, content)
-      if RUBY_VERSION < '1.9.3'
-        File.open(path, 'wb') do |f|
-          f.print content
-        end
-      else
-        File.write(path, content)
-      end
-    end
-
-    # Unescape string
-    #
-    # @param [String] string
-    #   The string which should be unescaped, e.g. the output of a command
-    #
-    # @return
-    #   The string stripped from escape sequences
-    def unescape(string, keep_ansi = true)
-      string = string.gsub('\n', "\n").gsub('\"', '"').gsub('\e', "\e")
-      string = string.gsub(/\e\[\d+(?>(;\d+)*)m/, '') unless keep_ansi
-      string
-    end
-
-    # Transform hash to a string table which can be output on stderr/stdout
-    def simple_table(hash)
-      SimpleTable.new(hash).to_s
-    end
-
-    # Resolve path for command using the PATH-environment variable
-    #
-    # Mostly taken from here: https://github.com/djberg96/ptools
-    #
-    # @param [#to_s] program
-    #   The name of the program which should be resolved
-    #
-    # @param [String] path
-    #   The PATH, a string concatenated with ":", e.g. /usr/bin/:/bin on a
-    #   UNIX-system
-    #
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/CyclomaticComplexity
-    def which(program, path = ENV['PATH'])
-      on_windows = false
-      on_windows = true if File::ALT_SEPARATOR
-
-      program = program.to_s
-
-      path_exts = ENV['PATHEXT'] ? ('.{' + ENV['PATHEXT'].tr(';', ',').tr('.','') + '}').downcase : '.{exe,com,bat}' if on_windows
-
-      raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
-
-      # Bail out early if an absolute path is provided or the command path is relative
-      # Examples: /usr/bin/command or bin/command.sh
-      if Aruba::Platform.absolute_path?(program) || Aruba::Platform.relative_command?(program)
-        program += path_exts if on_windows && File.extname(program).empty?
-
-        found = Dir[program].first
-
-        return File.expand_path(found) if found && Aruba::Platform.executable_file?(found)
-        return nil
-      end
-
-      # Iterate over each path glob the dir + program.
-      path.split(File::PATH_SEPARATOR).each do |dir|
-        dir = Aruba::Platform.expand_path(dir, Dir.getwd)
-
-        next unless Aruba::Platform.exist?(dir) # In case of bogus second argument
-        file = File.join(dir, program)
-
-        # Dir[] doesn't handle backslashes properly, so convert them. Also, if
-        # the program name doesn't have an extension, try them all.
-        if on_windows
-          file = file.tr("\\", "/")
-          file += path_exts if File.extname(program).empty?
-        end
-
-        found = Dir[file].first
-
-        # Convert all forward slashes to backslashes if supported
-        if found && Aruba::Platform.executable_file?(found)
-          found.tr!(File::SEPARATOR, File::ALT_SEPARATOR) if on_windows
-          return found
-        end
-      end
-
-      nil
-    end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/CyclomaticComplexity
-
-    module_function :detect_ruby, \
-      :current_ruby, \
-      :ensure_newline, \
-      :require_matching_files, \
-      :mkdir, \
-      :rm, \
-      :chdir, \
-      :deprecated, \
-      :touch, \
-      :cp, \
-      :chmod, \
-      :file?, \
-      :directory?, \
-      :exist?, \
-      :expand_path, \
-      :absolute_path?, \
-      :relative_command?, \
-      :executable_file?, \
-      :unescape, \
-      :getwd, \
-      :which, \
-      :simple_table, \
-      :write_file
+  class << self
+    attr_reader :platform
   end
 end

--- a/lib/aruba/platforms/aruba_file_creator.rb
+++ b/lib/aruba/platforms/aruba_file_creator.rb
@@ -15,9 +15,9 @@ module Aruba
       # @param [TrueClass, FalseClass] check_presence (false)
       #   Check if file exist
       def write(path, content, check_presence = false)
-        fail "Expected #{path} to be present" if check_presence && !Aruba::Platform.file?(path)
+        fail "Expected #{path} to be present" if check_presence && !Aruba.platform.file?(path)
 
-        Aruba::Platform.mkdir(File.dirname(path))
+        Aruba.platform.mkdir(File.dirname(path))
 
         if RUBY_VERSION < '1.9.3'
           File.open(path, 'w') { |f| f << content }

--- a/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
+++ b/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
@@ -19,9 +19,9 @@ module Aruba
       # @param [TrueClass, FalseClass] check_presence (false)
       #   Check if file exist
       def write(path, size, check_presence)
-        fail "Expected #{path} to be present" if check_presence && !Aruba::Platform.file?(path)
+        fail "Expected #{path} to be present" if check_presence && !Aruba.platform.file?(path)
 
-        Aruba::Platform.mkdir(File.dirname(path))
+        Aruba.platform.mkdir(File.dirname(path))
 
         File.open(path, "wb"){ |f| f.seek(size - 1); f.write("\0") }
 

--- a/lib/aruba/platforms/simple_table.rb
+++ b/lib/aruba/platforms/simple_table.rb
@@ -1,5 +1,5 @@
 module Aruba
-  module Platform
+  module Platforms
     class SimpleTable
       private
 

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -1,0 +1,246 @@
+require 'rbconfig'
+require 'pathname'
+
+require 'aruba/platforms/simple_table'
+
+module Aruba
+  # This abstracts OS-specific things
+  module Platforms
+    # WARNING:
+    # All methods found here are not considered part of the public API of aruba.
+    #
+    # Those methods can be changed at any time in the feature or removed without
+    # any further notice.
+    #
+    # This includes all methods for the UNIX platform
+    class UnixPlatform
+      def self.match?
+        !FFI::Platform.windows?
+      end
+
+      def environment_variables
+        Environment.new
+      end
+
+      def detect_ruby(cmd)
+        if cmd =~ /^ruby\s/
+          cmd.gsub(/^ruby\s/, "#{current_ruby} ")
+        else
+          cmd
+        end
+      end
+
+      def deprecated(msg)
+        warn(format('%s. Called by %s', msg, caller[1]))
+      end
+
+      def current_ruby
+        ::File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+      end
+
+      # @deprecated
+      # Add newline at the end
+      def ensure_newline(str)
+        deprecated('The use of "#ensure_newline" is deprecated. It will be removed soon')
+
+        str.chomp << "\n"
+      end
+
+      def require_matching_files(pattern, base)
+        if RUBY_VERSION < '1.9.3'
+          ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
+        else
+          ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require_relative f }
+        end
+      end
+
+      # Create directory and subdirectories
+      def mkdir(dir_name)
+        dir_name = ::File.expand_path(dir_name)
+
+        ::FileUtils.mkdir_p(dir_name) unless ::File.directory?(dir_name)
+      end
+
+      # Remove file, directory + sub-directories
+      def rm(paths, options = {})
+        paths = Array(paths).map { |p| ::File.expand_path(p) }
+
+        FileUtils.rm_r(paths, options)
+      end
+
+      # Get current working directory
+      def getwd
+        Dir.getwd
+      end
+
+      # Change to directory
+      def chdir(dir_name, &block)
+        dir_name = ::File.expand_path(dir_name.to_s)
+
+        begin
+          if RUBY_VERSION <= '1.9.3'
+            old_env = ENV.to_hash
+          else
+            old_env = ENV.to_h
+          end
+
+          ENV['OLDPWD'] = getwd
+          ENV['PWD'] = dir_name
+          ::Dir.chdir(dir_name, &block)
+        ensure
+          ENV.clear
+          ENV.update old_env
+        end
+      end
+
+      # Touch file, directory
+      def touch(args, options)
+        FileUtils.touch(args, options)
+      end
+
+      # Copy file/directory
+      def cp(args, options)
+        FileUtils.cp_r(args, options)
+      end
+
+      # Change mode of file/directory
+      def chmod(mode, args, options)
+        FileUtils.chmod_R(mode, args, options)
+      end
+
+      # Exists and is file
+      def file?(f)
+        File.file? f
+      end
+
+      # Exists and is directory
+      def directory?(f)
+        File.directory? f
+      end
+
+      # Path Exists
+      def exist?(f)
+        File.exist? f
+      end
+
+      # Path is executable
+      def executable_file?(f)
+        File.file?(f) && File.executable?(f)
+      end
+
+      # Expand path
+      def expand_path(path, base)
+        File.expand_path(path, base)
+      end
+
+      def absolute_path?(path)
+        Pathname.new(path).absolute?
+      end
+
+      # Check if command is relative
+      #
+      # @return [TrueClass, FalseClass]
+      #   true
+      #     * bin/command.sh
+      #
+      #   false
+      #     * /bin/command.sh
+      #     * command.sh
+      def relative_command?(path)
+        p = Pathname.new(path)
+        p.relative? && p.basename != p
+      end
+
+      # Write to file
+      def write_file(path, content)
+        if RUBY_VERSION < '1.9.3'
+          File.open(path, 'wb') do |f|
+            f.print content
+          end
+        else
+          File.write(path, content)
+        end
+      end
+
+      # Unescape string
+      #
+      # @param [String] string
+      #   The string which should be unescaped, e.g. the output of a command
+      #
+      # @return
+      #   The string stripped from escape sequences
+      def unescape(string, keep_ansi = true)
+        string = string.gsub('\n', "\n").gsub('\"', '"').gsub('\e', "\e")
+        string = string.gsub(/\e\[\d+(?>(;\d+)*)m/, '') unless keep_ansi
+        string
+      end
+
+      # Transform hash to a string table which can be output on stderr/stdout
+      def simple_table(hash)
+        SimpleTable.new(hash).to_s
+      end
+
+      # Resolve path for command using the PATH-environment variable
+      #
+      # Mostly taken from here: https://github.com/djberg96/ptools
+      #
+      # @param [#to_s] program
+      #   The name of the program which should be resolved
+      #
+      # @param [String] path
+      #   The PATH, a string concatenated with ":", e.g. /usr/bin/:/bin on a
+      #   UNIX-system
+      #
+      # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def which(program, path = ENV['PATH'])
+        on_windows = false
+        on_windows = true if File::ALT_SEPARATOR
+
+        program = program.to_s
+
+        path_exts = ENV['PATHEXT'] ? ('.{' + ENV['PATHEXT'].tr(';', ',').tr('.','') + '}').downcase : '.{exe,com,bat}' if on_windows
+
+        raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
+
+        # Bail out early if an absolute path is provided or the command path is relative
+        # Examples: /usr/bin/command or bin/command.sh
+        if Aruba.platform.absolute_path?(program) || Aruba.platform.relative_command?(program)
+          program += path_exts if on_windows && File.extname(program).empty?
+
+          found = Dir[program].first
+
+          return File.expand_path(found) if found && Aruba.platform.executable_file?(found)
+          return nil
+        end
+
+        # Iterate over each path glob the dir + program.
+        path.split(File::PATH_SEPARATOR).each do |dir|
+          dir = Aruba.platform.expand_path(dir, Dir.getwd)
+
+          next unless Aruba.platform.exist?(dir) # In case of bogus second argument
+          file = File.join(dir, program)
+
+          # Dir[] doesn't handle backslashes properly, so convert them. Also, if
+          # the program name doesn't have an extension, try them all.
+          if on_windows
+            file = file.tr("\\", "/")
+            file += path_exts if File.extname(program).empty?
+          end
+
+          found = Dir[file].first
+
+          # Convert all forward slashes to backslashes if supported
+          if found && Aruba.platform.executable_file?(found)
+            found.tr!(File::SEPARATOR, File::ALT_SEPARATOR) if on_windows
+            return found
+          end
+        end
+
+        nil
+      end
+      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity
+    end
+  end
+end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -1,0 +1,20 @@
+require 'aruba/platforms/unix_platform'
+require 'ffi'
+
+module Aruba
+  # This abstracts OS-specific things
+  module Platforms
+    # WARNING:
+    # All methods found here are not considered part of the public API of aruba.
+    #
+    # Those methods can be changed at any time in the feature or removed without
+    # any further notice.
+    #
+    # This includes all methods for the Windows platform
+    class WindowsPlatform < UnixPlatform
+      def self.match?
+        FFI::Platform.windows?
+      end
+    end
+  end
+end

--- a/lib/aruba/process_monitor.rb
+++ b/lib/aruba/process_monitor.rb
@@ -60,7 +60,7 @@ module Aruba
     # @param [String] cmd
     #   The command
     def output_from(cmd)
-      cmd = Platform.detect_ruby(cmd)
+      cmd = Aruba.platform.detect_ruby(cmd)
       get_process(cmd).output
     end
 
@@ -69,7 +69,7 @@ module Aruba
     # @param [String] cmd
     #   The command
     def stdout_from(cmd)
-      cmd = Platform.detect_ruby(cmd)
+      cmd = Aruba.platform.detect_ruby(cmd)
       get_process(cmd).stdout
     end
 
@@ -78,7 +78,7 @@ module Aruba
     # @param [String] cmd
     #   The command
     def stderr_from(cmd)
-      cmd = Platform.detect_ruby(cmd)
+      cmd = Aruba.platform.detect_ruby(cmd)
       get_process(cmd).stderr
     end
 

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -43,7 +43,7 @@ module Aruba
       private
 
       def which(program)
-        Aruba::Platform.which(program, environment['PATH'])
+        Aruba.platform.which(program, environment['PATH'])
       end
 
       def command

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -45,7 +45,7 @@ RSpec.configure do |config|
     next unless self.class.include?(Aruba::Api)
 
     if example.metadata[:announce_environment]
-      Aruba::Platform.deprecated 'announce_environment is deprecated. Use announce_modified_environment instead'
+      Aruba.platform.deprecated 'announce_environment is deprecated. Use announce_modified_environment instead'
 
       announcer.activate(:modified_environment)
     end

--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -10,7 +10,7 @@ module Aruba
       @config            = Aruba.config.make_copy
       @current_directory = ArubaPath.new(@config.working_directory)
       @root_directory    = ArubaPath.new(@config.root_directory)
-      @environment       = Environment.new
+      @environment       = Aruba.platform.environment_variables
 
       @logger      = ArubaLogger.new
       @logger.mode = @config.log_level
@@ -24,12 +24,12 @@ module Aruba
     def fixtures_directory
       unless @fixtures_directory
         candidates = config.fixtures_directories.map { |dir| File.join(root_directory, dir) }
-        @fixtures_directory = candidates.find { |d| Aruba::Platform.directory? d }
+        @fixtures_directory = candidates.find { |d| Aruba.platform.directory? d }
 
         fail "No existing fixtures directory found in #{candidates.map { |d| format('"%s"', d) }.join(', ')}. " unless @fixtures_directory
       end
 
-      fail %(Fixtures directory "#{@fixtures_directory}" is not a directory) unless Aruba::Platform.directory?(@fixtures_directory)
+      fail %(Fixtures directory "#{@fixtures_directory}" is not a directory) unless Aruba.platform.directory?(@fixtures_directory)
 
       ArubaPath.new(@fixtures_directory)
     end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -32,7 +32,7 @@ describe Aruba::Api  do
 
     context 'when file exist' do
       before :each do
-        Aruba::Platform.write_file(path, '')
+        Aruba.platform.write_file(path, '')
       end
 
       it { expect(all_paths).to include expand_path(name) }
@@ -43,7 +43,7 @@ describe Aruba::Api  do
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
       before :each do
-        Aruba::Platform.mkdir(path)
+        Aruba.platform.mkdir(path)
       end
 
       it { expect(all_paths).to include expand_path(name) }
@@ -60,7 +60,7 @@ describe Aruba::Api  do
 
     context 'when file exist' do
       before :each do
-        Aruba::Platform.write_file(path, '')
+        Aruba.platform.write_file(path, '')
       end
 
       it { expect(all_files).to include expand_path(name) }
@@ -71,7 +71,7 @@ describe Aruba::Api  do
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
       before :each do
-        Aruba::Platform.mkdir(path)
+        Aruba.platform.mkdir(path)
       end
 
       it { expect(all_files).to eq [] }
@@ -88,7 +88,7 @@ describe Aruba::Api  do
 
     context 'when file exist' do
       before :each do
-        Aruba::Platform.write_file(path, '')
+        Aruba.platform.write_file(path, '')
       end
 
       it { expect(all_directories).to eq [] }
@@ -99,7 +99,7 @@ describe Aruba::Api  do
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
       before :each do
-        Aruba::Platform.mkdir(path)
+        Aruba.platform.mkdir(path)
       end
 
       it { expect(all_directories).to include expand_path(name) }
@@ -170,7 +170,7 @@ describe Aruba::Api  do
         let(:name) { 'test.d' }
 
         before :each do
-          Array(path).each { |p| Aruba::Platform.mkdir p }
+          Array(path).each { |p| Aruba.platform.mkdir p }
         end
 
         it { expect { @aruba.read(name) }.to raise_error ArgumentError }
@@ -206,11 +206,11 @@ describe Aruba::Api  do
 
       context 'when directory' do
         before :each do
-          Array(path).each { |p| Aruba::Platform.mkdir p }
+          Array(path).each { |p| Aruba.platform.mkdir p }
         end
 
         before :each do
-          Array(content).each { |p| Aruba::Platform.mkdir File.join(path, p) }
+          Array(content).each { |p| Aruba.platform.mkdir File.join(path, p) }
         end
 
         context 'when has subdirectories' do
@@ -298,7 +298,7 @@ describe Aruba::Api  do
 
       context 'when exists' do
         before :each do
-          Array(path).each { |p| Aruba::Platform.mkdir p }
+          Array(path).each { |p| Aruba.platform.mkdir p }
         end
 
         before :each do
@@ -396,7 +396,7 @@ describe Aruba::Api  do
         let(:path) { Array(name).map { |p| File.join(@aruba.aruba.current_directory, p) } }
 
         context 'when exist' do
-          before(:each) { Array(path).each { |p| Aruba::Platform.mkdir p } }
+          before(:each) { Array(path).each { |p| Aruba.platform.mkdir p } }
 
           before :each do
             @aruba.touch(name, options)
@@ -446,7 +446,7 @@ describe Aruba::Api  do
 
         context 'when exists' do
           before :each do
-            Aruba::Platform.write_file(path, '')
+            Aruba.platform.write_file(path, '')
           end
 
           it { expect(@aruba).to be_exist(name) }
@@ -463,7 +463,7 @@ describe Aruba::Api  do
 
         context 'when exists' do
           before :each do
-            Aruba::Platform.mkdir(path)
+            Aruba.platform.mkdir(path)
           end
 
           it { expect(@aruba).to be_exist(name) }
@@ -482,7 +482,7 @@ describe Aruba::Api  do
 
         context 'when exists' do
           before :each do
-            Aruba::Platform.write_file(path, '')
+            Aruba.platform.write_file(path, '')
           end
 
           it { expect(@aruba).to be_file(name) }
@@ -499,7 +499,7 @@ describe Aruba::Api  do
 
         context 'when exists' do
           before :each do
-            Aruba::Platform.mkdir(path)
+            Aruba.platform.mkdir(path)
           end
 
           it { expect(@aruba).not_to be_file(name) }
@@ -518,7 +518,7 @@ describe Aruba::Api  do
 
         context 'when exists' do
           before :each do
-            Aruba::Platform.write_file(path, '')
+            Aruba.platform.write_file(path, '')
           end
 
           it { expect(@aruba).not_to be_directory(name) }
@@ -535,7 +535,7 @@ describe Aruba::Api  do
 
         context 'when exists' do
           before :each do
-            Aruba::Platform.mkdir(path)
+            Aruba.platform.mkdir(path)
           end
 
           it { expect(@aruba).to be_directory(name) }
@@ -589,7 +589,7 @@ describe Aruba::Api  do
             let(:destination) { 'dst.d' }
 
             before :each do
-              Aruba::Platform.mkdir(File.join(@aruba.aruba.current_directory, source))
+              Aruba.platform.mkdir(File.join(@aruba.aruba.current_directory, source))
             end
 
             before :each do
@@ -619,7 +619,7 @@ describe Aruba::Api  do
               let(:destination_files) { source.map { |s| File.join(destination, s) } }
 
               before :each do
-                Aruba::Platform.mkdir(File.join(@aruba.aruba.current_directory, destination))
+                Aruba.platform.mkdir(File.join(@aruba.aruba.current_directory, destination))
               end
 
               before :each do
@@ -903,7 +903,7 @@ describe Aruba::Api  do
         file_name = 'nested/dir/hello_world.txt'
         file_path = File.join(@aruba.aruba.current_directory, file_name)
 
-        Aruba::Platform.mkdir(File.dirname(file_path))
+        Aruba.platform.mkdir(File.dirname(file_path))
         File.open(file_path, 'w') { |f| f << "" }
 
         @aruba.check_file_presence(file_name)
@@ -916,7 +916,7 @@ describe Aruba::Api  do
         file_name = 'nested/dir/hello_world.txt'
         file_path = File.join(@aruba.aruba.current_directory, file_name)
 
-        Aruba::Platform.mkdir(File.dirname(file_path))
+        Aruba.platform.mkdir(File.dirname(file_path))
         File.open(file_path, 'w') { |f| f << "" }
 
         @aruba.check_file_presence([ /test123/ ], false )
@@ -929,7 +929,7 @@ describe Aruba::Api  do
         file_name = 'nested/dir/hello_world.txt'
         file_path = File.join(@aruba.aruba.current_directory, file_name)
 
-        Aruba::Platform.mkdir(File.dirname(file_path))
+        Aruba.platform.mkdir(File.dirname(file_path))
         File.open(file_path, 'w') { |f| f << "" }
 
         @aruba.check_file_presence([ file_name, /nested/  ], true )
@@ -940,7 +940,7 @@ describe Aruba::Api  do
         file_path = File.join('~', random_string)
 
         @aruba.with_environment 'HOME' => File.expand_path(@aruba.aruba.current_directory) do
-          Aruba::Platform.mkdir(File.dirname(File.expand_path(file_path)))
+          Aruba.platform.mkdir(File.dirname(File.expand_path(file_path)))
           File.open(File.expand_path(file_path), 'w') { |f| f << "" }
 
           @aruba.check_file_presence( [ file_path ], true )

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'File Matchers' do
   describe 'to_have_file_content' do
     context 'when file exists' do
       before :each do
-        Aruba::Platform.write_file(@file_path, 'aba')
+        Aruba.platform.write_file(@file_path, 'aba')
       end
 
       context 'and file content is exactly equal string ' do
@@ -108,7 +108,7 @@ RSpec.describe 'File Matchers' do
   describe 'to_have_file_size' do
     context 'when file exists' do
       before :each do
-        Aruba::Platform.write_file(@file_path, '')
+        Aruba.platform.write_file(@file_path, '')
       end
 
       context 'and file size is equal' do

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Path Matchers' do
     context 'when pattern is string' do
       context 'when there is file which matches path pattern' do
         before :each do
-          Aruba::Platform.write_file(@file_path, '')
+          Aruba.platform.write_file(@file_path, '')
         end
 
         it { expect(all_paths).to match_path_pattern(expand_path(@file_name)) }
@@ -28,7 +28,7 @@ RSpec.describe 'Path Matchers' do
     context 'when pattern is regex' do
       context 'when there is file which matches path pattern' do
         before :each do
-          Aruba::Platform.write_file(@file_path, '')
+          Aruba.platform.write_file(@file_path, '')
         end
 
         it { expect(all_paths).to match_path_pattern(/test/) }
@@ -57,7 +57,7 @@ RSpec.describe 'Path Matchers' do
     context 'when file' do
       context 'exists' do
         before :each do
-          Aruba::Platform.write_file(@file_path, '')
+          Aruba.platform.write_file(@file_path, '')
         end
 
         it { expect(@file_name).to be_an_existing_path }

--- a/spec/aruba/platform/simple_table_spec.rb
+++ b/spec/aruba/platform/simple_table_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe '.simple_table' do
     end
     let(:rows) { ['# key1 => value', '# key2 => value'] }
 
-    it { expect(Aruba::Platform.simple_table(hash)).to eq rows }
+    it { expect(Aruba.platform.simple_table(hash)).to eq rows }
   end
 
   context 'when empty hash' do
     let(:hash) { {} }
     let(:rows) { [] }
 
-    it { expect(Aruba::Platform.simple_table(hash)).to eq rows }
+    it { expect(Aruba.platform.simple_table(hash)).to eq rows }
   end
 end


### PR DESCRIPTION
This is the PR for #298. It introduces three classes to aruba, which abstract the os specific code. @mattwynne Matt, is this what you've in mind? Pinging @weedySeaDragon as well.

I split this PR in several commits, each one can be reviewed by it's own.