### PR TITLE
JRuby 9k fails cuke tests where the output contain non-English characters

### DIFF
--- a/lib/aruba/matchers/string/include_output_string.rb
+++ b/lib/aruba/matchers/string/include_output_string.rb
@@ -19,6 +19,7 @@
 #     end
 RSpec::Matchers.define :include_output_string do |expected|
   match do |actual|
+    actual.force_encoding('UTF-8')
     @expected = Regexp.new(Regexp.escape(sanitize_text(expected.to_s)), Regexp::MULTILINE)
     @actual   = sanitize_text(actual)
 

--- a/lib/aruba/matchers/string/match_output_string.rb
+++ b/lib/aruba/matchers/string/match_output_string.rb
@@ -19,6 +19,7 @@
 #     end
 RSpec::Matchers.define :match_output_string do |expected|
   match do |actual|
+    actual.force_encoding('UTF-8')
     @expected = Regexp.new(unescape_text(expected), Regexp::MULTILINE)
     @actual   = sanitize_text(actual)
 

--- a/lib/aruba/matchers/string/output_string_eq.rb
+++ b/lib/aruba/matchers/string/output_string_eq.rb
@@ -19,6 +19,7 @@
 #     end
 RSpec::Matchers.define :output_string_eq do |expected|
   match do |actual|
+    actual.force_encoding('UTF-8')
     @expected = sanitize_text(expected.to_s)
     @actual   = sanitize_text(actual.to_s)
 

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -64,6 +64,9 @@ module Aruba
         @stdout_file.sync = true
         @stderr_file.sync = true
 
+        @stdout_file.binmode
+        @stderr_file.binmode
+
         @exit_status = nil
         @duplex      = true
 


### PR DESCRIPTION
## Summary

JRuby 9.0.5.0 fails cuke tests where the output contain non-English characters.
## Details

I tracked this down to an encoding error reported in childprocess when pumping data from the invoked command to the stdout tempfile. My fix is to set the stdout and stderr output files to be in binmode, and then the string matchers for the output declare that the actual result (read from the tempfiles as binary data) is actually UTF-8. This causes no harm in old JRuby or MRI afaict; my cuke tests for my application pass with this fix in place just like they passed before.
## Motivation and Context

Cuke tests for the DataStax Ruby driver failed against jruby 9k, a platform we are trying to support now.
## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

Sorry, don't have aruba tests. :(

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, tests ran to see how -->

<!--- your change affects other areas of the code, etc. -->

The cuke test that failed (there are several that failed the same way, but I focused on this one): https://github.com/datastax/ruby-driver/blob/master/features/asynchronous_io/executing_queries.feature#L45-L62

The error occurred in the "When it is executed" part:
https://datastax-oss.atlassian.net/browse/RUBY-163

Fixing SpawnProcess.start got past this error, but the "Then" clause started failing with an encoding error. I introduced the force_encoding of actual results in relevant functions to fix that. 

I did test that my cuke tests pass on MRI 2.3 and JRuby 1.7.x with these changes, so it doesn't seem like I introduced a regression.
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  I'm not sure if this will break anyone. Changing those matchers to assume 'actual' is utf-8 _might_ be overzealous.
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
