### PR TITLE
stop supporting ruby 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 script: script/test
 install: script/bootstrap --without development debug
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.8

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :debug do
     gem 'pry-byebug', '~> 3.1.0'
   end
 
-  if RUBY_VERSION < '2' && RUBY_VERSION > '1.9' && !RUBY_PLATFORM.include?('java')
+  if RUBY_VERSION < '2' && !RUBY_PLATFORM.include?('java')
     gem 'debugger', '~> 1.6.8'
     gem 'pry-debugger', '~> 0.2.3'
   end
@@ -48,32 +48,20 @@ group :development, :test do
   gem 'rspec', '~> 3.4'
   gem 'fuubar', '~> 2.0.0'
 
-  # using platform for this make bundler complain about the same gem given
+  # using platform for this makes bundler complain about the same gem given
   # twice
-  if RUBY_VERSION < '1.9.3'
-    gem 'cucumber', '~> 1.3.20'
-  else
-    gem 'cucumber', '~> 2.0'
-  end
+  gem 'cucumber', '~> 2.0'
 
-  if RUBY_VERSION >= '1.9.3'
-    # Make aruba compliant to ruby community guide
-    gem 'rubocop', '~> 0.32'
-  end
+  # Make aruba compliant to ruby community guide
+  gem 'rubocop', '~> 0.32'
 
-  if RUBY_VERSION >= '1.9.3'
-    # gem 'cucumber-pro', '~> 0.0'
-  end
+  # gem 'cucumber-pro', '~> 0.0'
 
-  if RUBY_VERSION >= '1.9.3'
-    # License compliance
-    gem 'license_finder', '~> 2.0.4'
-  end
+  # License compliance
+  gem 'license_finder', '~> 2.0.4'
 
-  if RUBY_VERSION >= '1.9.3'
-    # Upload documentation
-    gem 'relish', '~> 0.7.1'
-  end
+  # Upload documentation
+  gem 'relish', '~> 0.7.1'
 
   gem 'minitest', '~> 5.8.0'
 end

--- a/README.md
+++ b/README.md
@@ -107,11 +107,7 @@ prefer to setup `aruba` yourself, please move on to the next section.
    ~~~ruby
    $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-   if RUBY_VERSION < '1.9.3'
-     ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-   else
-     ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-   end
+   ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
    ~~~
 
 3. Create a file named named "spec/use_aruba_with_rspec_spec.rb" with:
@@ -144,11 +140,7 @@ prefer to setup `aruba` yourself, please move on to the next section.
    ~~~ruby
    $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-   if RUBY_VERSION < '1.9.3'
-     ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-   else
-     ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-   end
+   ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
    ~~~
 
 3. Add a file named "test/use_aruba_with_minitest.rb" with:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: '18'
     - ruby_version: '19'
     - ruby_version: '20'
     - ruby_version: '21'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -24,17 +24,10 @@ Gem::Specification.new do |s|
 
   s.rubygems_version = ">= 1.6.1"
 
-  if Aruba::VERSION >= '1'
-    s.required_ruby_version = '>= 1.9.3'
-  else
-    s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.9.3'
 
+  unless Aruba::VERSION >= '1'
     s.post_install_message = <<-EOS
-Use on ruby 1.8.7
-* Make sure you add something like that to your `Gemfile`. Otherwise you will
-  get cucumber > 2 and this will fail on ruby 1.8.7
-
-  gem 'cucumber', '~> 1.3.20'
 
 With aruba >= 1.0 there will be breaking changes. Make sure to read https://github.com/cucumber/aruba/blob/master/History.md for 1.0.0
 EOS

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -17,8 +17,6 @@ ignore_opts <<  '--tags ~@unsupported-on-platform-windows' if FFI::Platform.wind
 ignore_opts <<  '--tags ~@unsupported-on-platform-unix'    if FFI::Platform.unix?
 ignore_opts <<  '--tags ~@unsupported-on-platform-mac'     if FFI::Platform.mac?
 ignore_opts <<  '--tags ~@unsupported-on-ruby-older-2'     if RUBY_VERSION < '2'
-ignore_opts <<  '--tags ~@unsupported-on-ruby-older-193'   if RUBY_VERSION < '1.9.3'
-ignore_opts <<  '--tags ~@unsupported-on-ruby-older-19'    if RUBY_VERSION < '1.9'
 ignore_opts <<  '--tags ~@requires-aruba-version-1'        if Aruba::VERSION < '1'
 ignore_opts = ignore_opts.join(' ')
 %>

--- a/features/api/filesystem/disk_usage.feature
+++ b/features/api/filesystem/disk_usage.feature
@@ -1,4 +1,3 @@
-@unsupported-on-ruby-older-19
 Feature: Report disk usage
 
   Sometimes you need to check, what amount of disk space a file consumes. We do

--- a/features/development/test.feature
+++ b/features/development/test.feature
@@ -14,7 +14,6 @@ Feature: Run test suite of aruba
     Given I successfully run `cucumber`
     Then the features should all pass
 
-  @unsupported-on-ruby-older-193
   Scenario: Testing compliance to ruby community guide
     Given I successfully run `rubocop`
     Then the features should all pass

--- a/features/getting_started/supported_testing_frameworks.feature
+++ b/features/getting_started/supported_testing_frameworks.feature
@@ -39,11 +39,7 @@ Feature: Supported Testing Frameworks
     """
     $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-    if RUBY_VERSION < '1.9.3'
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-    else
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-    end
+    ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
     """
     And a file named "spec/use_aruba_with_rspec_spec.rb" with:
     """
@@ -71,11 +67,7 @@ Feature: Supported Testing Frameworks
     """
     $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-    if RUBY_VERSION < '1.9.3'
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-    else
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-    end
+    ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
     """
     And a file named "test/use_aruba_with_minitest.rb" with:
     """
@@ -93,7 +85,7 @@ Feature: Supported Testing Frameworks
 
       def getting_started_with_aruba
         file = 'file.txt'
-        content = 'Hello World' 
+        content = 'Hello World'
 
         write_file file, content
         read(file).must_equal [content]

--- a/features/hooks/after/command.feature
+++ b/features/hooks/after/command.feature
@@ -20,11 +20,7 @@ Feature: After command hooks
   Scenario: Run a simple command with an "after(:command)"-hook
     Given a file named "spec/support/hooks.rb" with:
     """
-    if RUBY_VERSION < '1.9.3'
-      require 'aruba'
-    else
-      require_relative 'aruba'
-    end
+    require_relative 'aruba'
 
     Aruba.configure do |config|
       config.after :command do |cmd|

--- a/features/hooks/before/command.feature
+++ b/features/hooks/before/command.feature
@@ -23,11 +23,7 @@ Feature: before_cmd hooks
   Scenario: Run a simple command with a "before(:command)"-hook
     Given a file named "spec/support/hooks.rb" with:
     """
-    if RUBY_VERSION < '1.9.3'
-      require 'aruba'
-    else
-      require_relative 'aruba'
-    end
+    require_relative 'aruba'
 
     Aruba.configure do |config|
       config.before :command do |cmd|
@@ -55,11 +51,7 @@ Feature: before_cmd hooks
   Scenario: Run a simple command with a "before(:cmd)"-hook (deprecated)
     Given a file named "spec/support/hooks.rb" with:
     """
-    if RUBY_VERSION < '1.9.3'
-      require 'aruba'
-    else
-      require_relative 'aruba'
-    end
+    require_relative 'aruba'
 
     Aruba.configure do |config|
       config.before :cmd do |cmd|

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -1,25 +1,5 @@
 require 'cucumber/platform'
 
-Before '@requires-ruby-version-193' do |scenario|
-  next if RUBY_VERSION >= '1.9.3'
-
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
-end
-
-Before '@requires-ruby-version-19' do |scenario|
-  next if RUBY_VERSION >= '1.9'
-
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
-end
-
 Before '@requires-ruby-version-2' do |scenario|
   next if RUBY_VERSION >= '2'
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -25,9 +25,5 @@ Before do |scenario|
   simplecov_setup_pathname = Pathname.new(__FILE__).expand_path.parent.join('simplecov_setup')
 
   # set environment variable so child processes will merge their coverage data with parent process's coverage data.
-  ENV['RUBYOPT'] = if RUBY_VERSION < '1.9'
-                     "-r rubygems -r#{simplecov_setup_pathname} #{ENV['RUBYOPT']}"
-                   else
-                     "-r#{simplecov_setup_pathname} #{ENV['RUBYOPT']}"
-                   end
+  ENV['RUBYOPT'] = "-r#{simplecov_setup_pathname} #{ENV['RUBYOPT']}"
 end

--- a/fixtures/cli-app/lib/cli/app.rb
+++ b/fixtures/cli-app/lib/cli/app.rb
@@ -1,10 +1,6 @@
 require 'cli/app/version'
 
-if RUBY_VERSION < '1.9.3'
-  ::Dir.glob(::File.expand_path('../**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  ::Dir.glob(File.expand_path('../**/*.rb', __FILE__)).each { |f| require_relative f }
-end
+::Dir.glob(File.expand_path('../**/*.rb', __FILE__)).each { |f| require_relative f }
 
 module Cli
   module App

--- a/fixtures/cli-app/spec/spec_helper.rb
+++ b/fixtures/cli-app/spec/spec_helper.rb
@@ -2,8 +2,4 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'cli/app'
 
-if RUBY_VERSION < '1.9.3'
-  ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-end
+::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }

--- a/fixtures/empty-app/lib/cli/app.rb
+++ b/fixtures/empty-app/lib/cli/app.rb
@@ -1,10 +1,6 @@
 require 'cli/app/version'
 
-if RUBY_VERSION < '1.9.3'
-  ::Dir.glob(::File.expand_path('../**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  ::Dir.glob(File.expand_path('../**/*.rb', __FILE__)).each { |f| require_relative f }
-end
+::Dir.glob(File.expand_path('../**/*.rb', __FILE__)).each { |f| require_relative f }
 
 module Cli
   module App

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -132,17 +132,8 @@ module Aruba
         aruba.logger.warn %(`aruba`'s working directory does not exist. Maybe you forgot to run `setup_aruba` before using it's API. This warning will be an error from 1.0.0) unless Aruba.platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
         # rubocop:enable Metrics/LineLength
 
-        if RUBY_VERSION < '1.9'
-          prefix = file_name.chars.to_a[0].to_s
-          rest = if file_name.chars.to_a[2..-1].nil?
-                   nil
-                 else
-                   file_name.chars.to_a[2..-1].join
-                 end
-        else
-          prefix = file_name[0]
-          rest = file_name[2..-1]
-        end
+        prefix = file_name[0]
+        rest = file_name[2..-1]
 
         if aruba.config.fixtures_path_prefix == prefix
           path = File.join(*[aruba.fixtures_directory, rest].compact)

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -567,7 +567,7 @@ module Aruba
       def assert_exact_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_exact_output" is deprecated. Use "expect(command).to have_output \'exact\'" instead. There are also special matchers for "stdout" and "stderr"')
 
-        actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
+        actual.force_encoding(expected.encoding)
         expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).to eq Aruba.platform.unescape(expected, aruba.config.keep_ansi)
       end
 
@@ -580,7 +580,7 @@ module Aruba
       def assert_partial_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_partial_output" is deprecated. Use "expect(command).to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
 
-        actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
+        actual.force_encoding(expected.encoding)
         expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).to include(Aruba.platform.unescape(expected, aruba.config.keep_ansi))
       end
 
@@ -593,7 +593,7 @@ module Aruba
       def assert_matching_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_matching_output" is deprecated. Use "expect(command).to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
 
-        actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
+        actual.force_encoding(expected.encoding)
         expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).to match(/#{Aruba.platform.unescape(expected, aruba.config.keep_ansi)}/m)
       end
 
@@ -606,7 +606,7 @@ module Aruba
       def assert_not_matching_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_not_matching_output" is deprecated. Use "expect(command).not_to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
 
-        actual.force_encoding(expected.encoding) if RUBY_VERSION >= "1.9"
+        actual.force_encoding(expected.encoding)
         expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).not_to match(/#{Aruba.platform.unescape(expected, aruba.config.keep_ansi)}/m)
       end
 
@@ -619,7 +619,7 @@ module Aruba
       def assert_no_partial_output(unexpected, actual)
         Aruba.platform.deprecated('The use of "#assert_no_partial_output" is deprecated. Use "expect(command).not_to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
 
-        actual.force_encoding(unexpected.encoding) if RUBY_VERSION >= "1.9"
+        actual.force_encoding(unexpected.encoding)
         if Regexp === unexpected
           expect(Aruba.platform.unescape(actual, aruba.config.keep_ansi)).not_to match unexpected
         else

--- a/lib/aruba/aruba_path.rb
+++ b/lib/aruba/aruba_path.rb
@@ -54,24 +54,6 @@ module Aruba
       @delegate_sd_obj.pop
     end
 
-    if RUBY_VERSION < '1.9'
-      def to_s
-        __getobj__.to_s
-      end
-
-      def relative?
-        !(%r{\A/} === to_s)
-      end
-
-      def absolute?
-        (%r{\A/} === to_s)
-      end
-
-      def to_ary
-        to_a
-      end
-    end
-
     # How many parts has the file name
     #
     # @return [Integer]
@@ -83,14 +65,7 @@ module Aruba
     # path.depth # => 3
     #
     def depth
-      if RUBY_VERSION < '1.9'
-        items = []
-        __getobj__.each_filename { |f| items << f }
-
-        items.size
-      else
-        __getobj__.each_filename.to_a.size
-      end
+      __getobj__.each_filename.to_a.size
     end
 
     # Path ends with string
@@ -113,11 +88,7 @@ module Aruba
     #
     # @param [Integer, Range] index
     def [](index)
-      if RUBY_VERSION < '1.9'
-        to_s.chars.to_a[index].to_a.join('')
-      else
-        to_s[index]
-      end
+      to_s[index]
     end
 
     # Report count of blocks allocated on disk

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -217,11 +217,7 @@ module Aruba
 
     # Set if name is option
     def set_if_option(name, *args)
-      if RUBY_VERSION < '1.9'
-        send("#{name}=".to_sym, *args) if option? name
-      else
-        public_send("#{name}=".to_sym, *args) if option? name
-      end
+      public_send("#{name}=".to_sym, *args) if option? name
     end
 
     private

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -25,11 +25,7 @@ module Aruba
 
     option_accessor :working_directory, :contract => { Aruba::Contracts::RelativePath => Aruba::Contracts::RelativePath }, :default => 'tmp/aruba'
 
-    if RUBY_VERSION < '1.9'
-      option_reader :fixtures_path_prefix, :contract => { None => String }, :default => '%'
-    else
-      option_reader :fixtures_path_prefix, :contract => { None => String }, :default => ?%
-    end
+    option_reader :fixtures_path_prefix, :contract => { None => String }, :default => ?%
 
     option_accessor :exit_timeout, :contract => { Num => Num }, :default => 15
     option_accessor :stop_signal, :contract => { Maybe[String] => Maybe[String] }, :default => nil

--- a/lib/aruba/console/help.rb
+++ b/lib/aruba/console/help.rb
@@ -18,13 +18,7 @@ module Aruba
 
       # List available methods in aruba
       def aruba_methods
-        ms = if RUBY_VERSION < '1.9'
-               # rubocop:disable Style/EachWithObject
-               (Aruba::Api.instance_methods - Module.instance_methods).inject([]) { |a, e| a << format("* %s", e); a }.sort
-               # rubocop:enable Style/EachWithObject
-             else
-               (Aruba::Api.instance_methods - Module.instance_methods).each_with_object([]) { |e, a| a << format("* %s", e) }.sort
-             end
+        ms = (Aruba::Api.instance_methods - Module.instance_methods).each_with_object([]) { |e, a| a << format("* %s", e) }.sort
 
         puts "Available Methods:\n" + ms.join("\n")
 

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -99,11 +99,7 @@ When(/^I stop the command(?: started last)? if (output|stdout|stderr) contains:$
   begin
     Timeout.timeout(aruba.config.exit_timeout) do
       loop do
-        output = if RUBY_VERSION < '1.9.3'
-                   last_command_started.send channel.to_sym, :wait_for_io => 0
-                 else
-                   last_command_started.public_send channel.to_sym, :wait_for_io => 0
-                 end
+        output = last_command_started.public_send channel.to_sym, :wait_for_io => 0
 
         output   = sanitize_text(output)
         expected = sanitize_text(expected)

--- a/lib/aruba/event_bus/name_resolver.rb
+++ b/lib/aruba/event_bus/name_resolver.rb
@@ -10,11 +10,7 @@ module Aruba
       # Helpers for Resolvers
       module ResolveHelpers
         def camel_case(underscored_name)
-          if RUBY_VERSION < '1.9.3'
-            underscored_name.to_s.split('_').map { |word| word.upcase.chars.to_a[0] + word.chars.to_a[1..-1].join }.join
-          else
-            underscored_name.to_s.split('_').map { |word| word.upcase[0] + word[1..-1] }.join
-          end
+          underscored_name.to_s.split('_').map { |word| word.upcase[0] + word[1..-1] }.join
         end
 
         # Thanks ActiveSupport
@@ -36,11 +32,7 @@ module Aruba
             else
               candidate = constant.const_get(name)
 
-              if RUBY_VERSION < '1.9.3'
-                next candidate if constant.const_defined?(name)
-              else
-                next candidate if constant.const_defined?(name, false)
-              end
+              next candidate if constant.const_defined?(name, false)
 
               next candidate unless Object.const_defined?(name)
 

--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -83,13 +83,8 @@ module Aruba
         send creator, file, <<-EOS
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-if RUBY_VERSION < '1.9.3'
-  ::Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-  ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  ::Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
-  ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-end
+::Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
+::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
 EOS
       end
 
@@ -154,13 +149,8 @@ module Aruba
         send creator, file, <<-EOS
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-if RUBY_VERSION < '1.9.3'
-  ::Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-  ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  ::Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
-  ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-end
+::Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
+::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
 EOS
       end
 

--- a/lib/aruba/matchers/base/object_formatter.rb
+++ b/lib/aruba/matchers/base/object_formatter.rb
@@ -64,11 +64,6 @@ module Aruba
         def self.format_time(time)
           time.strftime("#{TIME_FORMAT}.#{format('%09d', time.nsec)} %z")
         end
-      else # for 1.8.7
-        # @private
-        def self.format_time(time)
-          time.strftime("#{TIME_FORMAT}.#{format('%06d', time.usec)} %z")
-        end
       end
 
       DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z".freeze

--- a/lib/aruba/platforms/aruba_file_creator.rb
+++ b/lib/aruba/platforms/aruba_file_creator.rb
@@ -22,11 +22,7 @@ module Aruba
 
         Aruba.platform.mkdir(File.dirname(path))
 
-        if RUBY_VERSION < '1.9.3'
-          File.open(path, 'w') { |f| f << content }
-        else
-          File.write(path, content)
-        end
+        File.write(path, content)
 
         self
       end

--- a/lib/aruba/platforms/aruba_logger.rb
+++ b/lib/aruba/platforms/aruba_logger.rb
@@ -18,11 +18,7 @@ module Aruba
 
     [:fatal, :warn, :debug, :info, :error, :unknown].each do |m|
       define_method m do |msg|
-        if RUBY_VERSION < '1.9'
-          logger.send m, msg
-        else
-          logger.public_send m, msg
-        end
+        logger.public_send m, msg
       end
     end
 

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -134,13 +134,7 @@ module Aruba
     def all_stdout
       registered_commands.each(&:stop)
 
-      if RUBY_VERSION < '1.9.3'
-        # rubocop:disable Style/EachWithObject
-        registered_commands.inject("") { |a, e| a << e.stdout; a }
-        # rubocop:enable Style/EachWithObject
-      else
-        registered_commands.each_with_object("") { |e, a| a << e.stdout }
-      end
+      registered_commands.each_with_object("") { |e, a| a << e.stdout }
     end
 
     # @deprecated
@@ -151,13 +145,7 @@ module Aruba
     def all_stderr
       registered_commands.each(&:stop)
 
-      if RUBY_VERSION < '1.9.3'
-        # rubocop:disable Style/EachWithObject
-        registered_commands.inject("") { |a, e| a << e.stderr; a }
-        # rubocop:enable Style/EachWithObject
-      else
-        registered_commands.each_with_object("") { |e, a| a << e.stderr }
-      end
+      registered_commands.each_with_object("") { |e, a| a << e.stderr }
     end
 
     # @deprecated

--- a/lib/aruba/platforms/filesystem_status.rb
+++ b/lib/aruba/platforms/filesystem_status.rb
@@ -22,11 +22,7 @@ module Aruba
 
       public
 
-      if RUBY_VERSION >= '1.9.3'
-        def_delegators :@status, *METHODS
-      else
-        def_delegators :@status, :executable?, :ctime, :atime, :mtime, :size
-      end
+      def_delegators :@status, *METHODS
 
       def initialize(path)
         @status = File::Stat.new(path)

--- a/lib/aruba/platforms/unix_command_string.rb
+++ b/lib/aruba/platforms/unix_command_string.rb
@@ -15,13 +15,6 @@ module Aruba
       def to_a
         Shellwords.split __getobj__
       end
-
-      if RUBY_VERSION < '1.9'
-        def to_s
-          __getobj__.to_s
-        end
-        alias inspect to_s
-      end
     end
   end
 end

--- a/lib/aruba/platforms/unix_environment_variables.rb
+++ b/lib/aruba/platforms/unix_environment_variables.rb
@@ -11,13 +11,9 @@ module Aruba
         def initialize(other_env, &block)
           @other_env = other_env
 
-          @other_env = if RUBY_VERSION <= '1.9.3'
-                         # rubocop:disable Style/EachWithObject
-                         @other_env.to_hash.inject({}) { |a, (k, v)| a[k] = v.to_s; a }
-                       # rubocop:enable Style/EachWithObject
-                       else
-                         @other_env.to_h.each_with_object({}) { |(k, v), a| a[k] = v.to_s }
-                       end
+          to_hash = RUBY_VERSION >= '2' ? :to_h : :to_hash
+
+          @other_env = @other_env.public_send(to_hash).each_with_object({}) { |(k, v), a| a[k] = v.to_s }
 
           @block = if block_given?
                      block
@@ -207,7 +203,7 @@ module Aruba
       private
 
       def prepared_environment
-        if RUBY_VERSION <= '1.9.3'
+        if RUBY_VERSION == '1.9.3'
           # rubocop:disable Style/EachWithObject
           actions.inject(ENV.to_hash.merge(env)) { |a, e| e.call(a) }
           # rubocop:enable Style/EachWithObject

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -107,11 +107,7 @@ module Aruba
       end
 
       def require_matching_files(pattern, base)
-        if RUBY_VERSION < '1.9.3'
-          ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-        else
-          ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require_relative f }
-        end
+        ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require_relative f }
       end
 
       # Create directory and subdirectories
@@ -227,13 +223,7 @@ module Aruba
 
       # Write to file
       def write_file(path, content)
-        if RUBY_VERSION < '1.9.3'
-          File.open(path, 'wb') do |f|
-            f.print content
-          end
-        else
-          File.write(path, content)
-        end
+        File.write(path, content)
       end
 
       # Unescape string

--- a/lib/aruba/platforms/windows_command_string.rb
+++ b/lib/aruba/platforms/windows_command_string.rb
@@ -18,13 +18,6 @@ module Aruba
       def to_a
         Shellwords.split __getobj__
       end
-
-      if RUBY_VERSION < '1.9'
-        def to_s
-          __getobj__.to_s
-        end
-        alias inspect to_s
-      end
     end
   end
 end

--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -36,23 +36,11 @@ module Aruba
       def initialize(env = ENV.to_hash)
         @actions = []
 
-        @env = if RUBY_VERSION <= '1.9.3'
-                 # rubocop:disable Style/EachWithObject
-                 env.inject({}) { |a, (k,v)| a[k.to_s.upcase] = v; a }
-               # rubocop:enable Style/EachWithObject
-               else
-                 env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
-               end
+        @env = env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
       end
 
       def update(other_env, &block)
-        other_env = if RUBY_VERSION <= '1.9.3'
-                      # rubocop:disable Style/EachWithObject
-                      other_env.inject({}) { |a, (k,v)| a[k.to_s.upcase] = v; a }
-                    # rubocop:enable Style/EachWithObject
-                    else
-                      other_env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
-                    end
+        other_env = other_env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
 
         super(other_env, &block)
       end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -158,11 +158,7 @@ module Aruba
       def close_io(name)
         return if stopped?
 
-        if RUBY_VERSION < '1.9'
-          @process.io.send(name.to_sym).close
-        else
-          @process.io.public_send(name.to_sym).close
-        end
+        @process.io.public_send(name.to_sym).close
       end
 
       # Stop command

--- a/spec/aruba/api/runtime_spec.rb
+++ b/spec/aruba/api/runtime_spec.rb
@@ -4,10 +4,8 @@ RSpec.describe 'aruba' do
   describe '#config' do
     subject(:config) { aruba.config }
 
-    if RUBY_VERSION >= '1.9'
-      context 'when initialized' do
-        it { is_expected.to eq Aruba.config }
-      end
+    context 'when initialized' do
+      it { is_expected.to eq Aruba.config }
     end
 
     context 'when changed earlier' do

--- a/spec/aruba/platform/windows_environment_variables_spec.rb
+++ b/spec/aruba/platform/windows_environment_variables_spec.rb
@@ -116,15 +116,11 @@ RSpec.describe Aruba::Platforms::WindowsEnvironmentVariables do
         let(:variable) { 'unknown' }
 
         context 'and no default is given' do
-          if RUBY_VERSION < '1.9'
-            it { expect { environment.fetch(variable) }.to raise_error IndexError }
-          else
-            unless defined? KeyError
-              class KeyError < StandardError; end
-            end
-
-            it { expect { environment.fetch(variable) }.to raise_error KeyError }
+          unless defined? KeyError
+            class KeyError < StandardError; end
           end
+
+          it { expect { environment.fetch(variable) }.to raise_error KeyError }
         end
 
         context 'and default is given' do
@@ -160,15 +156,11 @@ RSpec.describe Aruba::Platforms::WindowsEnvironmentVariables do
         let(:variable) { 'unknown' }
 
         context 'and no default is given' do
-          if RUBY_VERSION < '1.9'
-            it { expect { environment.fetch(variable) }.to raise_error IndexError }
-          else
-            unless defined? KeyError
-              class KeyError < StandardError; end
-            end
-
-            it { expect { environment.fetch(variable) }.to raise_error KeyError }
+          unless defined? KeyError
+            class KeyError < StandardError; end
           end
+
+          it { expect { environment.fetch(variable) }.to raise_error KeyError }
         end
 
         context 'and default is given' do
@@ -204,15 +196,11 @@ RSpec.describe Aruba::Platforms::WindowsEnvironmentVariables do
         let(:variable) { 'unknown' }
 
         context 'and no default is given' do
-          if RUBY_VERSION < '1.9'
-            it { expect { environment.fetch(variable) }.to raise_error IndexError }
-          else
-            unless defined? KeyError
-              class KeyError < StandardError; end
-            end
-
-            it { expect { environment.fetch(variable) }.to raise_error KeyError }
+          unless defined? KeyError
+            class KeyError < StandardError; end
           end
+
+          it { expect { environment.fetch(variable) }.to raise_error KeyError }
         end
 
         context 'and default is given' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,13 +11,8 @@ require 'bundler'
 Bundler.require
 
 # Loading support files
-if RUBY_VERSION < '1.9'
-  Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-  Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
-  Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-end
+Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
+Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
 
 # Avoid writing "describe LocalPac::MyClass do [..]" but "describe MyClass do [..]"
 include Aruba

--- a/spec/support/matchers/option.rb
+++ b/spec/support/matchers/option.rb
@@ -15,11 +15,7 @@ end
 RSpec::Matchers.define :have_option_value do |expected|
   match do |actual|
     @old_actual = actual
-    @actual     = if RUBY_VERSION < '1.9'
-                    subject.send(actual.to_sym)
-                  else
-                    subject.public_send(actual.to_sym)
-                  end
+    @actual     = subject.public_send(actual.to_sym)
     values_match? expected, @actual
   end
 


### PR DESCRIPTION
## Summary

Remove all code, checks and RuboCop enabling/disabling for specifics related to Ruby < 1.9.2.

## Motivation and Context

Ruby 1.9.3 has been EOL for almost a year, so ideally users should move to Ruby 2.x. This makes Ruby 1.8.7 just too ancient to work with. E.g. I can't even install 1.8.7 without bending over backwards (because building 1.8.7 requires another ruby present, older versions of libraries). Pretty much the only place where 1.8.7 used nowadays is on Travis, etc.

Removing this would make contributing much easier, especially without the need to go back-and-forth with forgotten old-style hashes (` :a => :b` vs `a: :b`).

## How Has This Been Tested?

Green on Travis. (Running tests on master locally still means lots of issues).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

(Bug, since Ruby 1.8.7 is difficult to install and there's not official support to change that).

## Checklist:

- [X] My code follows the code style of this project.
