### PR TITLE
Changed "Aruba" to "aruba" twice in Dep Warning so you can cut/paste cleanly.

### DIFF
--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -180,7 +180,7 @@ module Aruba
 
         mode = if Aruba.process
                  # rubocop:disable Metrics/LineLength
-                 Aruba.platform.deprecated('The use of "Aruba.process = <process>" and "Aruba.process.main_class" is deprecated. Use "Aruba.configure { |config| config.command_launcher = :in_process|:debug|:spawn }" and "Aruba.configure { |config| config.main_class = <klass> }" instead.')
+                 Aruba.platform.deprecated('The use of "Aruba.process = <process>" and "Aruba.process.main_class" is deprecated. Use "aruba.configure { |config| config.command_launcher = :in_process|:debug|:spawn }" and "aruba.configure { |config| config.main_class = <klass> }" instead.')
                  # rubocop:enable Metrics/LineLength
                  Aruba.process
                else


### PR DESCRIPTION
Changed "Aruba" to "aruba" twice in Dep Warning so you can cut/paste cleanly.

