### PR TITLE
Fix broken ENV.delete (on Windows)

### DIFF
--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -81,8 +81,8 @@ module Aruba
         super(name.upcase, value)
       end
 
-      def delete(name, value)
-        super(name.upcase, value)
+      def delete(name)
+        super(name.upcase)
       end
     end
   end

--- a/spec/aruba/platform/windows_environment_variables_spec.rb
+++ b/spec/aruba/platform/windows_environment_variables_spec.rb
@@ -497,4 +497,18 @@ RSpec.describe Aruba::Platforms::WindowsEnvironmentVariables do
       end
     end
   end
+
+  describe '#delete' do
+    let(:variable) { 'my_variable' }
+    let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+
+    it "deletes a value from the environment" do
+      environment.delete(variable)
+      expect(environment[variable]).to eq nil
+    end
+
+    it "returns deleted value" do
+      expect(environment.delete(variable)).to eq('1')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

WindowsEnvironmentVariables implemented `:delete` with 2 args instead of 1.

This was fixed and spec was added to it can be tested on Linux.

## Motivation and Context

Failed only on AppVeyor (Windows).

Related issue: https://github.com/cucumber/aruba/issues/349

## How Has This Been Tested?

RSpec, locally.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the code style of this project.
