### PR TITLE
Reduce test output message to see the result from Travis page.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,12 +34,12 @@ end
 namespace :test do
   desc 'Run cucumber tests'
   task :cucumber do
-    sh 'bundle exec cucumber'
+    sh 'bundle exec cucumber -f progress'
   end
 
   desc 'Run cucumber tests which are "WORK IN PROGRESS" and are allowed to fail'
   task :cucumber_wip do
-    sh 'bundle exec cucumber -p wip'
+    sh 'bundle exec cucumber -p wip -f progress'
   end
 
   desc 'Run rspec tests'


### PR DESCRIPTION
## Summary

Reduce test output message to see the result from Travis page.

## Details

The `bundle exec rake cucumber`'s output is too long.
In general showing detail message on Travis looks good.
But in this case, bottom of the below page.

https://travis-ci.org/cucumber/aruba/jobs/258426780
> This log is too long to be displayed. Please reduce the verbosity of your build or download the raw log. 

Then seeing the raw log, it's hard to check by the color code.

So, currently the test output message does not work.
I think that a progress format is better to see the result from Travis page.

## Motivation and Context

This promotes contribution.
Right now the hurdle may be high.

## How Has This Been Tested?

I check it on my local environment.
Also you can see the progress format on Travis page.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
