### PR TITLE
Show output when command fails with "fail_on_error"

### DIFF
--- a/features/configuration/activate_announcer_on_command_failure.feature
+++ b/features/configuration/activate_announcer_on_command_failure.feature
@@ -1,0 +1,38 @@
+Feature: Configure announcer activation on command failure
+
+  As a developer
+  I want to configure which announcers should get activated on command failure
+  In order to understand what caused a command to fail
+
+  Background:
+    Given I use the fixture "cli-app"
+
+  Scenario: Default value
+    Given a file named "features/support/aruba.rb" with:
+    """ruby
+    Aruba.configure do |config|
+      puts %(The default value is "#{config.activate_announcer_on_command_failure.inspect}")
+    end
+    """
+    When I successfully run `cucumber`
+    Then the output should contain:
+    """ruby
+    The default value is "[]"
+    """
+
+  Scenario: Modify value
+    Given a file named "features/support/aruba.rb" with:
+    """ruby
+    Aruba.configure do |config|
+      config.activate_announcer_on_command_failure = [:foo, :bar]
+    end
+
+    Aruba.configure do |config|
+      puts %(The value is "#{config.activate_announcer_on_command_failure.inspect}")
+    end
+    """
+    Then I successfully run `cucumber`
+    Then the output should contain:
+    """
+    The value is "[:foo, :bar]"
+    """

--- a/features/steps/command/run.feature
+++ b/features/steps/command/run.feature
@@ -20,3 +20,31 @@ Feature: Run commands
     When I run `cucumber`
     Then the features should all pass
 
+  Scenario: Activate desired announcers when running command fails
+    Given an executable named "bin/cli" with:
+    """
+    #!/bin/bash
+    echo "Hello, I'm STDOUT"
+    exit 1
+    """
+    And a file named "features/run.feature" with:
+    """
+    Feature: Run it
+      Scenario: Run command
+        When I successfully run `cli`
+    """
+    And I append to "features/support/env.rb" with:
+    """
+    Before do
+      aruba.config.activate_announcer_on_command_failure = [:stdout]
+    end
+    """
+    When I run `cucumber`
+    Then the features should not pass
+    And the output should contain:
+    """
+    <<-STDOUT
+    Hello, I'm STDOUT
+
+    STDOUT
+    """

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -277,8 +277,13 @@ module Aruba
         end
 
         if fail_on_error
-          expect(command).to have_finished_in_time
-          expect(command).to be_successfully_executed
+          begin
+            expect(command).to have_finished_in_time
+            expect(command).to be_successfully_executed
+          rescue RSpec::Expectations::ExpectationNotMetError => e
+            aruba.announcer.activate(aruba.config.activate_announcer_on_command_failure)
+            raise e
+          end
         end
       end
       # rubocop:enable Metrics/CyclomaticComplexity

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -26,9 +26,9 @@ module Aruba
     option_accessor :working_directory, :contract => { Aruba::Contracts::RelativePath => Aruba::Contracts::RelativePath }, :default => 'tmp/aruba'
 
     if RUBY_VERSION < '1.9'
-      option_reader   :fixtures_path_prefix, :contract => { None => String }, :default => '%'
+      option_reader :fixtures_path_prefix, :contract => { None => String }, :default => '%'
     else
-      option_reader   :fixtures_path_prefix, :contract => { None => String }, :default => ?%
+      option_reader :fixtures_path_prefix, :contract => { None => String }, :default => ?%
     end
 
     option_accessor :exit_timeout, :contract => { Num => Num }, :default => 15
@@ -64,6 +64,8 @@ module Aruba
 
     option_accessor :physical_block_size, :contract => { Aruba::Contracts::IsPowerOfTwo => Aruba::Contracts::IsPowerOfTwo }, :default => 512
     option_accessor :console_history_file, :contract => { String => String }, :default => '~/.aruba_history'
+
+    option_accessor :activate_announcer_on_command_failure, :contract => { ArrayOf[Symbol] => ArrayOf[Symbol] }, :default => []
   end
 end
 


### PR DESCRIPTION
Happy New Year!

When testing some long-running flaky commands it can be quite difficult to understand what is causing a command to fail.
I think it could be useful to show the command's output if it failed unexpectedly.

This might be completely the wrong way of accomplishing that.
Wdyt in general of the idea?