### PR TITLE
Add "still" branch in Appveryor (CI for Windows environment).

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ version: "{build}"
 branches:
   only:
     - master
+    - still
 
 # Disable normal Windows builds in favor of our test script.
 build: off


### PR DESCRIPTION
## Summary

Add "still" branch in Appveryor (CI for Windows environment).

## Details

"master" and "still" branches are used for production.
But "still" is not set in appveryor.yml
Seeing past "git log", it is just forgot to add it.

## Motivation and Context

This prevents Appveryor to run 2 time per PR for pull-requeset to still branch.
This saves CI resource.

## How Has This Been Tested?

When sending pull-request to still branch, we will know it is correct.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
