### PR TITLE
Windows Environment Vars are converted to all upper case

### DIFF
--- a/lib/aruba/platforms/windows_environment_vars.rb
+++ b/lib/aruba/platforms/windows_environment_vars.rb
@@ -1,3 +1,5 @@
+require 'aruba/environment'
+
 module Aruba
   #
   # Windows is case-insensitive when it accesses its environment variables.  That means that
@@ -28,7 +30,9 @@ module Aruba
   class WindowsEnvironmentVars < Environment
     def initialize
       super
-      @env = ENV.to_hash.dup.inject({}) { |new_env, (k,v)| new_env[k.to_s.upcase] = v; new_env }
+      # rubocop:disable Style/EachWithObject
+      @env = ENV.to_hash.dup.inject({}) { |new_env, (k,v)| new_env[k.to_s.upcase] = v; new_env } #compatible with ruby < 1.9
+      # rubocop:enable Style/EachWithObject
     end
   end
 end

--- a/lib/aruba/platforms/windows_environment_vars.rb
+++ b/lib/aruba/platforms/windows_environment_vars.rb
@@ -1,0 +1,34 @@
+module Aruba
+  #
+  # Windows is case-insensitive when it accesses its environment variables.  That means that
+  # at the Windows command line:
+  #  C:>set Path
+  #  C:>Path=.;.\bin;c:\rubys\ruby-2.1.6-p336\bin;
+  #  C:>set PATH
+  #  C:>Path=.;.\bin;c:\rubys\ruby-2.1.6-p336\bin;
+  #
+  # If you access environment variables through ENV, you can access values no matter the
+  # case of the key:
+  #  irb: > ENV["Path"]
+  #  => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
+  #  irb: > ENV["Path"]
+  #  => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
+  #
+  # But if you copy the ENV to a hash, Ruby treats the keys as case sensitive:
+  #  irb: > env_copy = ENV.to_hash
+  #  => {"ALLUSERSPROFILE"=>"C:\\ProgramData", "ANSICON"=>"119x1000 (119x58)", "ANSICON_DEF"=>"7",  APPDATA"=>"C:\\Users\\blorf\\AppData\\Roaming", ....}
+  #  irb: > env["Path"]
+  #  => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
+  #  irb: > env["PATH"]
+  #  => nil
+  #
+  # Thus we turn all of the environment variable keys to upper case so that aruba is ensured that
+  # accessing environment variables with upper case keys will always work.
+  #
+  class WindowsEnvironmentVars < Environment
+    def initialize
+      super
+      @env = ENV.to_hash.dup.inject({}) { |new_env, (k,v)| new_env[k.to_s.upcase] = v; new_env }
+    end
+  end
+end

--- a/lib/aruba/platforms/windows_environment_vars.rb
+++ b/lib/aruba/platforms/windows_environment_vars.rb
@@ -27,6 +27,8 @@ module Aruba
   # Thus we turn all of the environment variable keys to upper case so that aruba is ensured that
   # accessing environment variables with upper case keys will always work.
   #
+  # TODO: investigate unicode characters that don't respond to [String].upcase
+  #
   class WindowsEnvironmentVars < Environment
     def initialize
       super

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -1,5 +1,6 @@
 require 'aruba/platforms/unix_platform'
 require 'ffi'
+require 'aruba/platforms/windows_environment_vars'
 
 module Aruba
   # This abstracts OS-specific things
@@ -14,6 +15,10 @@ module Aruba
     class WindowsPlatform < UnixPlatform
       def self.match?
         FFI::Platform.windows?
+      end
+
+      def environment_variables
+        WindowsEnvironmentVars.new
       end
     end
   end

--- a/spec/aruba/platform/windows_environment_vars_spec.rb
+++ b/spec/aruba/platform/windows_environment_vars_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+# create a value that does not exist in the collection. append a number to the original_str until not found
+def nonexistant(coll = [], str = "zzz")
+  not_found_value = str
+  i = 1
+  while coll.include?(not_found_value)
+    not_found_value = "#{not_found_value}-#{i}"
+    i += 1
+  end
+  not_found_value
+end
+
+describe WindowsEnvironmentVars do
+  subject(:windows_env) { described_class.new }
+
+  let(:env_1)         { "EnvVarAdapt-1" }
+  let(:env_1_value)   { "EVA one one one" }
+  let(:env_2)         { "EnvVarAdapt-2" }
+  let(:env_2_value)   { "EVA two two two" }
+  let(:default_value) { "default value" }
+
+  it "doesn't have any lower-case letters" do
+    expect(windows_env.to_h.select {|k, v| (k =~ /[a-z]+/) }).to be_empty
+  end
+
+  describe "only finds upper-case keys" do
+    before(:each) do
+      @orig_env = ENV.to_hash
+      ENV.store(env_1, env_1_value)
+      ENV.store(env_2, env_2_value)
+    end
+    after(:each) do
+      ENV.clear
+      ENV.update @orig_env
+    end
+
+    describe "fetch" do
+      let(:key_doesnt_exist) { nonexistant(windows_env.to_h.keys) }
+
+      it "finds key.upcase" do
+        expect(windows_env.fetch(env_1.upcase, default_value)).to eq(env_1_value)
+      end
+
+      it "doesn't find key.downcase" do
+        expect(windows_env.fetch(env_1.downcase, default_value)).to eq(default_value)
+      end
+
+      it "doesn't find key different mixed case" do
+        expect(windows_env.fetch(env_2, default_value)).to eq(default_value)
+      end
+
+      it "doesn't find what it shouldn't find" do
+        expect( windows_env.fetch(nonexistant(windows_env.to_h.keys), default_value) ).to eq(default_value)
+      end
+
+      it "#fetch(name, default)" do
+        expect(windows_env.fetch(key_doesnt_exist, default_value)).to eq(ENV.fetch(key_doesnt_exist, default_value))
+      end
+    end
+
+    describe "[]" do
+      it "finds key.upcase" do
+        expect(windows_env[env_1.upcase]).to eq(env_1_value)
+      end
+
+      it "doesn't find key.downcase" do
+        expect(windows_env[env_1.downcase]).to be_falsey
+      end
+
+      it "doesn't find key different mixed case" do
+        expect(windows_env[env_2]).to be_falsey
+      end
+
+      it "doesn't find what it shouldn't find" do
+        expect( windows_env[nonexistant(windows_env.to_h.keys)] ).to be_falsey
+      end
+    end
+
+    describe "key?" do
+      it "finds key.upcase" do
+        expect(windows_env.key?(env_1.upcase)).to be_truthy
+      end
+
+      it "doesn't find key.downcase" do
+        expect(windows_env.key?(env_1.downcase)).to be_falsey
+      end
+
+      it "doesn't find key different mixed case" do
+        expect(windows_env.key?(env_2)).to be_falsey
+      end
+
+      it "doesn't find what it shouldn't find" do
+        expect( windows_env.key?(nonexistant(windows_env.to_h.keys)) ).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
addresses #291 
```WindowsEnvironmentVars < Environment```  converts all ENV keys to upper case on initialization.  

```WindowsPlatform``` now uses ```WindowsEnvironmentVars``` as its environment:
```ruby
    class WindowsPlatform < UnixPlatform
      ...
      def environment_variables
        WindowsEnvironmentVars.new
      end
```

Rspec tests for ```WindowsEnvironmentVars``` included to be sure that accessing the environment variables by the keys will work and that ```WindowsEnvironmentVars.keys``` only has upper case chars.

-  I put the class into aruba/lib/platforms  but perhaps it should go somewhere else
-  "```WindowsEnvironmentVars.keys``` only has upper case chars." really means that it only checks to be sure that none of the keys match ```/[a-z]+/```  I think that might not catch lower case unicode chars that don't get 'upper-cased' by ```[String].upcase```
  - Is this is worth including a gem that does unicode checking and 'upper-casing' so that we can be sure to check this? (like [unicode_utils](https://github.com/lang/unicode_utils))   Or should we wait until someone has an issue with it and then deal with it?