### PR TITLE
Remove conditionals that will remain fixed once 1.0.0 is released

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -17,7 +17,6 @@ ignore_opts <<  '--tags ~@unsupported-on-platform-windows' if FFI::Platform.wind
 ignore_opts <<  '--tags ~@unsupported-on-platform-unix'    if FFI::Platform.unix?
 ignore_opts <<  '--tags ~@unsupported-on-platform-mac'     if FFI::Platform.mac?
 ignore_opts <<  '--tags ~@unsupported-on-ruby-older-2'     if RUBY_VERSION < '2'
-ignore_opts <<  '--tags ~@requires-aruba-version-1'        if Aruba::VERSION < '1'
 ignore_opts = ignore_opts.join(' ')
 %>
 default: <%= std_opts %> --tags ~@wip <%= java_default_opts %> <%= ignore_opts %>

--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -385,7 +385,6 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
-  @requires-aruba-version-1
   Scenario: Detect output from all processes
     Given an executable named "bin/aruba-test-cli1" with:
     """bash
@@ -488,7 +487,6 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
-  @requires-aruba-version-1
   Scenario: Detect output from all processes normal and interactive ones
     Given an executable named "bin/aruba-test-cli1" with:
     """

--- a/features/04_aruba_api/command/use_last_command_stopped.feature
+++ b/features/04_aruba_api/command/use_last_command_stopped.feature
@@ -55,7 +55,6 @@ Feature: Return last command stopped
     Then the specs should all pass
 
 
-  @requires-aruba-version-1
   Scenario: No command has been started
     Given a file named "spec/run_spec.rb" with:
     """ruby
@@ -68,7 +67,6 @@ Feature: Return last command stopped
     When I run `rspec`
     Then the specs should all pass
 
-  @requires-aruba-version-1
   Scenario: No command has been stopped
     Given an executable named "bin/aruba-test-cli" with:
     """bash

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -71,13 +71,7 @@ Before '@requires-ruby-version-2' do |scenario|
 end
 
 Before '@requires-aruba-version-1' do |scenario|
-  next if Aruba::VERSION > '1'
-
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  next
 end
 
 Before '@requires-ruby-platform-java' do |scenario|

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -70,10 +70,6 @@ Before '@requires-ruby-version-2' do |scenario|
   end
 end
 
-Before '@requires-aruba-version-1' do |scenario|
-  next
-end
-
 Before '@requires-ruby-platform-java' do |scenario|
   # leave if java
   next if RUBY_PLATFORM.include? 'java'

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -273,11 +273,6 @@ module Aruba
         command = run_command(cmd, opts)
         command.stop
 
-        if Aruba::VERSION < '1'
-          @last_exit_status = command.exit_status
-          @timed_out = command.timed_out?
-        end
-
         if fail_on_error
           begin
             expect(command).to have_finished_in_time

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -120,8 +120,6 @@ module Aruba
       # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/CyclomaticComplexity
       def expand_path(file_name, dir_string = nil)
-        check_for_deprecated_variables if Aruba::VERSION < '1'
-
         # rubocop:disable Metrics/LineLength
         message = %(Filename "#{file_name}" needs to be a string. It cannot be nil or empty either.  Please use `expand_path('.')` if you want the current directory to be expanded.)
         # rubocop:enable Metrics/LineLength

--- a/lib/aruba/config.rb
+++ b/lib/aruba/config.rb
@@ -38,12 +38,8 @@ module Aruba
     option_accessor :command_launcher, :contract => { Aruba::Contracts::Enum[:in_process, :spawn, :debug] => Aruba::Contracts::Enum[:in_process, :spawn, :debug] }, :default => :spawn
     option_accessor :main_class, :contract => { Class => Maybe[Class] }, :default => nil
 
-    if Aruba::VERSION >= '1.0.0'
-      option_accessor :home_directory, :contract => { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] } do |config|
-        File.join(config.root_directory.value, config.working_directory.value)
-      end
-    else
-      option_accessor :home_directory, :contract => { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] }, :default => ENV['HOME']
+    option_accessor :home_directory, :contract => { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] } do |config|
+      File.join(config.root_directory.value, config.working_directory.value)
     end
 
     option_accessor :log_level, :contract => { Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] => Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] }, :default => :info

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -171,23 +171,10 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
                             :an_output_string_including
                           end
 
-  if Aruba::VERSION < '1.0'
-    combined_output = commands.map do |c|
-      c.stop
-      c.send(channel.to_sym).chomp
-    end.join("\n")
-
-    if negated
-      expect(combined_output).not_to send(output_string_matcher, expected)
-    else
-      expect(combined_output).to send(output_string_matcher, expected)
-    end
+  if negated
+    expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
   else
-    if negated
-      expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
-    else
-      expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
-    end
+    expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
   end
 end
 
@@ -219,23 +206,10 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
                             :an_output_string_including
                           end
 
-  if Aruba::VERSION < '1.0'
-    combined_output = commands.map do |c|
-      c.stop
-      c.send(channel.to_sym).chomp
-    end.join("\n")
-
-    if negated
-      expect(combined_output).not_to send(output_string_matcher, expected)
-    else
-      expect(combined_output).to send(output_string_matcher, expected)
-    end
+  if negated
+    expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
   else
-    if negated
-      expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
-    else
-      expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
-    end
+    expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
   end
 end
 

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -3,10 +3,8 @@ require 'aruba/api'
 require 'aruba/platform'
 World(Aruba::Api)
 
-if Aruba::VERSION >= '1.0.0'
-  Around do |_, block|
-    with_environment(&block)
-  end
+Around do |_, block|
+  with_environment(&block)
 end
 
 Before do

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -45,18 +45,7 @@ module Aruba
       raise ArgumentError, e.message
     end
 
-    if Aruba::VERSION < '1'
-      # Return the last command stopped
-      def last_command_stopped
-        return @last_command_stopped unless @last_command_stopped.nil?
-
-        registered_commands.each(&:stop)
-
-        @last_command_stopped
-      end
-    else
-      attr_reader :last_command_stopped
-    end
+    attr_reader :last_command_stopped
 
     # Set last command started
     #

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -26,15 +26,13 @@ RSpec.configure do |config|
     stop_all_commands
   end
 
-  if Aruba::VERSION >= '1.0.0'
-    config.around :each do |example|
-      if self.class.include? Aruba::Api
-        with_environment do
-          example.run
-        end
-      else
+  config.around :each do |example|
+    if self.class.include? Aruba::Api
+      with_environment do
         example.run
       end
+    else
+      example.run
     end
   end
 

--- a/spec/aruba/api/deprecated_spec.rb
+++ b/spec/aruba/api/deprecated_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-if Aruba::VERSION <= '1.0.0'
+if Aruba::VERSION <= '1.1.0'
   RSpec.describe 'Deprecated API' do
     include_context 'uses aruba API'
 


### PR DESCRIPTION
## Summary

Aruba contains many conditionals on Aruba::VERSION. With the pending release of 1.0.0, many of these will forever be true (or false, as the case may be). This PR removes these conditionals and any old code that will remain unused.

## Motivation and Context

Part of cleaning up stuff for the 1.0.0 release.

## Types of changes

- Refactoring (cleanup of codebase withouth changing any existing functionality)