### PR TITLE
unset BSD_ECHO for Zsh features

### DIFF
--- a/features/steps/command/shell.feature
+++ b/features/steps/command/shell.feature
@@ -72,6 +72,7 @@ Feature: Running shell commands
       Scenario: Running zsh commands
         When I run the following commands with `zsh`:
         \"\"\"bash
+        unsetopt BSD_ECHO
         echo "Hello \c"
         echo $((2 + 2))
         \"\"\"
@@ -115,6 +116,7 @@ Feature: Running shell commands
       Scenario: Running zsh commands #1
         When I run the following commands with `/bin/zsh`:
         \"\"\"bash
+        unsetopt BSD_ECHO
         echo "Hello \c"
         echo $((6 - 2))
         \"\"\"
@@ -123,6 +125,7 @@ Feature: Running shell commands
       Scenario: Running zsh commands #1
         When I run the following commands in `/bin/zsh`:
         \"\"\"bash
+        unsetopt BSD_ECHO
         echo "Hello \c"
         echo $((6 - 2))
         \"\"\"
@@ -138,6 +141,7 @@ Feature: Running shell commands
       Scenario: Running zsh commands #1
         When I run the following commands with `zsh`:
         \"\"\"bash
+        unsetopt BSD_ECHO
         echo "Hello \c"
         echo $((6 - 2))
         \"\"\"
@@ -146,6 +150,7 @@ Feature: Running shell commands
       Scenario: Running zsh commands #2
         When I run the following commands in `zsh`:
         \"\"\"bash
+        unsetopt BSD_ECHO
         echo "Hello \c"
         echo $((6 - 2))
         \"\"\"


### PR DESCRIPTION
## Summary

<!--- Provide a general summary of your changes in the Title above -->

Make Zsh shell scripts work regardless of local user Zsh configuration.

## Details

Some scenarios depend on echo allowing escape sequences.

From the Zsh manual:

```
BSD_ECHO
Make the echo builtin compatible with the BSD echo(1) command. This disables backslashed escape sequences in echo strings unless the `-e' option is specified.
```

## Motivation and Context

Having `setopt BSD_ECHO` in Zsh config files (like I did) causes shell-related scenarios to fail.
Making sure this option is unset allows tests to work locally, even if this is set.

## How Has This Been Tested?

Local tests now work. Doesn't affect anything other than those few previously-failing cucumber scenarios.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the code style of this project.