### PR TITLE
Fix problems with API-calls based on last_command_started

### DIFF
--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -45,18 +45,7 @@ module Aruba
       raise ArgumentError, e.message
     end
 
-    if Aruba::VERSION < '1'
-      # Return the last command stopped
-      def last_command_stopped
-        return @last_command_stopped unless @last_command_stopped.nil?
-
-        registered_commands.each(&:stop)
-
-        @last_command_stopped
-      end
-    else
-      attr_reader :last_command_stopped
-    end
+    attr_reader :last_command_stopped
 
     # Set last command started
     #


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

There are some API-calls which depend on `#last_command_started'. The behaviour changed with aruba >= 1.0.0. Now all commands need to be stopped explicitly. This PR clarifies this.

<!--- Provide a general summary description of your changes -->

## Motivation and Context

TODO:

* [ ] Add examples for the new behaviour
* [ ] Find places where we need to stop commands explicitly
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
