### PR TITLE
Drop unsupported rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: ruby
 script: script/test
 install: script/bootstrap --without development debug
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.8
@@ -13,7 +11,6 @@ rvm:
   - jruby
   - jruby-20mode
   - jruby-21mode
-  - rbx
 matrix:
   include:
     - rvm: jruby-9.0.1.0
@@ -23,7 +20,6 @@ matrix:
     - rvm: jruby-9.0.1.0-21mode
       env: JRUBY_OPTS='--dev'
   allow_failures:
-  - rvm: rbx
   - rvm: jruby-9.0.1.0
     env: JRUBY_OPTS='--dev'
   - rvm: jruby-9.0.1.0-20mode

--- a/History.md
+++ b/History.md
@@ -1,5 +1,6 @@
 ## [v1.0.0.alpha](https://github.com/cucumber/aruba/compare/v0.14.1...v1.0.0.alpha)
 
+* Drop support for ruby < 1.9.3 and rubinius
 * Fixed wrong number of arguments in `Aruba::Platforms::WindowsEnvironmentVariables#delete` (issue #349, PR #358, credit @e2)
 * Fixed colors in `script/bootstrap` (PR  #352, credit @e2)
 * Fixed use of removed `Utils`-module (PR #347, credit @e2)

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -13,32 +13,19 @@ Gem::Specification.new do |s|
   s.email       = 'cukes@googlegroups.com'
   s.homepage    = 'http://github.com/cucumber/aruba'
 
-  s.add_runtime_dependency 'cucumber', '>= 1.3.19'
+  s.add_runtime_dependency 'cucumber', '~> 2.3.0'
   s.add_runtime_dependency 'childprocess', '~> 0.5.6'
   s.add_runtime_dependency 'ffi', '~> 1.9.10'
-  s.add_runtime_dependency 'rspec-expectations', '>= 2.99'
-  s.add_runtime_dependency 'contracts', '~> 0.9'
+  s.add_runtime_dependency 'rspec-expectations', '~> 3.4.0'
+  s.add_runtime_dependency 'contracts', '~> 0.14'
   s.add_runtime_dependency 'thor', '~> 0.19'
 
   s.add_development_dependency 'bundler', '~> 1.11'
-
   s.rubygems_version = ">= 1.6.1"
+  s.required_ruby_version = '>= 1.9.3'
 
-  if Aruba::VERSION >= '1'
-    s.required_ruby_version = '>= 1.9.3'
-  else
-    s.required_ruby_version = '>= 1.8.7'
-
-    s.post_install_message = <<-EOS
-Use on ruby 1.8.7
-* Make sure you add something like that to your `Gemfile`. Otherwise you will
-  get cucumber > 2 and this will fail on ruby 1.8.7
-
-  gem 'cucumber', '~> 1.3.20'
-
-With aruba >= 1.0 there will be breaking changes. Make sure to read https://github.com/cucumber/aruba/blob/master/History.md for 1.0.0
-EOS
-  end
+  # s.post_install_message = <<-EOS
+  # EOS
 
   s.files            = `git ls-files`.split("\n")
   s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")


### PR DESCRIPTION
## Summary

This PR drops supported for unsupported rubies from 1.0.0 on.