### PR TITLE
Improve frozen-string-literals compatibility.

### DIFF
--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -134,7 +134,7 @@ module Aruba
     def all_stdout
       registered_commands.each(&:stop)
 
-      registered_commands.each_with_object("") { |e, a| a << e.stdout }
+      registered_commands.each_with_object("".dup) { |e, a| a << e.stdout }
     end
 
     # @deprecated
@@ -145,7 +145,7 @@ module Aruba
     def all_stderr
       registered_commands.each(&:stop)
 
-      registered_commands.each_with_object("") { |e, a| a << e.stderr }
+      registered_commands.each_with_object("".dup) { |e, a| a << e.stderr }
     end
 
     # @deprecated


### PR DESCRIPTION
## Summary

Some changes to get Aruba in a state that's happy to run when the `--enable-frozen-string-literal` flag is being used. 

## Motivation and Context

I'm trying to get the RSpec test suite to a point where it can run with frozen string literals on MRI 2.4, and it makes use of Cucumber and Aruba, hence this patch (and another shortly for Cucumber as well).

## How Has This Been Tested?

The test suite for Aruba doesn't seem to be passing in its current state? So, my testing of this patch was done via running the Cucumber and rspec-core suites instead (which make use of Aruba). Hence, these patches may not be all the places where frozen string literals are being misused, but they're certainly the only places that crop up via either of the other test suites.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Depends if you consider supporting frozen string literals a feature or a bug. ¯\_(ツ)_/¯

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

As discussed above, the test suite in master wasn't green. Also, my changes don't require new tests (though at some point it'd be nice to have the test suite run in MRI 2.4 with the frozen string literal flag, to avoid regressions).