### PR TITLE
Refactor set/remove environment variables

### DIFF
--- a/features/api/environment/delete_environment_variable.feature
+++ b/features/api/environment/delete_environment_variable.feature
@@ -1,4 +1,4 @@
-Feature: Remove existing environment variable via API-method
+Feature: Delete existing environment variable via API-method
 
   It is quite handy to modify the environment of a process. To make this
   possible, `aruba` provides several methods. One of these is

--- a/features/api/environment/set_environment_variable.feature
+++ b/features/api/environment/set_environment_variable.feature
@@ -69,6 +69,46 @@ Feature: Set environment variable via API-method
     When I run `rspec`
     Then the specs should all pass
 
+  Scenario: Set variable via ENV
+
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=2' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Existing variable set in before block in RSpec
+
+    Setting environment variables with `#set_environment_variable('VAR', 'value')` takes
+    precedence before setting variables with `ENV['VAR'] = 'value'`.
+
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '1' }
+      before(:each) { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
   Scenario: Run some ruby code in code with previously set environment
 
     The `#with_environment`-block makes the change environment temporary
@@ -301,6 +341,34 @@ Feature: Set environment variable via API-method
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
     end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: External ruby file / ruby gem modifying ENV
+
+    There are some Rubygems around which need to modify ENV['NODE_PATH'] like
+    [`ruby-stylus`](https://github.com/forgecrafted/ruby-stylus/blob/e7293362dc8cbf550f7c317d721ba6b9087e8833/lib/stylus.rb#L168).
+    This is supported by aruba as well.
+
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) do
+        require_relative File.expand_path('../../lib/my_library.rb', __FILE__)
+      end
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
+    end
+    """
+    And a file named "lib/my_library.rb" with:
+    """
+    ENV['LONG_LONG_VARIABLE'] = '1'
     """
     When I run `rspec`
     Then the specs should all pass

--- a/features/api/environment/set_environment_variable.feature
+++ b/features/api/environment/set_environment_variable.feature
@@ -355,9 +355,11 @@ Feature: Set environment variable via API-method
     """ruby
     require 'spec_helper'
 
+    $LOAD_PATH <<  File.expand_path('../../lib', __FILE__)
+
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) do
-        require_relative File.expand_path('../../lib/my_library.rb', __FILE__)
+        require 'my_library'
       end
 
       before(:each) { run('env') }

--- a/features/configuration/command_runtime_environment.feature
+++ b/features/configuration/command_runtime_environment.feature
@@ -1,0 +1,129 @@
+Feature: Define default process environment
+  Say you want to have a default set of environment variables, then use this
+  code.
+
+  ~~~ruby
+  Aruba.configure do |config|
+    config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
+  end
+  ~~~
+
+  This can be changed via `#set_environment_variable`,
+  `#append_environment_variable`, `#delete_environment_variable` or
+  `#prepend_environment_variable`.
+
+  Background:
+    Given I use the fixture "cli-app"
+
+  Scenario: Overwrite existing variable with new default value
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    ENV['LONG_LONG_VARIABLE'] = 'y'
+
+    Aruba.configure do |config|
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+    end
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=x' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Overwrite default value for variable
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    ENV['LONG_LONG_VARIABLE'] = 'y'
+
+    Aruba.configure do |config|
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+    end
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', 'z' }
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=z' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Append value to default value
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    ENV['LONG_LONG_VARIABLE'] = 'y'
+
+    Aruba.configure do |config|
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+    end
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'z' }
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=xz' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Prepend value
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    ENV['LONG_LONG_VARIABLE'] = 'y'
+
+    Aruba.configure do |config|
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+    end
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'z' }
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=zx' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Remove variable from default set of variables
+    Given a file named "spec/environment_spec.rb" with:
+    """ruby
+    require 'spec_helper'
+
+    ENV['LONG_LONG_VARIABLE'] = 'y'
+
+    Aruba.configure do |config|
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+    end
+
+    RSpec.describe 'Environment command', :type => :aruba do
+      before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
+
+      before(:each) { run('env') }
+      before(:each) { stop_all_commands }
+
+      it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE' }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass

--- a/features/configuration/command_runtime_environment.feature
+++ b/features/configuration/command_runtime_environment.feature
@@ -4,7 +4,7 @@ Feature: Define default process environment
 
   ~~~ruby
   Aruba.configure do |config|
-    config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
+    config.command_runtime_environment = { 'MY_VARIABLE' => 'x' }
   end
   ~~~
 

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -164,7 +164,7 @@ module Aruba
         @commands ||= []
         @commands << cmd
 
-        environment       = aruba.environment.to_h
+        environment       = aruba.environment
         working_directory = expand_path('.')
         event_bus         = aruba.event_bus
 
@@ -202,7 +202,7 @@ module Aruba
           :exit_timeout      => exit_timeout,
           :io_wait_timeout   => io_wait_timeout,
           :working_directory => working_directory,
-          :environment       => environment,
+          :environment       => environment.to_hash,
           :main_class        => main_class,
           :stop_signal       => stop_signal,
           :startup_wait_time => startup_wait_time,
@@ -217,6 +217,7 @@ module Aruba
         end
 
         aruba.config.before(:command, self, command)
+
         command.start
 
         aruba.announcer.announce(:stop_signal, command.pid, stop_signal) if stop_signal

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -179,8 +179,10 @@ module Aruba
       def with_environment(env = {}, &block)
         old_aruba_env = aruba.environment.to_h
 
+        # make sure the old environment is really restored in "ENV"
         Aruba.platform.with_environment aruba.environment.update(env).to_h, &block
       ensure
+        # make sure the old environment is really restored in "aruba.environment"
         aruba.environment.clear
         aruba.environment.update old_aruba_env
       end

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -36,7 +36,7 @@ module Aruba
     option_accessor :io_wait_timeout, :contract => { Num => Num }, :default => 0.1
     option_accessor :startup_wait_time, :contract => { Num => Num }, :default => 0
     option_accessor :fixtures_directories, :contract => { Array => ArrayOf[String] }, :default => %w(features/fixtures spec/fixtures test/fixtures fixtures)
-    option_accessor :command_runtime_environment, :contract => { Hash => Hash }, :default => ENV.to_hash.dup
+    option_accessor :command_runtime_environment, :contract => { Hash => Hash }, :default => ENV.to_hash
     # rubocop:disable Metrics/LineLength
     option_accessor(:command_search_paths, :contract => { ArrayOf[String] => ArrayOf[String] }) { |config| [File.join(config.root_directory.value, 'bin')] }
     # rubocop:enable Metrics/LineLength

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -10,9 +10,6 @@ if Aruba::VERSION >= '1.0.0'
 end
 
 Before do
-  # this is ENV by default ...
-  aruba.environment.update aruba.config.command_runtime_environment
-
   # ... so every change needs to be done later
   prepend_environment_variable 'PATH', aruba.config.command_search_paths.join(':') + ':'
   set_environment_variable 'HOME', aruba.config.home_directory

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -34,7 +34,7 @@ module Aruba
       end
 
       def environment_variables
-        UnixEnvironmentVariables.new
+        UnixEnvironmentVariables
       end
 
       def command_string

--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -34,14 +34,14 @@ module Aruba
     # will always work.
     class WindowsEnvironmentVariables < UnixEnvironmentVariables
       def initialize(env = ENV.to_hash)
-        @env = Marshal.load(Marshal.dump(env))
+        @actions = []
 
         if RUBY_VERSION <= '1.9.3'
           # rubocop:disable Style/EachWithObject
-          @env = @env.inject({}) { |a, (k,v)| a[k.to_s.upcase] = v; a }
+          @env = env.inject({}) { |a, (k,v)| a[k.to_s.upcase] = v; a }
           # rubocop:enable Style/EachWithObject
         else
-          @env = @env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
+          @env = env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
         end
       end
 

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -30,7 +30,7 @@ module Aruba
 
       # @see UnixPlatform#environment_variables
       def environment_variables
-        WindowsEnvironmentVariables.new
+        WindowsEnvironmentVariables
       end
 
       # @see UnixPlatform#which

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -91,14 +91,13 @@ RSpec.configure do |config|
   config.before :each do
     next unless self.class.include? Aruba::Api
 
-    aruba.environment.update aruba.config.command_runtime_environment
-    aruba.environment.prepend 'PATH', aruba.config.command_search_paths.join(':') + ':'
+    prepend_environment_variable 'PATH', aruba.config.command_search_paths.join(':') + ':'
   end
 
   # Use configured home directory as HOME
   config.before :each do |example|
     next unless self.class.include? Aruba::Api
 
-    aruba.environment['HOME'] =  aruba.config.home_directory
+    set_environment_variable 'HOME', aruba.config.home_directory
   end
 end

--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -40,13 +40,14 @@ module Aruba
     attr_accessor :config, :environment, :logger, :command_monitor, :announcer, :event_bus
 
     def initialize(opts = {})
-      @environment     = opts.fetch(:environment, Aruba.platform.environment_variables)
-      @event_bus     = ::Event::Bus.new(::Event::NameResolver.new(Aruba::Events))
+      @event_bus       = ::Event::Bus.new(::Event::NameResolver.new(Aruba::Events))
       @announcer       = opts.fetch(:announcer, Aruba.platform.announcer.new)
-
-      @config            = opts.fetch(:config, ConfigWrapper.new(Aruba.config.make_copy, @event_bus))
+      @config          = opts.fetch(:config, ConfigWrapper.new(Aruba.config.make_copy, @event_bus))
+      @environment     = opts.fetch(:environment, Aruba.platform.environment_variables.new)
       @current_directory = ArubaPath.new(@config.working_directory)
       @root_directory    = ArubaPath.new(@config.root_directory)
+
+      @environment.update(@config.command_runtime_environment)
 
       if Aruba::VERSION < '1'
         @command_monitor = opts.fetch(:command_monitor, Aruba.platform.command_monitor.new(:announcer => @announcer))


### PR DESCRIPTION
`ruby-stylus` sets `ENV['NODE_PATH']` but aruba's env ignores that. I hope to fix it one time in the future. This PR tracks the progress.