### PR TITLE
Fix environment handling

### DIFF
--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -61,7 +61,7 @@ module Aruba
 
             Aruba.platform.chdir File.join(aruba.root_directory, aruba.current_directory)
 
-            result = Aruba.platform.with_environment(
+            result = with_environment(
               'OLDPWD' => old_dir,
               'PWD' => File.expand_path(File.join(aruba.root_directory, aruba.current_directory)),
               &block

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -5,7 +5,7 @@ World(Aruba::Api)
 
 if Aruba::VERSION >= '1.0.0'
   Around do |_, block|
-    Aruba.platform.with_environment(&block)
+    with_environment(&block)
   end
 end
 

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -18,6 +18,12 @@ RSpec.configure do |config|
     if self.class.include? Aruba::Api
       restore_env
       setup_aruba
+
+      # Modify PATH to include project/bin
+      prepend_environment_variable 'PATH', aruba.config.command_search_paths.join(':') + ':'
+
+      # Use configured home directory as HOME
+      set_environment_variable 'HOME', aruba.config.home_directory
     end
 
     example.run
@@ -28,7 +34,11 @@ RSpec.configure do |config|
 
   if Aruba::VERSION >= '1.0.0'
     config.around :each do |example|
-      Aruba.platform.with_environment do
+      if self.class.include? Aruba::Api
+        with_environment do
+          example.run
+        end
+      else
         example.run
       end
     end
@@ -89,19 +99,5 @@ RSpec.configure do |config|
       aruba.announcer.activate(:command_content)
       aruba.announcer.activate(:command_filesystem_status)
     end
-  end
-
-  # Modify PATH to include project/bin
-  config.before :each do
-    next unless self.class.include? Aruba::Api
-
-    prepend_environment_variable 'PATH', aruba.config.command_search_paths.join(':') + ':'
-  end
-
-  # Use configured home directory as HOME
-  config.before :each do |example|
-    next unless self.class.include? Aruba::Api
-
-    set_environment_variable 'HOME', aruba.config.home_directory
   end
 end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -102,6 +102,26 @@ describe Aruba::Api do
         expect(File.exist?(File.expand_path(@directory_path))).to be_truthy
       end
     end
+
+    describe '#cd' do
+      context 'with a block given' do
+        it 'runs the passed block in the given directory' do
+          @aruba.create_directory @directory_name
+          full_path = File.expand_path(@directory_path)
+          @aruba.cd @directory_name do
+            expect(Dir.pwd).to eq full_path
+          end
+          expect(Dir.pwd).not_to eq full_path
+        end
+
+        it 'does not touch non-directory environment the passed block' do
+          @aruba.create_directory @directory_name
+          @aruba.cd @directory_name do
+            expect(ENV['HOME']).not_to be_nil
+          end
+        end
+      end
+    end
   end
 
   describe '#read' do

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1071,6 +1071,48 @@ describe Aruba::Api do
 
         expect(ENV[variable]).to eq '1'
       end
+
+      it 'works together with #set_environment_variable' do
+        variable = 'THIS_IS_A_ENV_VAR'
+        @aruba.set_environment_variable variable, '1'
+
+        @aruba.with_environment do
+          expect(ENV[variable]).to eq '1'
+          @aruba.set_environment_variable variable, '0'
+          @aruba.with_environment do
+            expect(ENV[variable]).to eq '0'
+          end
+          expect(ENV[variable]).to eq '1'
+        end
+      end
+
+      it 'works with a mix of ENV and #set_environment_variable' do
+        variable = 'THIS_IS_A_ENV_VAR'
+        @aruba.set_environment_variable variable, '1'
+        ENV[variable] = '2'
+        expect(ENV[variable]).to eq '2'
+
+        @aruba.with_environment do
+          expect(ENV[variable]).to eq '1'
+          @aruba.set_environment_variable variable, '0'
+          @aruba.with_environment do
+            expect(ENV[variable]).to eq '0'
+          end
+          expect(ENV[variable]).to eq '1'
+        end
+        expect(ENV[variable]).to eq '2'
+      end
+
+      it 'keeps values not set in argument' do
+        variable = 'THIS_IS_A_ENV_VAR'
+        ENV[variable] = '2'
+        expect(ENV[variable]).to eq '2'
+
+        @aruba.with_environment do
+          expect(ENV[variable]).to eq '2'
+        end
+        expect(ENV[variable]).to eq '2'
+      end
     end
   end
 

--- a/spec/aruba/rspec_spec.rb
+++ b/spec/aruba/rspec_spec.rb
@@ -12,4 +12,14 @@ RSpec.describe 'RSpec Integration', :type => :aruba do
       it { expect(config.io_wait_timeout).to eq 0.1 }
     end
   end
+
+  describe 'Setting up the environment' do
+    it 'sets HOME to the configured value' do
+      expect(ENV['HOME']).to eq aruba.config.home_directory
+    end
+
+    it 'includes configured command search paths in PATH' do
+      expect(ENV['PATH']).to include aruba.config.command_search_paths.join(':')
+    end
+  end
 end

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -8,7 +8,7 @@ RSpec.shared_context 'uses aruba API' do
   def create_test_files(files, data = 'a')
     Array(files).each do |s|
       next if s.to_s[0] == '%'
-      local_path = expand_path(s)
+      local_path = @aruba.expand_path(s)
 
       FileUtils.mkdir_p File.dirname(local_path)
       File.open(local_path, 'w') { |f| f << data }


### PR DESCRIPTION
## Summary

Improve handling of environment. In particular, makes `ENV['HOME']` have a correct and safe value.

~~This PR depends on #441 so needs to be rebased after that PR has been merged.~~

## Motivation and Details

The main purpose is to make all the current specs pass. It does this by changing the environment setup in the specs, so that:

* HOME and PATH are set early enough so that all specs run with the set values. This also ensures no leaking of files outside of the build directory.
* Where the Aruba runtime is the object under test, it uses the test object when expanding paths.

This change also fixes the `#cd` method to not clear the entire environment inside the block.

After this PR has been merged we can revisit #434 and concentrate on the cucumber scenarios there.