### PR TITLE
Fix broken exception handler

### DIFF
--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -115,16 +115,13 @@ module Aruba
       def after_run; end
 
       def inspect
-        out = stdout(:wait_for_io => 0) + stderr(:wait_for_io => 0)
+        out = truncate("#{stdout(:wait_for_io => 0).inspect}", 35)
+        err = truncate("#{stderr(:wait_for_io => 0).inspect}", 35)
 
-        out = if out.length > 76
-                out[0, 75] + ' ...'
-              else
-                out
-              end
-
-        format '#<%s:%s commandline="%s": output="%s">', self.class, self.object_id, commandline, out
+        fmt = '#<%s:%s commandline="%s": stdout=%s stderr=%s>'
+        format fmt, self.class, self.object_id, commandline, out, err
       end
+
       alias to_s inspect
 
       private
@@ -137,6 +134,11 @@ module Aruba
         return Shellwords.split(commandline)[1..-1] if Shellwords.split(commandline).size > 1
 
         []
+      end
+
+      def truncate(string, max_length)
+        return string if string.length <= max_length
+        string[0, max_length - 1] + ' ...'
       end
     end
   end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -83,7 +83,7 @@ module Aruba
             sleep startup_wait_time
           end
         rescue ChildProcess::LaunchError => e
-          raise LaunchError, "It tried to start #{cmd}. " + e.message
+          raise LaunchError, "It tried to start #{commandline}. " + e.message
         end
 
         after_run

--- a/spec/aruba/processes/basic_process_spec.rb
+++ b/spec/aruba/processes/basic_process_spec.rb
@@ -1,0 +1,64 @@
+require 'aruba/processes/basic_process'
+
+RSpec.describe Aruba::Processes::BasicProcess do
+  let(:cmd) { 'foobar' }
+  let(:exit_timeout) { 0 }
+  let(:io_wait_timeout) { 0 }
+  let(:working_directory) { Dir.pwd }
+  let(:stdout) { "foo output" }
+  let(:stderr) { "foo error output" }
+
+  subject do
+    Class.new(described_class) do
+      def initialize(*args)
+        @stdout = args.shift
+        @stderr= args.shift
+        super(*args)
+      end
+
+      def stdout(*args)
+        @stdout
+      end
+
+      def stderr(*args)
+        @stderr
+      end
+
+    end.new(stdout, stderr, cmd, exit_timeout, io_wait_timeout, working_directory)
+  end
+
+  describe "#inspect" do
+    it "it shows useful info" do
+      expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout="foo output" stderr="foo error output"/
+      expect(subject.inspect).to match(expected)
+    end
+
+    context "with no stdout" do
+      let(:stdout) { nil }
+
+      it "it shows useful info" do
+        expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout=nil stderr="foo error output"/
+        expect(subject.inspect).to match(expected)
+      end
+    end
+
+    context "with no stderr" do
+      let(:stderr) { nil }
+
+      it "it shows useful info" do
+        expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout="foo output" stderr=nil/
+        expect(subject.inspect).to match(expected)
+      end
+    end
+
+    context "with neither stderr nor stdout" do
+      let(:stderr) { nil }
+      let(:stdout) { nil }
+
+      it "it shows useful info" do
+        expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout=nil stderr=nil/
+        expect(subject.inspect).to match(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

An old, undefined variable (`cmd`) was left over after refactoring. It was replaced with the right one (`commandline`).

Also, a spec was added to force the code to fail on Unix.

## Details

This caused failures on AppVeyor, because the exception handler crashed.

This failed only on Windows because the PATH traversing didn't throw an error earlier.

Still, the error could've occurred on Unix if the program was in the PATH (so no exception there), and yet there was an error accessing a program's file (like if the file wasn't readable). 

## Motivation and Context

Fixes failure on AppVeyor.

## How Has This Been Tested?

Locally, RSpec.

This probably can be simulated in Cucumber scenarios by having an unreadable binary file (e.g. using `chmod -r`)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the code style of this project.
