### PR TITLE
RuboCop Lint/UnneededDisable warnings heeded

### DIFF
--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -523,8 +523,6 @@ module Aruba
       end
 
       # @deprecated
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       def check_for_deprecated_variables
         if defined? @aruba_exit_timeout
           Aruba.platform.deprecated('The use of "@aruba_exit_timeout" is deprecated. Use "#aruba.config.exit_timeout = <numeric>" instead')

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -57,7 +57,6 @@ module Aruba
       # @option [Object] default
       #   The default value
       #
-      # rubocop:disable Metrics/CyclomaticComplexity
       def option_accessor(name, opts = {})
         contract = opts[:contract]
         default  = opts[:default]
@@ -75,7 +74,6 @@ module Aruba
         # Add reader
         option_reader name, :contract => { None => contract.values.first }
       end
-      # rubocop:enable Metrics/CyclomaticComplexity
 
       private
 

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -40,11 +40,8 @@ module Aruba
     option_accessor :remove_ansi_escape_sequences, :contract => { Bool => Bool }, :default => true
     # rubocop:disable Metrics/LineLength
     option_accessor :command_launcher, :contract => { Aruba::Contracts::Enum[:in_process, :spawn, :debug] => Aruba::Contracts::Enum[:in_process, :spawn, :debug] }, :default => :spawn
-    # rubocop:enable Metrics/LineLength
     option_accessor :main_class, :contract => { Class => Maybe[Class] }, :default => nil
-    # rubocop:disable Metrics/LineLength
 
-    # rubocop:disable Metrics/LineLength
     if Aruba::VERSION >= '1.0.0'
       option_accessor :home_directory, :contract => { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] } do |config|
         File.join(config.root_directory.value, config.working_directory.value)
@@ -52,11 +49,8 @@ module Aruba
     else
       option_accessor :home_directory, :contract => { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] }, :default => ENV['HOME']
     end
-    # rubocop:enable Metrics/LineLength
 
-    # rubocop:disable Metrics/LineLength
     option_accessor :log_level, :contract => { Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] => Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] }, :default => :info
-    # rubocop:enable Metrics/LineLength
 
     # TODO: deprecate this value and replace with "filesystem allocation unit"
     # equal to 4096 by default. "filesystem allocation unit" would represent

--- a/lib/aruba/console.rb
+++ b/lib/aruba/console.rb
@@ -35,7 +35,6 @@ module Aruba
       IRB.conf[:SAVE_HISTORY] = 1000
       IRB.conf[:HISTORY_FILE] = Aruba.config.console_history_file
 
-      # rubocop:disable Lint/NestedMethodDefinition
       context = Class.new do
         include Aruba::Api
         include Aruba::Console::Help
@@ -48,7 +47,6 @@ module Aruba
           'nil'
         end
       end
-      # rubocop:enable Lint/NestedMethodDefinition
 
       irb = IRB::Irb.new(IRB::WorkSpace.new(context.new))
       IRB.conf[:MAIN_CONTEXT] = irb.context

--- a/lib/aruba/event_bus/name_resolver.rb
+++ b/lib/aruba/event_bus/name_resolver.rb
@@ -16,7 +16,6 @@ module Aruba
         # Thanks ActiveSupport
         # (Only needed to support Ruby 1.9.3 and JRuby)
         # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/MethodLength
         def constantize(camel_cased_word)
           names = camel_cased_word.split('::')
 
@@ -52,7 +51,6 @@ module Aruba
           end
         end
         # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/MethodLength
       end
 
       # @private

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -34,7 +34,6 @@ module Aruba
       end
     end
 
-    # rubocop:disable Metrics/MethodLength
     def initialize(opts = {})
       @registered_commands = []
       @announcer = opts.fetch(:announcer)

--- a/lib/aruba/platforms/unix_environment_variables.rb
+++ b/lib/aruba/platforms/unix_environment_variables.rb
@@ -204,9 +204,7 @@ module Aruba
 
       def prepared_environment
         if RUBY_VERSION == '1.9.3'
-          # rubocop:disable Style/EachWithObject
           actions.inject(ENV.to_hash.merge(env)) { |a, e| e.call(a) }
-          # rubocop:enable Style/EachWithObject
         else
           actions.each_with_object(ENV.to_hash.merge(env)) { |e, a| a = e.call(a) }
         end

--- a/lib/aruba/platforms/unix_which.rb
+++ b/lib/aruba/platforms/unix_which.rb
@@ -36,8 +36,6 @@ module Aruba
           Aruba.platform.command?(program)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/MethodLength
         def call(program, path)
           # Iterate over each path glob the dir + program.
           path.split(File::PATH_SEPARATOR).each do |dir|
@@ -50,8 +48,6 @@ module Aruba
 
           nil
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/MethodLength
       end
 
       private

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -38,8 +38,6 @@ module Aruba
           Aruba.platform.command?(program)
         end
 
-        # rubocop:disable Metrics/CyclomaticComplexity
-        # rubocop:disable Metrics/MethodLength
         def call(program, path)
           # Iterate over each path glob the dir + program.
           path.split(File::PATH_SEPARATOR).each do |dir|
@@ -63,8 +61,6 @@ module Aruba
 
           nil
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
-        # rubocop:enable Metrics/MethodLength
       end
 
       private

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -90,7 +90,6 @@ module Aruba
 
         yield self if block_given?
       end
-      # rubocop:disable Metrics/MethodLength
 
       # Access to stdout of process
       def stdin
@@ -249,9 +248,7 @@ module Aruba
         # gather fully qualified path
         cmd = Aruba.platform.which(command, environment['PATH'])
 
-        # rubocop:disable  Metrics/LineLength
         fail LaunchError, %(Command "#{command}" not found in PATH-variable "#{environment['PATH']}".) if cmd.nil?
-        # rubocop:enable  Metrics/LineLength
 
         Aruba.platform.command_string.new(cmd)
       end

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'aruba/event_bus'
 
-# rubocop:disable Style/Documentation
 module Events
   class TestEvent; end
   class AnotherTestEvent; end
@@ -13,7 +12,6 @@ class MyHandler
 end
 
 class MyMalformedHandler; end
-# rubocop:enable Style/Documentation
 
 describe Aruba::EventBus do
   subject(:bus) { described_class.new(name_resolver) }


### PR DESCRIPTION
## Summary

This PR avoids all of the currently output RuboCop warnings.

