### PR TITLE
ignore table headers on 'following files exist:' step

### DIFF
--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -79,7 +79,7 @@ When(/^I cd to "([^"]*)"$/) do |dir|
 end
 
 Then(/^the following files should (not )?exist:$/) do |negated, files|
-  files = files.rows.flatten
+  files = files.raw.flatten
 
   if negated
     expect(files).not_to include an_existing_file


### PR DESCRIPTION
## Summary

Fixes the "the following files should exist:" cucumber step table handling so it checks all files supplied.

## Details

I had started with a cucumber scenario in which it wasn't failing like I expected to. I added a header to the table that was using the "following files should exist" table and then it failed. However, the documentation and tests for that rule i.e. https://github.com/cucumber/aruba/blob/master/features/cli/init.feature#L11 have without a header.

## How Has This Been Tested?

There are existing tests for this, however, they weren't actually testing it correctly. Now they do.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] My code follows the code style of this project.