### PR TITLE
Move Build Status Badge to top of the README page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+[![master Linux/OS X Build Status](https://travis-ci.org/cucumber/aruba.svg?branch=master)](https://travis-ci.org/cucumber/aruba)
+[![master Windows Build Status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl/branch/master?svg=true&passingText=master%20windows%20passing&failingText=master%20windows%20failing&pendingText==master%20windows%20pending)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/master)
+([master](https://github.com/cucumber/aruba/tree/master)),
+[![still Linux/OS X Build Status](https://travis-ci.org/cucumber/aruba.svg?branch=still)](https://travis-ci.org/cucumber/aruba)
+[![still Wiindows Build Status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl/branch/still?svg=true&passingText=still%20windows%20passing&failingText=still%20windows%20failing&pendingText==master%20windows%20pending)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/still)
+([still](https://github.com/cucumber/aruba/tree/still))
+
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/master/LICENSE)
 [![Docs](https://img.shields.io/badge/cucumber.pro-aruba-3d10af.svg)](https://app.cucumber.pro/projects/aruba)
 [![Gem Version](https://badge.fury.io/rb/aruba.svg)](http://badge.fury.io/rb/aruba)
@@ -77,10 +84,3 @@ For an up-to-date list of all supported Ruby versions, please see our [`.travis.
 ## Contributing
 
 Please see the [CONTRIBUTING](CONTRIBUTING.md) file.
-
-## Build Status
-
-|Version|Linux / OS X|Windows|
-| ------ | ------ | ------ |
-| master | [![Build Status](https://travis-ci.org/cucumber/aruba.svg?branch=master)](https://travis-ci.org/cucumber/aruba) | [![Build status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl?svg=true)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/master)|
-| still | [![Build Status](https://travis-ci.org/cucumber/aruba.svg?branch=still)](https://travis-ci.org/cucumber/aruba) | [![Build status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl?svg=true)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/still)


### PR DESCRIPTION

## Summary

Move Build Status Badge to top of the README page.

## Details
## Motivation and Context

Right now build status is in the bottom of the `README.md`.
This style has been seen by https://github.com/rails/rails

However, other projects in cucumber have the build status on the top of `README.md`.
such as
https://github.com/cucumber/cucumber-ruby/blob/master/README.md
https://github.com/junaruga/cucumber-ruby-core/blob/master/README.md
https://github.com/cucumber/gherkin-ruby/blob/master/README.md

This style's merit is that people can see the status easily without scroll down.
I think that this style promotes contribution to pass tests.

You can see modified README here.
https://github.com/junaruga/aruba/blob/feature/build-status-badge-on-top/README.md

By the way,
https://ci.appveyor.com/project/cucumberbdd/aruba/branch/still
> Build not found or access denied.

Appveyor does not have still branch?


Appveryor has an custom test on build status image.
https://www.appveyor.com/blog/2014/11/26/customizing-text-of-build-status-badges/
Travis does not have the custom text.
https://github.com/travis-ci/travis-ci/issues/5037

This image URL that is currently used in `still` branch is not right.
This image may be for master branch.
https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl?svg=true


## How Has This Been Tested?

Checked modified README.
But I want to ask you about the detail design.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
