### PR TITLE
Prevent duplicate output for commands.

### DIFF
--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -70,7 +70,7 @@ module Aruba
                  all_commands
                end
 
-        cmds.each(&:stop)
+        cmds.each { |cmd| cmd.stop unless cmd.stopped? }
 
         self
       end

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -48,6 +48,8 @@ module Aruba
 
     # Stop command
     def stop(*)
+      fail Aruba::UserError, 'Please start a command first, before stopping it' if __getobj__.stopped?
+
       __getobj__.stop
       event_bus.notify Events::CommandStopped.new(self)
 
@@ -56,6 +58,8 @@ module Aruba
 
     # Terminate command
     def terminate(*)
+      return if __getobj__.stopped?
+
       __getobj__.terminate
       event_bus.notify Events::CommandStopped.new(self)
 
@@ -64,6 +68,8 @@ module Aruba
 
     # Start command
     def start
+      fail Aruba::UserError, 'Please stop a command first, before starting it' if __getobj__.started?
+
       __getobj__.start
       event_bus.notify Events::CommandStarted.new(self)
 

--- a/lib/aruba/matchers/command/have_exit_status.rb
+++ b/lib/aruba/matchers/command/have_exit_status.rb
@@ -20,7 +20,7 @@ RSpec::Matchers.define :have_exit_status do |expected|
   match do |actual|
     @old_actual = actual
 
-    @old_actual.stop
+    @old_actual.stop unless @old_actual.stopped?
     @actual = actual.exit_status
 
     next false unless @old_actual.respond_to? :exit_status

--- a/lib/aruba/matchers/command/have_finished_in_time.rb
+++ b/lib/aruba/matchers/command/have_finished_in_time.rb
@@ -26,7 +26,7 @@ RSpec::Matchers.define :have_finished_in_time do
 
     next false unless @old_actual.respond_to? :timed_out?
 
-    @old_actual.stop
+    @old_actual.stop unless @old_actual.stopped?
 
     @old_actual.timed_out? == false
   end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -906,7 +906,7 @@ describe Aruba::Api do
 
   describe 'tags' do
     describe '@announce_stdout' do
-      after(:each) { @aruba.all_commands.each(&:stop) }
+      after(:each) { @aruba.stop_all_commands }
 
       context 'enabled' do
         before :each do
@@ -936,7 +936,7 @@ describe Aruba::Api do
 
   describe '#run_command' do
     before(:each){ @aruba.run_command 'cat' }
-    after(:each) { @aruba.all_commands.each(&:stop) }
+    after(:each) { @aruba.stop_all_commands }
 
     it "respond to input" do
       @aruba.type "Hello"
@@ -974,7 +974,7 @@ describe Aruba::Api do
 
   describe "#set_environment_variable" do
     after(:each) do
-      @aruba.all_commands.each(&:stop)
+      @aruba.stop_all_commands
     end
 
     it "set environment variable" do

--- a/spec/aruba/command_spec.rb
+++ b/spec/aruba/command_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe Aruba::Command do
+  subject do
+    described_class.new(
+      'true',
+      event_bus: event_bus,
+      exit_timeout: exit_timeout,
+      io_wait_timeout: io_wait_timeout,
+      working_directory: working_directory,
+      environment: environment,
+      main_class: main_class,
+      stop_signal: stop_signal,
+      startup_wait_time: startup_wait_time
+    )
+  end
+
+  let(:event_bus) { instance_double('Aruba::EventBus') }
+  let(:exit_timeout) { 1 }
+  let(:io_wait_timeout) { 1 }
+  let(:working_directory) { expand_path('.') }
+  let(:environment) { ENV.to_hash }
+  let(:main_class) { nil }
+  let(:stop_signal) { nil }
+  let(:startup_wait_time) { 1 }
+
+  context '#started' do
+    before :each do
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStarted) }
+    end
+
+    before :each do
+      subject.start
+    end
+
+    it { is_expected.to be_started }
+  end
+
+  context '#stopped' do
+    before :each do
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStarted) }
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStopped) }
+    end
+
+    before :each do
+      subject.start
+      subject.stop
+    end
+
+    it { is_expected.to be_stopped }
+  end
+
+  context '#terminate' do
+    before :each do
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStarted) }
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStopped) }
+    end
+
+    before :each do
+      subject.start
+      subject.terminate
+    end
+
+    it { is_expected.to be_stopped }
+  end
+end


### PR DESCRIPTION
## Summary

This should fix  #374.

<!-- This sections are meant as guidance for you. If some doesn't fit, skip them. -->

<!--- Provide a general summary of your changes in the Title above -->
## Details

If a user decides to use `run_simple`, a command is stopped twice:
1. After the configured wait time
2. On the end of test suite via `terminate_all_commands`

This makes the output appear twice. This is fixed by this PR.

It also makes a method call fail if:

1. Command already stopped, `#stop` is called again
2. Command has not been started, but is `#stop`ped

TODO: This PR needs some feature tests + Unit tests for the changed functionality.

<!--- Describe your changes in detail -->
## Motivation and Context

Having that many output makes it difficult to find information within the output.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
## How Has This Been Tested?

<!--- Please add tests for bugs and new features otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, tests ran to see how -->

<!--- your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

