### PR TITLE
Remove gems for unsupported rubinius platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,8 +71,3 @@ group :development, :test do
 
   gem 'json', '~>2.1'
 end
-
-platforms :rbx do
-  gem 'rubysl', '~> 2.0'
-  gem 'rubinius-developer_tools'
-end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Remove gems which are only required for unsupported platforms like Rubinius.

<!--- Provide a general summary description of your changes -->
