### PR TITLE
Restrict branches to run Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
   - rvm: jruby-9.1.12.0-21mode
     env: JRUBY_OPTS='--dev'
   fast_finish: true
+branches:
+  only:
+    - master
+    - still
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
## Summary

Restrict branches to run Travis.

## Details

For example, below case.
2 builds (PR and branch push) on Travis are running.
https://github.com/cucumber/aruba/pull/465

When sending pull-request from cucumber/aruba repository's branch,
prevent 2 builds to run.


## Motivation and Context

Saving the resource.
That affects Travis's running time.
If the time becomes shorten, contributors are happy.

## How Has This Been Tested?

When sending pull-request from `cucumber/aruba`'s branch, that is tested.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
