### PR TITLE
Fix a typo for README appveyor badge image URL pending text.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![master Linux/OS X Build Status](https://travis-ci.org/cucumber/aruba.svg?branch=master)](https://travis-ci.org/cucumber/aruba)
-[![master Windows Build Status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl/branch/master?svg=true&passingText=master%20windows%20passing&failingText=master%20windows%20failing&pendingText==master%20windows%20pending)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/master)
+[![master Windows Build Status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl/branch/master?svg=true&passingText=master%20windows%20passing&failingText=master%20windows%20failing&pendingText=master%20windows%20pending)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/master)
 ([master](https://github.com/cucumber/aruba/tree/master)),
 [![still Linux/OS X Build Status](https://travis-ci.org/cucumber/aruba.svg?branch=still)](https://travis-ci.org/cucumber/aruba)
-[![still Wiindows Build Status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl/branch/still?svg=true&passingText=still%20windows%20passing&failingText=still%20windows%20failing&pendingText==master%20windows%20pending)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/still)
+[![still Wiindows Build Status](https://ci.appveyor.com/api/projects/status/jfo2tkqhnrqqcivl/branch/still?svg=true&passingText=still%20windows%20passing&failingText=still%20windows%20failing&pendingText=master%20windows%20pending)](https://ci.appveyor.com/project/cucumberbdd/aruba/branch/still)
 ([still](https://github.com/cucumber/aruba/tree/still))
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/master/LICENSE)


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix a typo for README appver badge image URL pending text.

## Details

This fixes the typo: "pendingText==master%20windows%20pending" (double equal) by https://github.com/cucumber/aruba/pull/469

## Motivation and Context

Correct pending text of appveyor is good.

## How Has This Been Tested?

I will know that is right after merging.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
