### PR TITLE
Travis: use only latest JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,25 +10,11 @@ rvm:
   - 2.3.0
   - 2.4.0
   - ruby-head
-  - jruby
-  - jruby-20mode
-  - jruby-21mode
+  - jruby-9.1.12.0
 matrix:
-  include:
-    - rvm: jruby-9.0.1.0
-      env: JRUBY_OPTS='--dev'
-    - rvm: jruby-9.0.1.0-20mode
-      env: JRUBY_OPTS='--dev'
-    - rvm: jruby-9.0.1.0-21mode
-      env: JRUBY_OPTS='--dev'
   allow_failures:
   - rvm: ruby-head
-  - rvm: jruby-9.0.1.0
-    env: JRUBY_OPTS='--dev'
-  - rvm: jruby-9.0.1.0-20mode
-    env: JRUBY_OPTS='--dev'
-  - rvm: jruby-9.0.1.0-21mode
-    env: JRUBY_OPTS='--dev'
+  - rvm: jruby-9.1.12.0
   fast_finish: true
 notifications:
   webhooks:


### PR DESCRIPTION
## Summary

This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/06/15/jruby-9-1-12-0.html

## Status

I don't know if new issues will pop up, but that's why I want to read the output on Travis.