### PR TITLE
"Compatibly" reimplement disk_usage API and logic

### DIFF
--- a/features/api/filesystem/disk_usage.feature
+++ b/features/api/filesystem/disk_usage.feature
@@ -1,14 +1,28 @@
 @unsupported-on-ruby-older-19
 Feature: Report disk usage
 
-  Sometimes you need to check, what amount of disk space a file consumes. We do
-  NOT support "directories" with `#disk_usage`. This does not work reliably
-  over different systems. Here can help `'#disk_usage`. But be careful, by
-  default it uses a block size of "512" (physical block size) to calculate the
-  usage. You may need to adjust this by using `Aruba.configure { |config|
-  config.physical_block_size = 4_096 }`. Don't get confused, if you check the
-  block size by using `File::Stat` (in ruby). It reports the block size of your
-  filesystem, which can be "4_096" for example.
+  Sometimes you need to check, what amount of disk space a file consumes.
+
+  This is useful, since many tiny files will usually take up a lot more disk
+  space than their sizes suggest.
+
+  While not be very accurate, `'#disk_usage` helps estimate this "real"
+  allocated size on disk.
+
+  NOTE 1: currently "directories" are NOT supported.
+
+  NOTE 2: Aruba assumes the 'physical block size' is 512 bytes. (It usually is).
+
+  If your OS/filesystem doesn't report the number of blocks used (and your
+  allocation unit size is not 4096 bytes), you can change the default "block
+  size" Aruba uses for calculations:
+
+  E.g. for a 32kB "allocation unit size" and 16 blocks used for a tiny file
+  (check `File::Stat.blocks` reported by Ruby), just divide the
+  two numbers to get the "physical block size" you need to set:
+
+  `Aruba.configure { |config| config.physical_block_size = 32_768 / 16 }`.
+
 
   We're gonna use the (correct) IEC-notation
   (https://en.wikipedia.org/wiki/Binary_prefix) here:
@@ -16,6 +30,7 @@ Feature: Report disk usage
     \* kilo => kibi
     \* mega => mebi
     \* giga => gibi
+
 
   Background:
     Given I use a fixture named "cli-app"

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -372,10 +372,25 @@ module Aruba
       #
       # @result [FileSize]
       #   Bytes on disk
+
+      TYPICAL_FS_UNIT = 4096 # Very typical, except for giant or embedded filesystems
+      TYPICAL_DEV_BSIZE = 512 # Google DEV_BSIZE for more info
+
       def disk_usage(*paths)
         expect(paths.flatten).to Aruba::Matchers.all be_an_existing_path
+        expanded = paths.flatten.map { |p| ArubaPath.new(expand_path(p)) }
 
-        Aruba.platform.determine_disk_usage paths.flatten.map { |p| ArubaPath.new(expand_path(p)) }, aruba.config.physical_block_size
+        # TODO: change the API so that you could set something like
+        # aruba.config.fs_allocation_unit_size directly
+
+        block_multiplier = TYPICAL_FS_UNIT / TYPICAL_DEV_BSIZE
+        fs_unit_size = aruba.config.physical_block_size * block_multiplier
+
+        # TODO: the size argument here is unnecessary - ArubaPath should decide
+        # what the disk usage of a file is (even if Aruba.config needs to be
+        # read)
+        deprecated_block_count = fs_unit_size / block_multiplier
+        Aruba.platform.determine_disk_usage(expanded, deprecated_block_count)
       end
 
       # Get size of file

--- a/lib/aruba/aruba_path.rb
+++ b/lib/aruba/aruba_path.rb
@@ -126,8 +126,61 @@ module Aruba
     #
     # @return [Integer]
     #   The count of blocks on disk
+    #
+    # @deprecated
     def blocks
-      File::Stat.new(to_s).blocks
+      min_bytes_used = minimum_disk_space_used
+      min_bytes_used / Aruba.config.physical_block_size
+    end
+
+    # TODO: Aruba.config.physical_block_size could be allowed to be nil
+    # (So the unit size can be autodetected)
+
+    TYPICAL_FS_UNIT = 4096
+    TYPICAL_DEV_BSIZE = 512 # Google DEV_BSIZE for more info
+
+    # Report minimum disk space used
+    #
+    # This estimates the minimum bytes allocated by the path.
+    #
+    # E.g. a 1-byte text file on a typical EXT-3 filesystem takes up 4096 bytes
+    # (could be more if it was truncated or less for sparse files).
+    #
+    # Both `File::Stat` and the `stat()` system call will report 8 `blocks`
+    # (each "usually" represents 512 bytes). So 8 * 512 is exactly 4096 bytes.
+    #
+    # (The "magic" 512 bye implied makes the value of "blocks" so confusing).
+    #
+    # Currently Aruba allows you to set what's called the `physical_block_size`,
+    # which is a bit misleading - it's the "512" value. So if you somehow have a
+    # "filesystem unit size" of 8192 (instead of a typical 4KB), set the
+    # `physical_block_size` to 1024 (yes, divide by 8: 8192/8 = 1024).
+    #
+    # Ideally, Aruba should provide e.g. `Aruba.config.fs_allocation_unit`
+    # (with 4096 as the default), so you wouldn't have to "divide by 8".
+    #
+    # (TYPICAL_FS_UNIT / TYPICAL_DEV_BSIZE = 4096 / 512 = 8)
+    #
+    #
+    # @return [Integer]
+    #   Total bytes allocate
+    #
+    # TODO: this is recommended over the above "blocks"
+    def minimum_disk_space_used
+      # TODO: replace Aruba.config.physical_block_size
+      # with something like Aruba.config.fs_allocation_unit
+      dev_bsize = Aruba.config.physical_block_size
+
+      stat = File::Stat.new(to_s)
+
+      blocks = stat.blocks
+      return (blocks * dev_bsize) if blocks
+
+      block_multiplier = TYPICAL_FS_UNIT / TYPICAL_DEV_BSIZE
+      fs_unit_size = dev_bsize * block_multiplier
+      fs_units = (stat.size + fs_unit_size - 1) / fs_unit_size
+      fs_units = 1 if fs_units.zero?
+      fs_units * fs_unit_size
     end
   end
 end

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -62,6 +62,9 @@ module Aruba
     option_accessor :log_level, :contract => { Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] => Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] }, :default => :info
     # rubocop:enable Metrics/LineLength
 
+    # TODO: deprecate this value and replace with "filesystem allocation unit"
+    # equal to 4096 by default. "filesystem allocation unit" would represent
+    # the actual MINIMUM space taken in bytes by a 1-byte file
     option_accessor :physical_block_size, :contract => { Aruba::Contracts::IsPowerOfTwo => Aruba::Contracts::IsPowerOfTwo }, :default => 512
     option_accessor :console_history_file, :contract => { String => String }, :default => '~/.aruba_history'
 

--- a/lib/aruba/platforms/determine_disk_usage.rb
+++ b/lib/aruba/platforms/determine_disk_usage.rb
@@ -11,13 +11,18 @@ module Aruba
       def call(*args)
         args = args.flatten
 
-        physical_block_size = args.pop
+        deprecated_block_size = args.pop
         paths = args
 
         size = paths.flatten.map do |p|
+          # TODO: replace the `call` methods signature so that you can use just
+          # p.minimum_disk_space_used
+          #
+          # (Same result, since the values are multiplied, so
+          # deprecated_block_size is canceled out
           DiskUsageCalculator.new.call(
-            p.blocks,
-            physical_block_size
+            (p.minimum_disk_space_used / deprecated_block_size),
+            deprecated_block_size
           )
         end.inject(0, &:+)
 

--- a/spec/aruba/aruba_path_spec.rb
+++ b/spec/aruba/aruba_path_spec.rb
@@ -94,10 +94,103 @@ RSpec.describe Aruba::ArubaPath do
 
   describe '#blocks' do
     let(:new_path) { expand_path('path/to/file') }
+    let(:stat) { instance_double(File::Stat) }
 
-    before(:each) { FileUtils.mkdir_p File.dirname(new_path) }
-    before(:each) { File.open(new_path, 'w') { |f| f.print 'a' } }
+    subject do
+      path.blocks
+    end
 
-    it { expect(path.blocks).to be > 0 }
+    before do
+      allow(File::Stat).to receive(:new).and_return(stat)
+      allow(stat).to receive(:blocks).and_return(blocks)
+      allow(stat).to receive(:size) { size }
+    end
+
+    context "when blocks info is available" do
+      let(:blocks) { 8 }
+      it { is_expected.to eq 8 }
+    end
+
+    context "when blocks info is not available" do
+      let(:blocks) { nil }
+
+      context "when blksize is 512" do
+        before do
+          allow(Aruba.config).to receive(:physical_block_size).and_return(512)
+        end
+
+        context "when file is empty" do
+          let(:size) { 0 }
+          it { is_expected.to eq 8 } # on 4k block neede
+        end
+
+        context "when file is tiny" do
+          let(:size) { 1 }
+          it { is_expected.to eq 8 } # 8 * 512 = one 4k block
+        end
+
+        context "when the file would barely fit in a unit" do
+          let(:size) { 4096 }
+          it { is_expected.to eq 8 }
+        end
+
+        context "when the file wouldn't fit in a 4k unit" do
+          let(:size) { 4096 + 1 }
+          it { is_expected.to eq 16 }
+        end
+
+        context "when the file doesn't fit in 2 units" do
+          let(:size) { 2 * 4096 + 1}
+          it { is_expected.to eq 24 } # 24 * 512b blocks = 3 * 4kB units
+        end
+
+        context "when the file doesn't fit in multiple units" do
+          let(:size) { 50_000 }
+          it { is_expected.to eq 104 }  # 13 * 4k units = 140 * 512 byte blocks
+        end
+      end
+
+      context "when blksize is 256" do
+        before do
+          # NOTE: 256 means an actual filesystem allocation unit of 2048
+          allow(Aruba.config).to receive(:physical_block_size).and_return(256)
+        end
+
+        context "when file is empty" do
+          let(:size) { 0 }
+          it { is_expected.to eq 8 }
+        end
+
+        context "when file is tiny" do
+          let(:size) { 1 }
+          it { is_expected.to eq 8 } # 8 * 256 = 2kB block
+        end
+
+        context "when the file fits in the configure block size" do
+          let(:size) { 2048 - 1 }
+          it { is_expected.to eq 8 }
+        end
+
+        context "when the file barely fits in the configured block size" do
+          let(:size) { 2048 }
+          it { is_expected.to eq 8 } # 8 Aruba-sized blocks = (2kB)
+        end
+
+        context "when the file doesn't fit in the configured block size" do
+          let(:size) { 2048 + 1 }
+          it { is_expected.to eq 16 } # 16 Aruba-sized blocks = 2 * 2kB units
+        end
+
+        context "when the file doesn't fit in 2 blocks of configured size" do
+          let(:size) { 2 * 2048 + 1 }
+          it { is_expected.to eq 24 } # 24 * 256b blocks = 3 * 2048b units
+        end
+
+        context "when the file doesn't fit in more blocks of configured size" do
+          let(:size) { 12 * 2048 + 1 }
+          it { is_expected.to eq 104 } # 104 * 256b blocks =  13 * 4kB units
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implement `ArubaPath#blocks` by guessing when it's not available for a given filesystem.

NOTE: If the block size cannot be determined, a default of 4096 is used. (I'm aware this is different from the default of `Aruba.config.physical_block_size`, which has a default of 512 - I believe it should be 4096).

## Details

The formula is basically asking "how many blocks are needed to at least fit the file's size?".

A spec was added to test various edge values.

## Motivation and Context

If `File::Stat.blocks` is nil, guessing is a better option than nothing.

Also, "disk usage" based on "blocks reported by stat()" is unreliable because of filesystem metadata and things like compression/deduplication (e.g. BTRFS).

So since disk usage is a "guess" at best anyway, I implemented this by calculating the blocks based on the file size. Primitive filesystems (e.g FAT) are likely more conservative with blocks, so it seems reasonable.

And there are network filesystem where we'll "never know" anyway.

Futher more, network filesystems won't even tell you what the `blksize` is, so that has to be "guessed" too.

I assumed: 4096 bytes. This seems reasonable because:

1. Only exotic filesystems and ones with custom settings have different values.
2. It's a sane balance between many small files and losing too much disk space.
3. Most Windows filesystems (where it's the usually case where values aren't available) usually defaults to 4k anyway
4. People likely aren't going to be using Aruba for calculating disk space on humongous filesystems
5. Most large-blocked local filesystems usually will likely be advanced enough to provide the info available anyway
6. Systems with smaller block sizes will be "overestimated", which is still a good thing. This doesn't matter much, because either the usage will exceed the device size (or be close), so people will notice ... or ... for lots of large files filling up the media, the total "margin of error" will be small.
7. Even mission-critical systems aren't likely going to rely on disk usage, which is to error-prone in theory alone.

So I see no downside. 

## How Has This Been Tested?

Specs added and they pass (locally). File::Stat is mocked, so whatever my own filesystem reports is irrelevant. 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

(The "guessing" could be unexpected, but assuming disk usage measurement can be accurate is ... incorrect anyway).

## Checklist:

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] Documentation has been updated
