### PR TITLE
Fix final cuke failures

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
@@ -1,7 +1,8 @@
 Feature: Check exit status of commands
 
   Use the `the exit status should be \d`-step to check the exit status of the
-  last command which was executed.
+  last command which was finished. If no commands have finished yet, it stops
+  the one that was started last.
 
   Background:
     Given I use a fixture named "cli-app"

--- a/features/04_aruba_api/filesystem/use_fixtures.feature
+++ b/features/04_aruba_api/filesystem/use_fixtures.feature
@@ -17,7 +17,7 @@ Feature: Use fixtures in your tests
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before :each { copy '%/song.mp3', 'file.mp3' }
+          before(:each) { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -35,8 +35,8 @@ Feature: Use fixtures in your tests
     require 'spec_helper'
 
     RSpec.describe 'My Feature', :type => :aruba do
-      before :each { copy '%/my_file.txt', 'new_file.txt' }
-      before :each { run_command 'aruba-test-cli new_file.txt' }
+      before(:each) { copy '%/my_file.txt', 'new_file.txt' }
+      before(:each) { run_command 'aruba-test-cli new_file.txt' }
 
       it { expect(last_command_started).to have_output 'Hello Aruba!' }
     end
@@ -56,14 +56,14 @@ Feature: Use fixtures in your tests
     Then the specs should all pass
 
   Scenario: Use a fixture for your tests in test/
-    Given a file named "features/fixtures.feature" with:
+    Given a file named "spec/fixture_spec.rb" with:
     """
     require 'spec_helper'
 
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before :each { copy '%/song.mp3', 'file.mp3' }
+          before(:each) { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -71,19 +71,19 @@ Feature: Use fixtures in your tests
     end
     """
     And a directory named "test/fixtures"
-    And an empty file named "test/fixtures/fixtures-app/test.txt"
+    And an empty file named "test/fixtures/song.mp3"
     When I run `rspec`
     Then the specs should all pass
 
   Scenario: Use a fixture for your tests in spec/
-    Given a file named "features/fixtures.feature" with:
+    Given a file named "spec/fixture_spec.rb" with:
     """
     require 'spec_helper'
 
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before :each { copy '%/song.mp3', 'file.mp3' }
+          before(:each) { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -91,19 +91,19 @@ Feature: Use fixtures in your tests
     end
     """
     And a directory named "spec/fixtures"
-    And an empty file named "spec/fixtures/fixtures-app/test.txt"
+    And an empty file named "spec/fixtures/song.mp3"
     When I run `rspec`
     Then the specs should all pass
 
   Scenario: Use a fixture for your tests in features/
-    Given a file named "features/fixtures.feature" with:
+    Given a file named "spec/fixture_spec.rb" with:
     """
     require 'spec_helper'
 
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before :each { copy '%/song.mp3', 'file.mp3' }
+          before(:each) { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -111,6 +111,6 @@ Feature: Use fixtures in your tests
     end
     """
     And a directory named "features/fixtures"
-    And an empty file named "features/fixtures/fixtures-app/test.txt"
+    And an empty file named "features/fixtures/song.mp3"
     When I run `rspec`
     Then the specs should all pass

--- a/features/07_development_of_aruba/build-aruba.feature
+++ b/features/07_development_of_aruba/build-aruba.feature
@@ -9,4 +9,4 @@ Feature: Build Aruba Gem
     To build the `aruba`-gem you can use the `gem:build`-rake task.
 
     Given I successfully run `rake rubygem:build`
-    Then the output should match %r<aruba \d+\.\d+\.\d+ built to pkg/aruba-\d+\.\d+\.\d+.gem>
+    Then the output should match %r<aruba \d+\.\d+\.\d+[\.\w]* built to pkg/aruba-\d+\.\d+\.\d+[\.\w]*\.gem>

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -280,6 +280,8 @@ Then(/^the exit status should( not)? be (\d+)$/) do |negated, exit_status|
 end
 
 Then(/^it should( not)? (pass|fail) with "(.*?)"$/) do |negated, pass_fail, expected|
+  last_command_started.stop
+
   if pass_fail == 'pass'
     expect(last_command_stopped).to be_successfully_executed
   else
@@ -294,6 +296,8 @@ Then(/^it should( not)? (pass|fail) with "(.*?)"$/) do |negated, pass_fail, expe
 end
 
 Then(/^it should( not)? (pass|fail) with:$/) do |negated, pass_fail, expected|
+  last_command_started.stop
+
   if pass_fail == 'pass'
     expect(last_command_stopped).to be_successfully_executed
   else
@@ -308,6 +312,8 @@ Then(/^it should( not)? (pass|fail) with:$/) do |negated, pass_fail, expected|
 end
 
 Then(/^it should( not)? (pass|fail) with exactly:$/) do |negated, pass_fail, expected|
+  last_command_started.stop
+
   if pass_fail == 'pass'
     expect(last_command_stopped).to be_successfully_executed
   else
@@ -322,6 +328,8 @@ Then(/^it should( not)? (pass|fail) with exactly:$/) do |negated, pass_fail, exp
 end
 
 Then(/^it should( not)? (pass|fail) (?:with regexp?|matching):$/) do |negated, pass_fail, expected|
+  last_command_started.stop
+
   if pass_fail == 'pass'
     expect(last_command_stopped).to be_successfully_executed
   else

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -268,6 +268,10 @@ Then(/^the output should( not)? match:$/) do |negated, expected|
 end
 
 Then(/^the exit status should( not)? be (\d+)$/) do |negated, exit_status|
+  if last_command_stopped.nil?
+    last_command_started.stop
+  end
+
   if negated
     expect(last_command_stopped).not_to have_exit_status exit_status.to_i
   else


### PR DESCRIPTION
## Summary

Fixes the remaining cucumber scenarios.

## Details

* Ensures at least one command is stopped before checking its exit status. Also updates the behavior described in the corresponding cucumber feature.
* Adjust the `should( not)? (pass|fail)` steps to do the same.
* Fix the aruba version matcher in the `build-aruba` feature.
* Fix the fixture feature not cause syntax errors and also actually run specs in each scenario.

## Motivation and Context

This final change should make the full cucumber suite pass.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Documentation fix