### PR TITLE
[docs] Your first Tests tutorial: add install step

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -78,11 +78,12 @@ prefer to setup `aruba` yourself, please move on to the next section.
 
 ### Your First Tests with "aruba"
 
-1. Clone "Getting Started"-application
+1. Clone the "Getting Started" application and install its dependencies
 
    ~~~bash
    git clone https://github.com/cli-testing/aruba-getting-started.git
    cd aruba-getting-started
+   bundle install
    ~~~
 
 #### Cucumber


### PR DESCRIPTION
Issue: When following the _Your First Tests_, there's no explicit instruction to run `bundle install`

```
Could not find gem 'aruba (~> 1.0.0.pre.alpha.1)' in any of the gem sources listed in your Gemfile.
Run `bundle install` to install missing gems.
```

Solution: add that, and mention it in step 1.

See #453