### PR TITLE
Use old version of license_finder for old rubies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,11 @@ group :development, :test do
   # gem 'cucumber-pro', '~> 0.0'
 
   # License compliance
-  gem 'license_finder', '~> 3.0'
+  if RUBY_VERSION < '2.3'
+    gem 'license_finder', '~> 2.0'
+  else
+    gem 'license_finder', '~> 3.0'
+  end
 
   # Upload documentation
   # gem 'relish', '~> 0.7.1'


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Downgrade `license_finder` to make the build succeed.

<!--- Describe your changes in detail -->

## Motivation and Context

The gem uses the new "Safe Navigation Operator" which was introduced in
C-Ruby 2.3. This make the build fail: https://travis-ci.org/cucumber/aruba/jobs/252903532.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
