### PR TITLE
Add console support to aruba

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -18,12 +18,18 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ffi', '~> 1.9.10'
   s.add_runtime_dependency 'rspec-expectations', '>= 2.99'
   s.add_runtime_dependency 'contracts', '~> 0.9'
+  s.add_runtime_dependency 'thor', '~> 0.19'
 
   s.add_development_dependency 'bundler', '~> 1.10.2'
 
   s.rubygems_version = ">= 1.6.1"
-  s.required_ruby_version = '>= 1.8.7'
-  s.post_install_message = <<-EOS
+
+  if Aruba::VERSION >= '1'
+    s.required_ruby_version = '>= 1.9.3'
+  else
+    s.required_ruby_version = '>= 1.8.7'
+
+    s.post_install_message = <<-EOS
 Use on ruby 1.8.7
 * Make sure you add something like that to your `Gemfile`. Otherwise you will
   get cucumber > 2 and this will fail on ruby 1.8.7
@@ -32,6 +38,7 @@ Use on ruby 1.8.7
 
 With aruba >= 1.0 there will be breaking changes. Make sure to read https://github.com/cucumber/aruba/blob/master/History.md for 1.0.0
 EOS
+  end
 
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")

--- a/bin/aruba
+++ b/bin/aruba
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path('../../lib', __FILE__)
+
+require 'aruba/cli'
+
+Aruba::Cli.start

--- a/features/cli/console.feature
+++ b/features/cli/console.feature
@@ -1,0 +1,49 @@
+Feature: Aruba Console
+
+  Background:
+    Given a mocked home directory
+
+  Scenario: Start console
+    Given I run `aruba console` interactively
+    When I close the stdin stream
+    Then the output should contain:
+    """
+    aruba:001:0>
+    """
+
+  Scenario: Show help
+    Given I run `aruba console` interactively
+    And I type "aruba_help"
+    When I close the stdin stream
+    Then the output should contain:
+    """
+    Version:
+    """
+    And the output should contain:
+    """
+    Issue Tracker:
+    """
+    And the output should contain:
+    """
+    Documentation:
+    """
+
+  Scenario: Show methods
+    Given I run `aruba console` interactively
+    And I type "aruba_methods"
+    When I close the stdin stream
+    Then the output should contain:
+    """
+    Methods:
+    """
+    And the output should contain:
+    """
+    * setup_aruba
+    """
+
+  Scenario: Has history
+    Given I run `aruba console` interactively
+    And I type "aruba_methods"
+    And I type "exit"
+    When I close the stdin stream
+    Then the file "~/.aruba_history" should exist

--- a/features/configuration/console_history_file.feature
+++ b/features/configuration/console_history_file.feature
@@ -1,0 +1,38 @@
+Feature: Configure the aruba console history file
+
+  As a developer
+  I want to configure the history file of aruba console
+  In order to have a better isolation of tests
+
+  Background:
+    Given I use the fixture "cli-app"
+
+  Scenario: Default value
+    Given a file named "features/support/aruba.rb" with:
+    """
+    Aruba.configure do |config|
+      puts %(The default value is "#{config.console_history_file}")
+    end
+    """
+    When I successfully run `cucumber`
+    Then the output should contain:
+    """
+    The default value is "~/.aruba_history"
+    """
+
+  Scenario: Set some value
+    Given a file named "features/support/aruba.rb" with:
+    """
+    Aruba.configure do |config|
+      config.console_history_file = '~/.config/aruba/history.txt'
+    end
+
+    Aruba.configure do |config|
+      puts %(The value is "#{config.console_history_file}")
+    end
+    """
+    Then I successfully run `cucumber`
+    Then the output should contain:
+    """
+    The value is "~/.config/aruba/history.txt"
+    """

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -26,7 +26,7 @@ module Aruba
       # '\033' => "\e"
       # '\"' => '"'
       def unescape_text(text)
-        text.gsub('\n', "\n").gsub('\"', '"').gsub('\e', "\e").gsub('\033', "\e").gsub('\016', "\016").gsub('\017', "\017")
+        text.gsub('\n', "\n").gsub('\"', '"').gsub('\e', "\e").gsub('\033', "\e").gsub('\016', "\016").gsub('\017', "\017").gsub('\t', "\t")
       end
 
       # Remove ansi characters from text

--- a/lib/aruba/cli.rb
+++ b/lib/aruba/cli.rb
@@ -1,0 +1,11 @@
+require 'thor'
+require 'aruba/console'
+
+module Aruba
+  class Cli < Thor
+    desc 'console', "Start aruba's console"
+    def console
+      Aruba::Console.new.start
+    end
+  end
+end

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -58,6 +58,7 @@ module Aruba
     # rubocop:enable Metrics/LineLength
 
     option_accessor :physical_block_size, :contract => { Aruba::Contracts::IsPowerOfTwo => Aruba::Contracts::IsPowerOfTwo }, :default => 512
+    option_accessor :console_history_file, :contract => { String => String }, :default => '~/.aruba_history'
   end
 end
 

--- a/lib/aruba/console.rb
+++ b/lib/aruba/console.rb
@@ -1,0 +1,66 @@
+require 'irb'
+
+require 'aruba/api'
+require 'aruba/console/help'
+
+module Aruba
+  class Console
+    # rubocop:disable Metrics/MethodLength
+    def start
+      # Start IRB with current context:
+      # http://stackoverflow.com/questions/4189818/how-to-run-irb-start-in-context-of-current-class
+      ARGV.clear
+      IRB.setup nil
+
+      IRB.conf[:PROMPT] = {}
+      IRB.conf[:IRB_NAME] = 'aruba'
+      IRB.conf[:PROMPT][:ARUBA] = {
+        :PROMPT_I => '%N:%03n:%i> ',
+        :PROMPT_N => '%N:%03n:%i> ',
+        :PROMPT_S => '%N:%03n:%i%l ',
+        :PROMPT_C => '%N:%03n:%i* ',
+        :RETURN => "# => %s\n"
+      }
+      IRB.conf[:PROMPT_MODE] = :ARUBA
+
+      IRB.conf[:RC] = false
+
+      require 'irb/completion'
+      require 'irb/ext/save-history'
+      IRB.conf[:READLINE] = true
+      IRB.conf[:SAVE_HISTORY] = 1000
+      IRB.conf[:HISTORY_FILE] = Aruba.config.console_history_file
+
+      # rubocop:disable Lint/NestedMethodDefinition
+      context = Class.new do
+        include Aruba::Api
+        include Aruba::Console::Help
+
+        def initialize
+          setup_aruba
+        end
+
+        def inspect
+          'nil'
+        end
+      end
+      # rubocop:enable Lint/NestedMethodDefinition
+
+      irb = IRB::Irb.new(IRB::WorkSpace.new(context.new))
+      IRB.conf[:MAIN_CONTEXT] = irb.context
+
+      trap("SIGINT") do
+        IRB.irb.signal_handle
+      end
+
+      begin
+        catch(:IRB_EXIT) do
+          irb.eval_input
+        end
+      ensure
+        IRB.irb_at_exit
+      end
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+end

--- a/lib/aruba/console/help.rb
+++ b/lib/aruba/console/help.rb
@@ -1,0 +1,33 @@
+require 'aruba/api'
+
+module Aruba
+  class Console
+    # Helpers for Aruba::Console
+    module Help
+      # Output help information
+      def aruba_help
+        puts 'Aruba Version: ' + Aruba::VERSION
+        puts 'Issue Tracker: ' + 'https://github.com/cucumber/aruba/issues'
+        puts "Documentation:\n" + %w(http://www.rubydoc.info/gems/aruba).map { |d| format('* %s', d) }.join("\n")
+        puts
+
+        nil
+      end
+
+      # List available methods in aruba
+      def aruba_methods
+        ms = if RUBY_VERSION < '1.9'
+               # rubocop:disable Style/EachWithObject
+               (Aruba::Api.instance_methods - Module.instance_methods).inject([]) { |a, e| a << format("* %s", e); a }.sort
+               # rubocop:enable Style/EachWithObject
+             else
+               (Aruba::Api.instance_methods - Module.instance_methods).each_with_object([]) { |e, a| a << format("* %s", e) }.sort
+             end
+
+        puts "Available Methods:\n" + ms.join("\n")
+
+        nil
+      end
+    end
+  end
+end

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -166,7 +166,7 @@ When /^I run `([^`]*)` interactively$/ do |cmd|
 end
 
 When /^I type "([^"]*)"$/ do |input|
-  type(input)
+  type(unescape_text(input))
 end
 
 When /^I close the stdin stream$/ do

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -85,9 +85,9 @@ module Aruba
 
         begin
           if RUBY_VERSION <= '1.9.3'
-            old_env = ENV.to_hash
+            old_env = ENV.to_hash.dup
           else
-            old_env = ENV.to_h
+            old_env = ENV.to_h.dup
           end
 
           ENV['OLDPWD'] = getwd

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -24,6 +24,26 @@ module Aruba
         stdout + stderr
       end
 
+      def write(*)
+        NotImplementedError
+      end
+
+      def stdin(*)
+        NotImplementedError
+      end
+
+      def stdout(*)
+        NotImplementedError
+      end
+
+      def stderr(*)
+        NotImplementedError
+      end
+
+      def close_io(*)
+        NotImplementedError
+      end
+
       # Was process already stopped
       def stopped?
         @stopped == true


### PR DESCRIPTION
This adds a console to aruba which users can use as "sandbox". It uses `tmp/aruba` as temporary directory.