### PR TITLE
Split up which for Unix and Windows

### DIFF
--- a/lib/aruba/platforms/unix_which.rb
+++ b/lib/aruba/platforms/unix_which.rb
@@ -1,0 +1,83 @@
+require 'aruba/platform'
+
+module Aruba
+  module Platforms
+    # Implement `which(command)` for UNIX/Linux
+    class UnixWhich
+      # Bail out because this should never be reached
+      class DefaultWhich
+        def self.match?(*)
+          true
+        end
+
+        def call(program, path)
+          fail %(Invalid input program "#{program}" and/or path "#{path}".)
+        end
+      end
+
+      # Find path for absolute or relative command
+      class AbsoluteOrRelativePathWhich
+        def self.match?(program)
+          Aruba.platform.absolute_path?(program) || Aruba.platform.relative_command?(program)
+        end
+
+        def call(program, path)
+          return File.expand_path(program) if Aruba.platform.executable_file?(program)
+
+          nil
+        end
+      end
+
+      # Find path for command
+      class ProgramWhich
+        def self.match?(program)
+          Aruba.platform.command?(program)
+        end
+
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/MethodLength
+        def call(program, path)
+          # Iterate over each path glob the dir + program.
+          path.split(File::PATH_SEPARATOR).each do |dir|
+            dir = Aruba.platform.expand_path(dir, Dir.getwd)
+            next unless Aruba.platform.exist?(dir) # In case of bogus second argument
+
+            found = Dir[File.join(dir, program)].first
+            return found if found && Aruba.platform.executable_file?(found)
+          end
+
+          nil
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/MethodLength
+      end
+
+      private
+
+      attr_reader :whiches
+
+      public
+
+      def initialize
+        @whiches = []
+        @whiches << AbsoluteOrRelativePathWhich
+        @whiches << ProgramWhich
+        @whiches << DefaultWhich
+      end
+
+      # Find fully quallified path for program
+      #
+      # @param [String] program
+      #   Name of program
+      #
+      # @param [String] path
+      #   ENV['PATH']
+      def call(program, path = ENV['PATH'])
+        raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
+        program = program.to_s
+
+        whiches.find { |w| w.match? program }.new.call(program, path)
+      end
+    end
+  end
+end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -3,6 +3,7 @@ require 'ffi'
 require 'aruba/platforms/unix_platform'
 require 'aruba/platforms/windows_command_string'
 require 'aruba/platforms/windows_environment_variables'
+require 'aruba/platforms/windows_which'
 
 module Aruba
   # This abstracts OS-specific things
@@ -19,12 +20,19 @@ module Aruba
         FFI::Platform.windows?
       end
 
+      # @see UnixPlatform#command_string
       def command_string
         WindowsCommandString
       end
 
+      # @see UnixPlatform#environment_variables
       def environment_variables
         WindowsEnvironmentVariables.new
+      end
+
+      # @see UnixPlatform#which
+      def which(program, path = ENV['PATH'])
+        WindowsWhich.new.call(program, path)
       end
     end
   end

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -1,0 +1,104 @@
+require 'aruba/platform'
+
+module Aruba
+  module Platforms
+    # Implement `which(command)` for windows
+    class WindowsWhich
+      # Bail out because this should never be reached
+      class DefaultWhich
+        def self.match?(*)
+          true
+        end
+
+        def call(program, path)
+          fail %(Invalid input program "#{program}" and/or path "#{path}".)
+        end
+      end
+
+      # Find path for absolute or relative command
+      class AbsoluteOrRelativePathWhich
+        def self.match?(program)
+          Aruba.platform.absolute_path?(program) || Aruba.platform.relative_command?(program)
+        end
+
+        def call(program, path)
+          # Expand `#path_exts`
+          found = Dir[program].first
+
+          return File.expand_path(found) if found && Aruba.platform.executable_file?(found)
+          nil
+        end
+      end
+
+      # Find path for command
+      class ProgramWhich
+        def self.match?(program)
+          Aruba.platform.command?(program)
+        end
+
+        # rubocop:disable Metrics/CyclomaticComplexity
+        # rubocop:disable Metrics/MethodLength
+        def call(program, path)
+          # Iterate over each path glob the dir + program.
+          path.split(File::PATH_SEPARATOR).each do |dir|
+            dir = Aruba.platform.expand_path(dir, Dir.getwd)
+
+            next unless Aruba.platform.exist?(dir) # In case of bogus second argument
+
+            file = File.join(dir, program)
+            # Dir[] doesn't handle backslashes properly, so convert them. Also, if
+            # the program name doesn't have an extension, try them all.
+            file = file.tr("\\", "/")
+
+            found = Dir[file].first
+
+            # Convert all forward slashes to backslashes if supported
+            if found && Aruba.platform.executable_file?(found)
+              found.tr!(File::SEPARATOR, File::ALT_SEPARATOR)
+              return found
+            end
+          end
+
+          nil
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity
+        # rubocop:enable Metrics/MethodLength
+      end
+
+      private
+
+      attr_reader :whiches
+
+      public
+
+      def initialize
+        @whiches = []
+        @whiches << AbsoluteOrRelativePathWhich
+        @whiches << ProgramWhich
+        @whiches << DefaultWhich
+      end
+
+      # Find fully quallified path for program
+      #
+      # @param [String] program
+      #   Name of program
+      #
+      # @param [String] path
+      #   ENV['PATH']
+      def call(program, path = ENV['PATH'])
+        raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
+
+        program = program.to_s
+        program += windows_executable_extentions if File.extname(program).empty?
+
+        whiches.find { |w| w.match? program }.new.call(program, path)
+      end
+
+      private
+
+      def windows_executable_extentions
+        ENV['PATHEXT'] ? format('.{%s}', ENV['PATHEXT'].tr(';', ',').tr('.','')).downcase : '.{exe,com,bat}'
+      end
+    end
+  end
+end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -46,11 +46,12 @@ module Aruba
       # rubocop:disable Metrics/CyclomaticComplexity
       def run!
         # gather fully qualified path
-        cmd = Aruba.platform.command_string.new(which(command)).to_s
-
+        cmd = which(command)
         # rubocop:disable  Metrics/LineLength
-        fail LaunchError, %(Command "#{command}" not found in PATH-variable "#{environment['PATH']}".) if cmd.nil? || cmd.empty?
+        fail LaunchError, %(Command "#{command}" not found in PATH-variable "#{environment['PATH']}".) if cmd.nil?
         # rubocop:enable  Metrics/LineLength
+
+        cmd = Aruba.platform.command_string.new(cmd).to_s
 
         @process   = ChildProcess.build(cmd, *arguments)
         @out       = Tempfile.new("aruba-out")
@@ -70,7 +71,7 @@ module Aruba
         begin
           @process.start
         rescue ChildProcess::LaunchError => e
-          raise LaunchError, e.message
+          raise LaunchError, "It tried to start #{cmd}." + e.message
         end
 
         after_run


### PR DESCRIPTION
Unix and Windows need a separate logic to find executables in PATH. This splits up the original implementation and uses `Aruba.platform` to decide which implementation to use.