### PR TITLE
Rename methods which run commands

### DIFF
--- a/features/02_configure_aruba/basics.feature
+++ b/features/02_configure_aruba/basics.feature
@@ -35,12 +35,12 @@ Feature: Usage of configuration
 
     RSpec.describe 'Run command', :type => :aruba do
       context 'when fast command' do
-        before(:each) { run('aruba-test-cli 0') }
+        before(:each) { run_command('aruba-test-cli 0') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command' do
-        before(:each) { run('aruba-test-cli 2') }
+        before(:each) { run_command('aruba-test-cli 2') }
         it { expect(last_command_started).not_to be_successfully_executed }
       end
     end
@@ -78,17 +78,17 @@ Feature: Usage of configuration
 
     RSpec.describe 'Run command', :type => :aruba do
       context 'when fast command' do
-        before(:each) { run('aruba-test-cli 0') }
+        before(:each) { run_command('aruba-test-cli 0') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command and this is known by the developer', :slow_command => true do
-        before(:each) { run('aruba-test-cli 2') }
+        before(:each) { run_command('aruba-test-cli 2') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command, but this might be a failure' do
-        before(:each) { run('aruba-test-cli 2') }
+        before(:each) { run_command('aruba-test-cli 2') }
         it { expect(last_command_started).not_to be_successfully_executed }
       end
     end

--- a/features/02_configure_aruba/command_runtime_environment.feature
+++ b/features/02_configure_aruba/command_runtime_environment.feature
@@ -27,7 +27,7 @@ Feature: Define default process environment
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=x' }
@@ -50,7 +50,7 @@ Feature: Define default process environment
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', 'z' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=z' }
@@ -73,7 +73,7 @@ Feature: Define default process environment
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'z' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=xz' }
@@ -96,7 +96,7 @@ Feature: Define default process environment
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'z' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=zx' }
@@ -119,7 +119,7 @@ Feature: Define default process environment
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE' }

--- a/features/03_testing_frameworks/rspec/hooks/define_after_hook_for_commands.feature
+++ b/features/03_testing_frameworks/rspec/hooks/define_after_hook_for_commands.feature
@@ -33,7 +33,7 @@ Feature: After command hooks
     require 'spec_helper'
 
     RSpec.describe 'Hooks', :type => :aruba do
-      before(:each) { run_simple 'echo running' }
+      before(:each) { run_command_and_stop 'echo running' }
 
       it { expect(last_command_started.stdout.chomp).to eq 'running' }
     end

--- a/features/03_testing_frameworks/rspec/hooks/define_before_hook_for_commands.feature
+++ b/features/03_testing_frameworks/rspec/hooks/define_before_hook_for_commands.feature
@@ -36,7 +36,7 @@ Feature: before_cmd hooks
     require 'spec_helper'
 
     RSpec.describe 'Hooks', :type => :aruba do
-      before(:each) { run_simple 'echo running' }
+      before(:each) { run_command_and_stop 'echo running' }
 
       it { expect(last_command_started.stdout.chomp).to eq 'running' }
     end
@@ -64,7 +64,7 @@ Feature: before_cmd hooks
     require 'spec_helper'
 
     RSpec.describe 'Hooks', :type => :aruba do
-      before(:each) { run_simple 'echo running' }
+      before(:each) { run_command_and_stop 'echo running' }
 
       it { expect(last_command_started.stdout.chomp).to eq 'running' }
     end

--- a/features/04_aruba_api/command/find_a_started_command.feature
+++ b/features/04_aruba_api/command/find_a_started_command.feature
@@ -11,7 +11,7 @@ Feature: Find a started command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello') }
+      before(:each) { run_command('echo hello') }
       let(:command) { find_command('echo hello') }
 
       before(:each) { stop_all_commands }
@@ -44,8 +44,8 @@ Feature: Find a started command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello1') }
-      before(:each) { run('echo hello2') }
+      before(:each) { run_command('echo hello1') }
+      before(:each) { run_command('echo hello2') }
       let(:command) { find_command('echo hello1') }
 
       before(:each) { stop_all_commands }
@@ -67,9 +67,9 @@ Feature: Find a started command
 
     RSpec.describe 'Run command', :type => :aruba do
       before(:each) { set_environment_variable 'ENV_VAR', '1' }
-      before(:each) { run('bash -c "echo -n $ENV_VAR"') }
+      before(:each) { run_command('bash -c "echo -n $ENV_VAR"') }
       before(:each) { set_environment_variable 'ENV_VAR', '2' }
-      before(:each) { run('bash -c "echo -n $ENV_VAR"') }
+      before(:each) { run_command('bash -c "echo -n $ENV_VAR"') }
 
       let(:command) { find_command('bash -c "echo -n $ENV_VAR"') }
 

--- a/features/04_aruba_api/command/read_stderr_of_command.feature
+++ b/features/04_aruba_api/command/read_stderr_of_command.feature
@@ -18,7 +18,7 @@ Feature: Access STDERR of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
       it { expect(last_command_started.stderr).to start_with  'Hello' }
     end
@@ -38,7 +38,7 @@ Feature: Access STDERR of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :io_wait_timeout => 2 do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started.stderr).to start_with 'Hello' }
     end
     """

--- a/features/04_aruba_api/command/read_stdout_of_command.feature
+++ b/features/04_aruba_api/command/read_stdout_of_command.feature
@@ -18,7 +18,7 @@ Feature: Access STDOUT of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
       it { expect(last_command_started.stdout).to start_with  'Hello' }
     end
@@ -38,7 +38,7 @@ Feature: Access STDOUT of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :io_wait_timeout => 2 do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started.stdout).to start_with 'Hello' }
     end
     """

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -7,7 +7,7 @@ Feature: Run command
 
     Given this option `aruba` waits n seconds after it started the command.
     This is most useful when using `#run()` and not really makes sense for
-    `#run_simple()`.
+    `#run_command_and_stop()`.
 
     You can use `#run()` + `startup_wait_time` to start background jobs.
 

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -6,10 +6,10 @@ Feature: Run command
   - `startup_wait_time`:
 
     Given this option `aruba` waits n seconds after it started the command.
-    This is most useful when using `#run()` and not really makes sense for
+    This is most useful when using `#run_command()` and not really makes sense for
     `#run_command_and_stop()`.
 
-    You can use `#run()` + `startup_wait_time` to start background jobs.
+    You can use `#run_command()` + `startup_wait_time` to start background jobs.
 
   - `exit_timeout`:
 
@@ -34,7 +34,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -52,7 +52,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('bin/aruba-test-cli') }
+      before(:each) { run_command('bin/aruba-test-cli') }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -66,7 +66,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Find path for command', :type => :aruba do
-      it { expect { run('aruba-test-cli') }.to raise_error Aruba::LaunchError, /Command "aruba-test-cli" not found in PATH-variable/ }
+      it { expect { run_command('aruba-test-cli') }.to raise_error Aruba::LaunchError, /Command "aruba-test-cli" not found in PATH-variable/ }
     end
     """
     When I run `rspec`
@@ -112,7 +112,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 2 do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { last_command_started.send_signal 'HUP' }
 
       it { expect(last_command_started).to be_successfully_executed }
@@ -145,7 +145,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 3 do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output /Hello, Aruba here/ }
@@ -220,8 +220,8 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1 do
-      before(:each) { run('aruba-test-cli1', 3, 0.1, 'TERM', 2) }
-      before(:each) { run('aruba-test-cli2', 3, 0.1, 'TERM', 1) }
+      before(:each) { run_command('aruba-test-cli1', 3, 0.1, 'TERM', 2) }
+      before(:each) { run_command('aruba-test-cli2', 3, 0.1, 'TERM', 1) }
       before(:each) { last_command_started.send_signal 'HUP' }
 
       it { expect(last_command_started).to be_successfully_executed }
@@ -298,8 +298,8 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1 do
-      before(:each) { run('aruba-test-cli1', :startup_wait_time => 2) }
-      before(:each) { run('aruba-test-cli2', :startup_wait_time => 1) }
+      before(:each) { run_command('aruba-test-cli1', :startup_wait_time => 2) }
+      before(:each) { run_command('aruba-test-cli2', :startup_wait_time => 1) }
       before(:each) { last_command_started.send_signal 'HUP' }
 
       it { expect(last_command_started).to be_successfully_executed }
@@ -342,8 +342,8 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli1', 3) }
-      before(:each) { run('aruba-test-cli2', 1) }
+      before(:each) { run_command('aruba-test-cli1', 3) }
+      before(:each) { run_command('aruba-test-cli2', 1) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output /Hello, Aruba here/ }
@@ -383,8 +383,8 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli1', :exit_timeout => 3) }
-      before(:each) { run('aruba-test-cli2', :exit_timeout => 1) }
+      before(:each) { run_command('aruba-test-cli1', :exit_timeout => 3) }
+      before(:each) { run_command('aruba-test-cli2', :exit_timeout => 1) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output /Hello, Aruba here/ }
@@ -404,7 +404,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       let!(:found_command) { find_command('aruba-test-cli') }
       it { expect { found_command.start }.to raise_error Aruba::CommandAlreadyStartedError }
     end

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -1,6 +1,6 @@
 Feature: Run command in a simpler fashion
 
-  To run a command use the `#run_simple`-method. There are some configuration options
+  To run a command use the `#run_command_and_stop`-method. There are some configuration options
   which are relevant here:
 
   - `fail_on_error`:
@@ -23,7 +23,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      it { expect { run_simple('aruba-test-cli') }.to raise_error RSpec::Expectations::ExpectationNotMetError }
+      it { expect { run_command_and_stop('aruba-test-cli') }.to raise_error RSpec::Expectations::ExpectationNotMetError }
     end
     """
     When I run `rspec`
@@ -40,7 +40,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      it { expect { run_simple('aruba-test-cli', :fail_on_error => true) }.to raise_error }
+      it { expect { run_command_and_stop('aruba-test-cli', :fail_on_error => true) }.to raise_error }
     end
     """
     When I run `rspec`
@@ -57,7 +57,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      it { expect { run_simple('aruba-test-cli', true) }.to raise_error }
+      it { expect { run_command_and_stop('aruba-test-cli', true) }.to raise_error }
     end
     """
     When I run `rspec`
@@ -74,7 +74,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      it { expect { run_simple('aruba-test-cli', :fail_on_error => false) }.not_to raise_error }
+      it { expect { run_command_and_stop('aruba-test-cli', :fail_on_error => false) }.not_to raise_error }
     end
     """
     When I run `rspec`
@@ -91,7 +91,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      it { expect { run_simple('aruba-test-cli', false) }.not_to raise_error }
+      it { expect { run_command_and_stop('aruba-test-cli', false) }.not_to raise_error }
     end
     """
     When I run `rspec`
@@ -126,7 +126,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 2 do
-      before(:each) { run_simple('aruba-test-cli') }
+      before(:each) { run_command_and_stop('aruba-test-cli') }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output /Hello, Aruba is working/ }
@@ -156,7 +156,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 3 do
-      before(:each) { run_simple('aruba-test-cli') }
+      before(:each) { run_command_and_stop('aruba-test-cli') }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output /Hello, Aruba here/ }
@@ -165,10 +165,10 @@ Feature: Run command in a simpler fashion
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Sending signals to commands started with `#run_simple()`
+  Scenario: Sending signals to commands started with `#run_command_and_stop()`
 
     Sending signals to a command which is started by
-    `#run_simple()` does not make sense. The command is stopped internally when
+    `#run_command_and_stop()` does not make sense. The command is stopped internally when
     its exit status is checked.
 
     Given an executable named "bin/aruba-test-cli" with:
@@ -199,7 +199,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2, :startup_wait_time => 1 do
-      before(:each) { run_simple('aruba-test-cli') }
+      before(:each) { run_command_and_stop('aruba-test-cli') }
       it { expect { last_command_started.send_signal 'HUP' }.to raise_error Aruba::CommandAlreadyStoppedError }
     end
     """
@@ -224,7 +224,7 @@ Feature: Run command in a simpler fashion
     end
 
     RSpec.describe 'Run command', :type => :aruba do
-      it { expect { run_simple('aruba-test-cli', :fail_on_error => true) }.to_not raise_error }
+      it { expect { run_command_and_stop('aruba-test-cli', :fail_on_error => true) }.to_not raise_error }
     end
     """
     When I run `rspec`

--- a/features/04_aruba_api/command/send_signal_to_command.feature
+++ b/features/04_aruba_api/command/send_signal_to_command.feature
@@ -26,7 +26,7 @@ Feature: Send running command a signal
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 5 do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { last_command_started.send_signal 'HUP' }
       it { expect(last_command_started).to have_output /Exit/ }
     end
@@ -45,7 +45,7 @@ Feature: Send running command a signal
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 5 do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       it { expect { last_command_started.send_signal 'HUP' }.to raise_error Aruba::CommandAlreadyStoppedError, /Command "aruba-test-cli" with PID/ }
     end
     """

--- a/features/04_aruba_api/command/stop_all_commands.feature
+++ b/features/04_aruba_api/command/stop_all_commands.feature
@@ -16,8 +16,8 @@ Feature: Stop all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 5 do
-      before(:each) { run('aruba-test-cli') }
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
 
       before(:each) { stop_all_commands }
 
@@ -38,9 +38,9 @@ Feature: Stop all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2 do
-      before(:each) { @cmd1 = run('aruba-test-cli') }
-      before(:each) { @cmd2 = run('aruba-test-cli') }
-      before(:each) { @cmd3 = run('sleep 1') }
+      before(:each) { @cmd1 = run_command('aruba-test-cli') }
+      before(:each) { @cmd2 = run_command('aruba-test-cli') }
+      before(:each) { @cmd3 = run_command('sleep 1') }
 
       before(:each) { stop_all_commands { |c| c.commandline == 'aruba-test-cli' } }
 

--- a/features/04_aruba_api/command/stop_single_command.feature
+++ b/features/04_aruba_api/command/stop_single_command.feature
@@ -28,7 +28,7 @@ Feature: Stop command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { last_command_started.stop }
       it { expect(last_command_started).to be_successfully_executed }
     end
@@ -52,7 +52,7 @@ Feature: Stop command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { find_command('aruba-test-cli').stop }
       it { expect(last_command_started).to be_successfully_executed }
     end
@@ -88,7 +88,7 @@ Feature: Stop command
     end
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -123,7 +123,7 @@ Feature: Stop command
     end
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started).to have_exit_status 2 }
     end
     """

--- a/features/04_aruba_api/command/terminate_all_commands.feature
+++ b/features/04_aruba_api/command/terminate_all_commands.feature
@@ -16,8 +16,8 @@ Feature: Terminate all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 5 do
-      before(:each) { run('aruba-test-cli') }
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
 
       before(:each) { terminate_all_commands }
 
@@ -38,9 +38,9 @@ Feature: Terminate all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2 do
-      before(:each) { @cmd1 = run('aruba-test-cli') }
-      before(:each) { @cmd2 = run('aruba-test-cli') }
-      before(:each) { @cmd3 = run('sleep 1') }
+      before(:each) { @cmd1 = run_command('aruba-test-cli') }
+      before(:each) { @cmd2 = run_command('aruba-test-cli') }
+      before(:each) { @cmd3 = run_command('sleep 1') }
 
       before(:each) { terminate_all_commands { |c| c.commandline == 'aruba-test-cli' } }
 

--- a/features/04_aruba_api/command/use_last_command_started.feature
+++ b/features/04_aruba_api/command/use_last_command_started.feature
@@ -9,7 +9,7 @@ Feature: Return last command started
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello') }
+      before(:each) { run_command('echo hello') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started).to be_successfully_executed }
@@ -25,8 +25,8 @@ Feature: Return last command started
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello') }
-      before(:each) { run('echo world') }
+      before(:each) { run_command('echo hello') }
+      before(:each) { run_command('echo world') }
 
       before(:each) { stop_all_commands }
 

--- a/features/04_aruba_api/command/use_last_command_stopped.feature
+++ b/features/04_aruba_api/command/use_last_command_stopped.feature
@@ -9,7 +9,7 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello') }
+      before(:each) { run_command('echo hello') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_stopped).to be_successfully_executed }
@@ -25,8 +25,8 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello') }
-      before(:each) { run('echo world') }
+      before(:each) { run_command('echo hello') }
+      before(:each) { run_command('echo world') }
 
       before(:each) { stop_all_commands }
 
@@ -43,9 +43,9 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('echo hello') }
+      before(:each) { run_command('echo hello') }
       before(:each) { find_command('echo hello').stop }
-      before(:each) { run('echo world') }
+      before(:each) { run_command('echo world') }
 
       it { expect(last_command_stopped).to be_successfully_executed }
       it { expect(last_command_stopped.commandline).to eq 'echo hello' }
@@ -80,7 +80,7 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
 
       it { expect{ last_command_stopped.commandline }.to raise_error Aruba::NoCommandHasBeenStoppedError }
     end

--- a/features/04_aruba_api/environment/append_environment_variable.feature
+++ b/features/04_aruba_api/environment/append_environment_variable.feature
@@ -21,7 +21,7 @@ Feature: Append environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'a' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=a' }
@@ -39,7 +39,7 @@ Feature: Append environment variable
       before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'a' }
       before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=ab' }
@@ -59,7 +59,7 @@ Feature: Append environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=ab' }
@@ -81,7 +81,7 @@ Feature: Append environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do
@@ -111,7 +111,7 @@ Feature: Append environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do

--- a/features/04_aruba_api/environment/delete_environment_variable.feature
+++ b/features/04_aruba_api/environment/delete_environment_variable.feature
@@ -15,7 +15,7 @@ Feature: Delete existing environment variable via API-method
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE=1' }
@@ -33,7 +33,7 @@ Feature: Delete existing environment variable via API-method
       before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
       before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE' }
@@ -53,7 +53,7 @@ Feature: Delete existing environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { delete_environment_variable 'REALLY_LONG_LONG_VARIABLE' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'REALLY_LONG_LONG_VARIABLE' }

--- a/features/04_aruba_api/environment/prepend_environment_variable.feature
+++ b/features/04_aruba_api/environment/prepend_environment_variable.feature
@@ -21,7 +21,7 @@ Feature: Prepend environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'a' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=a' }
@@ -39,7 +39,7 @@ Feature: Prepend environment variable
       before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'a' }
       before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=ba' }
@@ -59,7 +59,7 @@ Feature: Prepend environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=ba' }
@@ -81,7 +81,7 @@ Feature: Prepend environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do
@@ -111,7 +111,7 @@ Feature: Prepend environment variable
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do

--- a/features/04_aruba_api/environment/set_environment_variable.feature
+++ b/features/04_aruba_api/environment/set_environment_variable.feature
@@ -20,7 +20,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
@@ -38,7 +38,7 @@ Feature: Set environment variable via API-method
       before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
       before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=2' }
@@ -59,7 +59,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=2' }
@@ -78,7 +78,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=2' }
@@ -100,7 +100,7 @@ Feature: Set environment variable via API-method
       before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '1' }
       before(:each) { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
@@ -123,7 +123,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do
@@ -153,7 +153,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do
@@ -181,7 +181,7 @@ Feature: Set environment variable via API-method
       before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
 
       describe 'Method XX' do
-        before(:each) { run('env') }
+        before(:each) { run_command('env') }
         before(:each) { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
@@ -190,7 +190,7 @@ Feature: Set environment variable via API-method
       describe 'Method YY' do
         before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '2' }
 
-        before(:each) { run('env') }
+        before(:each) { run_command('env') }
         before(:each) { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=2' }
@@ -210,7 +210,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it do
@@ -283,7 +283,7 @@ Feature: Set environment variable via API-method
 
         it { expect(ENV['REALLY_LONG_LONG_VARIABLE']).to eq '1' }
 
-        before(:each) { run('env') }
+        before(:each) { run_command('env') }
         before(:each) { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
@@ -298,7 +298,7 @@ Feature: Set environment variable via API-method
 
         it { expect(ENV['LONG_LONG_VARIABLE']).to eq '2' }
 
-        before(:each) { run('env') }
+        before(:each) { run_command('env') }
         before(:each) { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
@@ -317,7 +317,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'long_LONG_VARIABLE', '1' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'long_LONG_VARIABLE=1' }
@@ -336,7 +336,7 @@ Feature: Set environment variable via API-method
     RSpec.describe 'Environment command', :type => :aruba do
       before(:each) { set_environment_variable 'long_LONG_VARIABLE', '1' }
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
@@ -362,7 +362,7 @@ Feature: Set environment variable via API-method
         require 'my_library'
       end
 
-      before(:each) { run('env') }
+      before(:each) { run_command('env') }
       before(:each) { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }

--- a/features/04_aruba_api/filesystem/cd_to_directory.feature
+++ b/features/04_aruba_api/filesystem/cd_to_directory.feature
@@ -24,7 +24,7 @@ Feature: Change current working directory
         cd 'new_dir.d'
       end
 
-      before(:each) { run_simple 'pwd' }
+      before(:each) { run_command_and_stop 'pwd' }
 
       it { expect(last_command_started.output).to include 'new_dir.d' }
     end
@@ -39,7 +39,7 @@ Feature: Change current working directory
 
     RSpec.describe 'cd to directory', :type => :aruba do
       before(:each) { cd 'new_dir.d' }
-      before(:each) { run_simple 'pwd' }
+      before(:each) { run_command_and_stop 'pwd' }
 
       it { expect(last_command_started.output).to include 'new_dir.d' }
       it { expect(last_command_started).to be_executed_in_time }

--- a/features/04_aruba_api/text/extract_text.feature
+++ b/features/04_aruba_api/text/extract_text.feature
@@ -17,7 +17,7 @@ Feature: Extract text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(extract_text(unescape_text(last_command.output))).to eq "Text" }
@@ -37,7 +37,7 @@ Feature: Extract text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(extract_text(unescape_text(last_command.output))).to eq "Text" }
@@ -57,7 +57,7 @@ Feature: Extract text from output
     #   require 'spec_helper'
     #
     #   RSpec.describe 'Run command', :type => :aruba do
-    #     before(:each) { run('aruba-test-cli') }
+    #     before(:each) { run_command('aruba-test-cli') }
     #     before(:each) { stop_all_commands }
     #
     #     it { expect(extract_text(unescape_text(last_command.output))).to eq "Text" }
@@ -77,7 +77,7 @@ Feature: Extract text from output
     #   require 'spec_helper'
     #
     #   RSpec.describe 'Run command', :type => :aruba do
-    #     before(:each) { run('aruba-test-cli') }
+    #     before(:each) { run_command('aruba-test-cli') }
     #     before(:each) { stop_all_commands }
     #
     #     it { expect(extract_text(unescape_text(last_command.output))).to eq "Text" }

--- a/features/04_aruba_api/text/replace_variables.feature
+++ b/features/04_aruba_api/text/replace_variables.feature
@@ -22,7 +22,7 @@ Feature: Replace variables
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
  
       it { expect(replace_variables('<pid-last-command-started>')).to eq last_command_started.pid.to_s }

--- a/features/04_aruba_api/text/sanitize_text.feature
+++ b/features/04_aruba_api/text/sanitize_text.feature
@@ -18,7 +18,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "text\ntext" }
@@ -38,7 +38,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
@@ -58,7 +58,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "text\"text" }
@@ -78,7 +78,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
@@ -98,7 +98,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
@@ -118,7 +118,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
@@ -138,7 +138,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "Text" }
@@ -158,7 +158,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "Text" }
@@ -178,7 +178,7 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :remove_ansi_escape_sequences => false, :keep_ansi => true do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "\e[31mText" }
@@ -198,7 +198,7 @@ Feature: Sanitize text from output
     #   require 'spec_helper'
     #
     #   RSpec.describe 'Run command', :type => :aruba do
-    #     before(:each) { run('aruba-test-cli') }
+    #     before(:each) { run_command('aruba-test-cli') }
     #     before(:each) { stop_all_commands }
     #
     #     it { expect(sanitize_text(last_command_started.output)).to eq "Text" }
@@ -218,7 +218,7 @@ Feature: Sanitize text from output
     #   require 'spec_helper'
     #
     #   RSpec.describe 'Run command', :type => :aruba do
-    #     before(:each) { run('aruba-test-cli') }
+    #     before(:each) { run_command('aruba-test-cli') }
     #     before(:each) { stop_all_commands }
     #
     #     it { expect(sanitize_text(last_command_started.output)).to eq "Text" }

--- a/features/04_aruba_api/text/unescape_text.feature
+++ b/features/04_aruba_api/text/unescape_text.feature
@@ -17,7 +17,7 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(unescape_text(last_command.output)).to eq "text\ntext" }
@@ -37,7 +37,7 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(unescape_text(last_command.output)).to eq "texttext" }
@@ -57,7 +57,7 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run(aruba-test-'cli') }
+      before(:each) { run_command(aruba-test-'cli') }
       before(:each) { stop_all_commands }
 
       it { expect(unescape_text(last_command.output)).to eq "text\"text" }
@@ -77,7 +77,7 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(unescape_text(last_command.output)).to eq "texttext" }
@@ -97,7 +97,7 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(unescape_text(last_command.output)).to eq "texttext" }
@@ -117,7 +117,7 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
       before(:each) { stop_all_commands }
 
       it { expect(unescape_text(last_command.output)).to eq "texttext" }

--- a/features/05_use_rspec_matchers/command/have_finished_within_time.feature
+++ b/features/05_use_rspec_matchers/command/have_finished_within_time.feature
@@ -13,7 +13,7 @@ Feature: Check if a timeout occured during command execution
     RSpec.describe 'Short running command', :type => :aruba do
       before(:each) { aruba.config.exit_timeout = 5 }
 
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
 
       it { expect(last_command_started).to have_finished_in_time }
     end

--- a/features/05_use_rspec_matchers/command/run_too_long.feature
+++ b/features/05_use_rspec_matchers/command/run_too_long.feature
@@ -18,7 +18,7 @@ Feature: Check if a timeout occured during command execution
     RSpec.describe 'Long running command', :type => :aruba do
       before(:each) { aruba.config.exit_timeout = 0 }
 
-      before(:each) { run('aruba-test-cli') }
+      before(:each) { run_command('aruba-test-cli') }
 
       it { expect(last_command_started).to run_too_long }
     end

--- a/features/step_definitions/aruba_dev_steps.rb
+++ b/features/step_definitions/aruba_dev_steps.rb
@@ -51,6 +51,6 @@ Given(/^the default feature-test$/) do
 end
 
 Then(/^aruba should be installed on the local system$/) do
-  run('gem list aruba')
+  run_command('gem list aruba')
   expect(last_command_started).to have_output(/aruba/)
 end

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -243,7 +243,7 @@ module Aruba
       #
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/MethodLength
-      def run_simple(*args)
+      def run_command_and_stop(*args)
         fail ArgumentError, 'Please pass at least a command as first argument.' if args.empty?
 
         cmd = args.shift
@@ -254,7 +254,7 @@ module Aruba
         else
           if args.size > 1
             # rubocop:disable Metrics/LineLength
-            Aruba.platform.deprecated("Please pass options to `#run_simple` as named parameters/hash and don\'t use the old style with positional parameters, NEW: e.g. `#run_simple('cmd', :exit_timeout => 5)`.")
+            Aruba.platform.deprecated("Please pass options to `#run_command_and_stop` as named parameters/hash and don\'t use the old style with positional parameters, NEW: e.g. `#run_command_and_stop('cmd', :exit_timeout => 5)`.")
             # rubocop:enable Metrics/LineLength
           end
 

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -136,7 +136,7 @@ module Aruba
       #
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/CyclomaticComplexity
-      def run(*args)
+      def run_command(*args)
         fail ArgumentError, 'Please pass at least a command as first argument.' if args.empty?
 
         cmd = args.shift
@@ -150,7 +150,7 @@ module Aruba
           startup_wait_time = opts[:startup_wait_time].nil? ? aruba.config.startup_wait_time : opts[:startup_wait_time]
         else
           if args.size > 1
-            Aruba.platform.deprecated("Please pass options to `#run` as named parameters/hash and don\'t use the old style, e.g. `#run('cmd', :exit_timeout => 5)`.")
+            Aruba.platform.deprecated("Please pass options to `#run` as named parameters/hash and don\'t use the old style, e.g. `#run_command('cmd', :exit_timeout => 5)`.")
           end
 
           exit_timeout      = args[0].nil? ? aruba.config.exit_timeout : args[0]
@@ -268,7 +268,7 @@ module Aruba
           }
         end
 
-        command = run(cmd, opts)
+        command = run_command(cmd, opts)
         command.stop
 
         if Aruba::VERSION < '1'

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -120,7 +120,7 @@ module Aruba
       def run_interactive(cmd)
         Aruba.platform.deprecated('The use of "#run_interactive" is deprecated. You can simply use "run" instead')
 
-        run(cmd)
+        run_command(cmd)
       end
 
       # @deprecated

--- a/lib/aruba/api/rvm.rb
+++ b/lib/aruba/api/rvm.rb
@@ -16,7 +16,7 @@ module Aruba
       # @param [String] gemset
       #   The name of the gemset to be used
       def use_clean_gemset(gemset)
-        run_simple(%{rvm gemset create "#{gemset}"}, true)
+        run_command_and_stop(%{rvm gemset create "#{gemset}"}, true)
         if all_stdout =~ /'#{gemset}' gemset created \((.*)\)\./
           gem_home = Regexp.last_match[1]
           set_environment_variable('GEM_HOME', gem_home)
@@ -27,7 +27,7 @@ module Aruba
           paths.unshift(File.join(gem_home, 'bin'))
           set_environment_variable('PATH', paths.uniq.join(File::PATH_SEPARATOR))
 
-          run_simple("gem install bundler", true)
+          run_command_and_stop("gem install bundler", true)
         else
           raise "I didn't understand rvm's output: #{all_stdout}"
         end

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -48,12 +48,12 @@ end
 
 When(/^I run `([^`]*)` interactively$/)do |cmd|
   cmd = sanitize_text(cmd)
-  @interactive = run(cmd)
+  @interactive = run_command(cmd)
 end
 
 # Merge interactive and background after refactoring with event queue
 When(/^I run `([^`]*)` in background$/)do |cmd|
-  run(sanitize_text(cmd))
+  run_command(sanitize_text(cmd))
 end
 
 When(/^I type "([^"]*)"$/) do |input|

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -7,26 +7,26 @@ When(/^I run "(.*)"$/)do |cmd|
   warn(%{\e[35m    The /^I run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
 
   cmd = sanitize_text(cmd)
-  run_simple(cmd, false)
+  run_command_and_stop(cmd, false)
 end
 
 When(/^I run `([^`]*)`$/)do |cmd|
   cmd = sanitize_text(cmd)
-  run_simple(cmd, :fail_on_error => false)
+  run_command_and_stop(cmd, :fail_on_error => false)
 end
 
 When(/^I successfully run "(.*)"$/)do |cmd|
   warn(%{\e[35m    The  /^I successfully run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
 
   cmd = sanitize_text(cmd)
-  run_simple(cmd)
+  run_command_and_stop(cmd)
 end
 
 ## I successfully run `echo -n "Hello"`
 ## I successfully run `sleep 29` for up to 30 seconds
 When(/^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/)do |cmd, secs|
   cmd = sanitize_text(cmd)
-  run_simple(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_i)
+  run_command_and_stop(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_i)
 end
 
 When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do |shell, commands|

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1086,7 +1086,7 @@ describe Aruba::Api do
         end
 
         it "should announce to stdout exactly once" do
-          @aruba.run_simple('echo "hello world"', false)
+          @aruba.run_command_and_stop('echo "hello world"', false)
           expect(@aruba.all_output).to include('hello world')
         end
       end
@@ -1094,7 +1094,7 @@ describe Aruba::Api do
       context 'disabled' do
         it "should not announce to stdout" do
           result = capture(:stdout) do
-            @aruba.run_simple('echo "hello world"', false)
+            @aruba.run_command_and_stop('echo "hello world"', false)
           end
 
           expect(result).not_to include('hello world')
@@ -1105,7 +1105,7 @@ describe Aruba::Api do
   end
 
   describe "#assert_not_matching_output" do
-    before(:each){ @aruba.run_simple("echo foo", false) }
+    before(:each){ @aruba.run_command_and_stop("echo foo", false) }
     after(:each) { @aruba.all_commands.each(&:stop) }
 
     it "passes when the output doesn't match a regexp" do
@@ -1142,8 +1142,8 @@ describe Aruba::Api do
     end
   end
 
-  describe "#run_simple" do
-    before(:each){@aruba.run_simple "true"}
+  describe "#run_command_and_stop" do
+    before(:each){@aruba.run_command_and_stop "true"}
     after(:each) { @aruba.all_commands.each(&:stop) }
     describe "get_process" do
       it "returns a process" do

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Command Matchers' do
   describe '#to_have_exit_status' do
     let(:cmd) { 'true' }
 
-    before(:each) { run(cmd) }
+    before(:each) { run_command(cmd) }
 
     context 'when has exit 0' do
       it { expect(last_command_started).to have_exit_status 0 }
@@ -29,7 +29,7 @@ RSpec.describe 'Command Matchers' do
   describe '#to_be_successfully_executed_' do
     let(:cmd) { 'true' }
 
-    before(:each) { run(cmd) }
+    before(:each) { run_command(cmd) }
 
     context 'when has exit 0' do
       it { expect(last_command_started).to be_successfully_executed }
@@ -46,15 +46,15 @@ RSpec.describe 'Command Matchers' do
     let(:output) { 'hello world' }
 
     context 'when have output hello world on stdout' do
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
       it { expect(last_command_started).to have_output output }
     end
 
     context 'when multiple commands output hello world on stdout' do
       context 'and all comands must have the output' do
         before(:each) do
-          run(cmd)
-          run(cmd)
+          run_command(cmd)
+          run_command(cmd)
         end
 
         it { expect(all_commands).to all have_output output }
@@ -62,8 +62,8 @@ RSpec.describe 'Command Matchers' do
 
       context 'and any comand can have the output' do
         before(:each) do
-          run(cmd)
-          run('echo hello universe')
+          run_command(cmd)
+          run_command('echo hello universe')
         end
 
         it { expect(all_commands).to include have_output(output) }
@@ -86,13 +86,13 @@ RSpec.describe 'Command Matchers' do
 
       let(:cmd) { "cmd.sh #{output}" }
 
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
 
       it { expect(last_command_started).to have_output output }
     end
 
     context 'when not has output' do
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
 
       it { expect(last_command_started).not_to have_output 'hello universe' }
     end
@@ -103,7 +103,7 @@ RSpec.describe 'Command Matchers' do
     let(:output) { 'hello world' }
 
     context 'when have output hello world on stdout' do
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
       it { expect(last_command_started).to have_output_on_stdout output }
     end
 
@@ -123,13 +123,13 @@ RSpec.describe 'Command Matchers' do
 
       let(:cmd) { "cmd.sh #{output}" }
 
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
 
       it { expect(last_command_started).not_to have_output_on_stdout output }
     end
 
     context 'when not has output' do
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
 
       it { expect(last_command_started).not_to have_output_on_stdout 'hello universe' }
     end
@@ -140,7 +140,7 @@ RSpec.describe 'Command Matchers' do
     let(:output) { 'hello world' }
 
     context 'when have output hello world on stdout' do
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
       it { expect(last_command_started).not_to have_output_on_stderr output }
     end
 
@@ -160,13 +160,13 @@ RSpec.describe 'Command Matchers' do
 
       let(:cmd) { "cmd.sh #{output}" }
 
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
 
       it { expect(last_command_started).to have_output_on_stderr output }
     end
 
     context 'when not has output' do
-      before(:each) { run(cmd) }
+      before(:each) { run_command(cmd) }
 
       it { expect(last_command_started).not_to have_output_on_stderr 'hello universe' }
     end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This PR changes the name of all methods running commands. Ping @cucumber/cucumber-ruby This will be on 1.0.0, so no breakage for now.
<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->
~~~
run             -> run_command
run_simple -> run_command_and_stop
~~~

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We had some issues with name clashes (e.g. #435) and personally I don't like `#run_simple` as method name as it hides some intent.

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
