### PR TITLE
Add links to documentation about various testing frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Code Climate](https://codeclimate.com/github/cucumber/aruba.svg)](https://codeclimate.com/github/cucumber/aruba)
 [![Support](https://img.shields.io/badge/cucumber-support-orange.svg)](https://cucumber.io/support)
 
-**This is the [latest](https://github.com/cucumber/aruba/blob/master/README.md) version of our README.md. There is also [the README of the latest released version of "aruba"](https://github.com/cucumber/aruba/blob/still/README.md).**
+**This is the [latest](https://github.com/cucumber/aruba/blob/master/README.md) version of our README.md (Branch: "[master](https://github.com/cucumber/aruba/tree/master)"). There is also [the README of the latest released version of "aruba"](https://github.com/cucumber/aruba/blob/still/README.md) (Branch: "[still](https://github.com/cucumber/aruba/tree/still)").**
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ gem install aruba
 
 Our most current documentation to get started with `aruba` as a user can be found on [![See our documentation on Cucumber Pro](https://github.com/cucumber-ltd/brand/raw/master/images/png/notm/cucumber-pro-black/cucumber-pro-black-32.png)](https://app.cucumber.pro/projects/aruba). It is generated from our feature files describing the use of `aruba`.
 
+### As a user getting started with a some ruby testing framework
+
+* **Cucumber**:
+
+    If you're new to the "Cucumber" ecosystem, it's worth to visit
+[the project's documentation site](https://cucumber.io/docs). This also includes
+information about how to write feature files in "Gherkin".
+
+* **RSpec**:
+
+    If you want to use "aruba" with "RSpec" and you need some information about how to use "RSpec", please visit [their website](http://rspec.info/documentation/).
+
+* **minitest**:
+
+    The documentation for "minitest" can be found [here](http://docs.seattlerb.org/minitest/).
+
 ### As a developer getting started with "aruba"
 
 A full documentation of the API for developers can be found on


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This is a follow up to #458. 

<!--- Provide a general summary description of your changes -->

## Details

As far as I remember we had several users who were not familiar with cucumber and ruby. This PR points them to the documentation of all supported testing frameworks to make it easier for them to find the information they need.

<!--- Describe your changes in detail -->

## Motivation and Context

We want to reduce the burden for users to use "aruba" and "cucumber".

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->



## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [x] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
