### PR TITLE
Actually fail the build if rake test fails

### DIFF
--- a/script/test
+++ b/script/test
@@ -6,5 +6,4 @@ if [ "$RUN_IN_DOCKER" == '1' ]; then
   bundle exec rake "docker:run[$*]"
 else
   bundle exec rake test $*
-  echo bundle exec rake test $*
 fi


### PR DESCRIPTION
## Summary

Fixes script/test so its exit code is that of rake rather than of echo.

## Motivation and Context

The Travis builds seem green, but if you look at the logs there are a lot of failed scenarios. It seems a lot of things are broken and actually failing the build is a first step to fixing them.