### PR TITLE
Improve docs to use our fixtures

### DIFF
--- a/features/04_aruba_api/filesystem/use_fixtures.feature
+++ b/features/04_aruba_api/filesystem/use_fixtures.feature
@@ -1,56 +1,74 @@
 Feature: Use fixtures in your tests
 
   Sometimes your tests need existing files to work - e.g binary data files you
-  cannot create programmatically. Since `aruba` >= 0.6.3 includes some basic
-  support for fixtures. All you need to do is the following:
-  
+  cannot create programmatically. All you need to do is the following:
+
   1. Create a `fixtures`-directory
   2. Create fixture files in this directory
-  
 
   Background:
     Given I use a fixture named "cli-app"
 
   Scenario: Use a fixture for your tests
-    Given a file named "features/fixtures.feature" with:
+    Given a file named "spec/fixture_spec.rb" with:
     """
-    Feature: Fixture
-      Scenario: Fixture
-        Given a file named "fixtures_spec.rb" with:
-        \"\"\"
-        RSpec.describe 'My Feature' do
-          describe '#read_music_file' do
-            context 'when the file exists' do
-              before :each { copy '%/song.mp3', 'file.mp3' }
+    require 'spec_helper'
 
-              it { expect('file.mp3').to be_an_existing_file }
-            end
-          end
+    RSpec.describe 'My Feature', :type => :aruba do
+      describe 'Copy file' do
+        context 'when the file exists' do
+          before :each { copy '%/song.mp3', 'file.mp3' }
+
+          it { expect('file.mp3').to be_an_existing_file }
         end
-        \"\"\"
+      end
+    end
     """
     And a directory named "fixtures"
-    And an empty file named "fixtures/fixtures-app/test.txt"
+    And an empty file named "fixtures/song.mp3"
+    When I run `rspec`
+    Then the specs should all pass
+
+  Scenario: Pass file from fixtures to your command
+    Given a file named "spec/fixture_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'My Feature', :type => :aruba do
+      before :each { copy '%/my_file.txt', 'new_file.txt' }
+      before :each { run_command 'aruba-test-cli new_file.txt' }
+
+      it { expect(last_command_started).to have_output 'Hello Aruba!' }
+    end
+    """
+    And a directory named "fixtures"
+    And a file named "fixtures/my_file.txt" with:
+    """
+    Hello Aruba!
+    """
+    And a file named "bin/aruba-test-cli" with:
+    """
+    #!/usr/bin/env ruby
+
+    puts File.read(ARGV[0]).chomp
+    """
     When I run `rspec`
     Then the specs should all pass
 
   Scenario: Use a fixture for your tests in test/
     Given a file named "features/fixtures.feature" with:
     """
-    Feature: Fixture
-      Scenario: Fixture
-        Given a file named "fixtures_spec.rb" with:
-        \"\"\"
-        RSpec.describe 'My Feature' do
-          describe '#read_music_file' do
-            context 'when the file exists' do
-              before :each { copy '%/song.mp3', 'file.mp3' }
+    require 'spec_helper'
 
-              it { expect('file.mp3').to be_an_existing_file }
-            end
-          end
+    RSpec.describe 'My Feature', :type => :aruba do
+      describe 'Copy file' do
+        context 'when the file exists' do
+          before :each { copy '%/song.mp3', 'file.mp3' }
+
+          it { expect('file.mp3').to be_an_existing_file }
         end
-        \"\"\"
+      end
+    end
     """
     And a directory named "test/fixtures"
     And an empty file named "test/fixtures/fixtures-app/test.txt"
@@ -60,20 +78,17 @@ Feature: Use fixtures in your tests
   Scenario: Use a fixture for your tests in spec/
     Given a file named "features/fixtures.feature" with:
     """
-    Feature: Fixture
-      Scenario: Fixture
-        Given a file named "fixtures_spec.rb" with:
-        \"\"\"
-        RSpec.describe 'My Feature' do
-          describe '#read_music_file' do
-            context 'when the file exists' do
-              before :each { copy '%/song.mp3', 'file.mp3' }
+    require 'spec_helper'
 
-              it { expect('file.mp3').to be_an_existing_file }
-            end
-          end
+    RSpec.describe 'My Feature', :type => :aruba do
+      describe 'Copy file' do
+        context 'when the file exists' do
+          before :each { copy '%/song.mp3', 'file.mp3' }
+
+          it { expect('file.mp3').to be_an_existing_file }
         end
-        \"\"\"
+      end
+    end
     """
     And a directory named "spec/fixtures"
     And an empty file named "spec/fixtures/fixtures-app/test.txt"
@@ -83,20 +98,17 @@ Feature: Use fixtures in your tests
   Scenario: Use a fixture for your tests in features/
     Given a file named "features/fixtures.feature" with:
     """
-    Feature: Fixture
-      Scenario: Fixture
-        Given a file named "fixtures_spec.rb" with:
-        \"\"\"
-        RSpec.describe 'My Feature' do
-          describe '#read_music_file' do
-            context 'when the file exists' do
-              before :each { copy '%/song.mp3', 'file.mp3' }
+    require 'spec_helper'
 
-              it { expect('file.mp3').to be_an_existing_file }
-            end
-          end
+    RSpec.describe 'My Feature', :type => :aruba do
+      describe 'Copy file' do
+        context 'when the file exists' do
+          before :each { copy '%/song.mp3', 'file.mp3' }
+
+          it { expect('file.mp3').to be_an_existing_file }
         end
-        \"\"\"
+      end
+    end
     """
     And a directory named "features/fixtures"
     And an empty file named "features/fixtures/fixtures-app/test.txt"


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This PR improves the documentation about using our fixtures API.

<!--- Provide a general summary description of your changes -->

## Details

* Fix false positive feature tests - they creating the wrong file and succeed although they should have failed
* Add example about how to use fixtures along with commands


<!--- Describe your changes in detail -->

## Motivation and Context

I've got an ongoing valuable discussion with @remy about the usage of fixtures. It turned out, that our docs are wrong at some places and additionally a good example was missing to clarify the use of fixtures with commands.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (cleanup of codebase withouth changing any existing functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
