### PR TITLE
Make rspec run all specs

### DIFF
--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -8,7 +8,7 @@ require 'aruba/platform'
 require 'aruba/api/core'
 require 'aruba/api/command'
 
-if Aruba::VERSION <= '1.0.0'
+if Aruba::VERSION <= '1.1.0'
   require 'aruba/api/deprecated'
 end
 
@@ -28,7 +28,9 @@ module Aruba
     include Aruba::Api::Environment
     include Aruba::Api::Filesystem
     include Aruba::Api::Rvm
-    include Aruba::Api::Deprecated
+    if Aruba::VERSION <= '1.1.0'
+      include Aruba::Api::Deprecated
+    end
     include Aruba::Api::Text
   end
 end

--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -49,11 +49,7 @@ module Aruba
 
       @environment.update(@config.command_runtime_environment)
 
-      @command_monitor = if Aruba::VERSION < '1'
-                           opts.fetch(:command_monitor, Aruba.platform.command_monitor.new(:announcer => @announcer))
-                         else
-                           opts.fetch(:command_monitor, Aruba.platform.command_monitor.new)
-                         end
+      @command_monitor = opts.fetch(:command_monitor, Aruba.platform.command_monitor.new(:announcer => @announcer))
 
       @logger = opts.fetch(:logger, Aruba.platform.logger.new)
       @logger.mode = @config.log_level

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1118,8 +1118,8 @@ describe Aruba::Api do
     end
   end
 
-  describe '#run' do
-    before(:each){ @aruba.run 'cat' }
+  describe '#run_command' do
+    before(:each){ @aruba.run_command 'cat' }
     after(:each) { @aruba.all_commands.each(&:stop) }
 
     it "respond to input" do
@@ -1178,14 +1178,14 @@ describe Aruba::Api do
 
     it "set environment variable" do
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.run "env"
+      @aruba.run_command "env"
       expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE=true")
     end
 
     it "overwrites environment variable" do
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'false'
-      @aruba.run "env"
+      @aruba.run_command "env"
       expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE=false")
     end
   end
@@ -1195,14 +1195,14 @@ describe Aruba::Api do
     it "restores environment variable" do
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.restore_env
-      @aruba.run "env"
+      @aruba.run_command "env"
       expect(@aruba.all_output).not_to include("LONG_LONG_ENV_VARIABLE")
     end
     it "restores environment variable that has been set multiple times" do
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'false'
       @aruba.restore_env
-      @aruba.run "env"
+      @aruba.run_command "env"
       expect(@aruba.all_output).not_to include("LONG_LONG_ENV_VARIABLE")
     end
   end

--- a/spec/aruba/hooks_spec.rb
+++ b/spec/aruba/hooks_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'aruba/config'
 
 describe Aruba::Hooks do

--- a/spec/aruba/processes/basic_process_spec.rb
+++ b/spec/aruba/processes/basic_process_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'aruba/processes/basic_process'
 
 RSpec.describe Aruba::Processes::BasicProcess do

--- a/spec/aruba/spawn_process_spec.rb
+++ b/spec/aruba/spawn_process_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'aruba/processes/spawn_process'
 
 RSpec.describe Aruba::Processes::SpawnProcess do

--- a/spec/event_bus/name_resolver_spec.rb
+++ b/spec/event_bus/name_resolver_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'aruba/event_bus/name_resolver'
 
 describe Aruba::EventBus::NameResolver do

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 require 'aruba/event_bus'
 
 # rubocop:disable Style/Documentation


### PR DESCRIPTION
## Summary

These changes make the RSpec specs run to completion.

## Details

These are some small fixes so RSpec doesn't abort prematurely:
* Load deprecated method module because it is still included and its methods are still tested (and sometimes used).
* Fix initialization of CommandMonitor; it always needs an announcer.
* Fix some left-over instances of the moved `#run` method.
* Load `spec_helper` in all spec files. This is mainly important when checking spec failures by running individual files.

## Motivation and Context

This is a small part of #434 that hopefully can be merged more quickly so there is a basis for making the final fixes to the specs and then fixing the cucumber scenarios.