### PR TITLE
Remove transitive deprecations

### DIFF
--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -153,7 +153,7 @@ When(/^I wait for (?:output|stdout) to contain "([^"]*)"$/) do |expected|
 end
 
 Then(/^the output should be (\d+) bytes long$/) do |size|
-  expect(all_output).to have_output_size size.to_i
+  expect(last_command_started.output).to be_size size.to_i
 end
 
 Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain( exactly)? "([^"]*)"$/) do |channel, cmd, negated, exactly, expected|

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -16,7 +16,6 @@ Before do
 end
 
 After do
-  restore_env
   terminate_all_commands
   aruba.command_monitor.clear
 end

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -16,7 +16,6 @@ RSpec.configure do |config|
   # Setup environment for aruba
   config.around :each do |example|
     if self.class.include? Aruba::Api
-      restore_env
       setup_aruba
     end
 

--- a/spec/aruba/api/deprecated_spec.rb
+++ b/spec/aruba/api/deprecated_spec.rb
@@ -293,4 +293,16 @@ RSpec.describe 'Deprecated API' do
     end
   end
 
+  describe "#get_process" do
+    before(:each){@aruba.run_simple "true"}
+    after(:each) { @aruba.all_commands.each(&:stop) }
+
+    it "returns a process" do
+      expect(@aruba.get_process("true")).not_to be(nil)
+    end
+
+    it "raises a descriptive exception" do
+      expect { @aruba.get_process("false") }.to raise_error CommandNotFoundError, "No command named 'false' has been started"
+    end
+  end
 end

--- a/spec/aruba/api/deprecated_spec.rb
+++ b/spec/aruba/api/deprecated_spec.rb
@@ -26,4 +26,271 @@ RSpec.describe 'Deprecated API' do
       end . to raise_error RSpec::Expectations::ExpectationNotMetError
     end
   end
+
+  describe '#filesystem_permissions' do
+    def actual_permissions
+      format( "%o" , File::Stat.new(file_path).mode )[-4,4]
+    end
+
+    let(:file_name) { @file_name }
+    let(:file_path) { @file_path }
+    let(:permissions) { '0655' }
+
+    before :each do
+      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
+    end
+
+    before(:each) do
+      File.open(file_path, 'w') { |f| f << "" }
+    end
+
+    before(:each) do
+      @aruba.filesystem_permissions(permissions, file_name)
+    end
+
+    context 'when file exists' do
+      context 'and permissions are given as string' do
+        it { expect(actual_permissions).to eq('0655') }
+      end
+
+      context 'and permissions are given as octal number' do
+        let(:permissions) { 0655 }
+        it { expect(actual_permissions).to eq('0655') }
+      end
+
+      context 'and path has ~ in it' do
+        let(:path) { random_string }
+        let(:file_name) { File.join('~', path) }
+        let(:file_path) { File.join(@aruba.aruba.current_directory, path) }
+
+        it { expect(actual_permissions).to eq('0655') }
+      end
+    end
+  end
+
+  describe '#check_filesystem_permissions' do
+    let(:file_name) { @file_name }
+    let(:file_path) { @file_path }
+
+    let(:permissions) { '0655' }
+
+    before :each do
+      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
+    end
+
+    before(:each) do
+      File.open(file_path, 'w') { |f| f << "" }
+    end
+
+    before(:each) do
+      @aruba.filesystem_permissions(permissions, file_name)
+    end
+
+    context 'when file exists' do
+      context 'and should have permissions' do
+        context 'and permissions are given as string' do
+          it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
+        end
+
+        context 'and permissions are given as octal number' do
+          let(:permissions) { 0666 }
+
+          it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
+        end
+
+        context 'and path includes ~' do
+          let(:string) { random_string }
+          let(:file_name) { File.join('~', string) }
+          let(:file_path) { File.join(@aruba.aruba.current_directory, string) }
+
+          it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
+        end
+
+        context 'but fails because the permissions are different' do
+          let(:expected_permissions) { 0666 }
+
+          it { expect { @aruba.check_filesystem_permissions(expected_permissions, file_name, true) }.to raise_error }
+        end
+      end
+
+      context 'and should not have permissions' do
+        context 'and succeeds when the difference is expected and permissions are different' do
+          let(:different_permissions) { 0666 }
+
+          it { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }
+        end
+
+        context 'and fails because the permissions are the same although they should be different' do
+          let(:different_permissions) { 0655 }
+
+          it { expect { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }.to raise_error }
+        end
+      end
+    end
+  end
+
+  context '#check_file_presence' do
+    before(:each) { File.open(@file_path, 'w') { |f| f << "" } }
+
+    it "should check existence using plain match" do
+      file_name = 'nested/dir/hello_world.txt'
+      file_path = File.join(@aruba.aruba.current_directory, file_name)
+
+      Aruba.platform.mkdir(File.dirname(file_path))
+      File.open(file_path, 'w') { |f| f << "" }
+
+      @aruba.check_file_presence(file_name)
+      @aruba.check_file_presence([file_name])
+      @aruba.check_file_presence([file_name], true)
+      @aruba.check_file_presence(['asdf'], false)
+    end
+
+    it "should check existence using regex" do
+      file_name = 'nested/dir/hello_world.txt'
+      file_path = File.join(@aruba.aruba.current_directory, file_name)
+
+      Aruba.platform.mkdir(File.dirname(file_path))
+      File.open(file_path, 'w') { |f| f << "" }
+
+      @aruba.check_file_presence([ /test123/ ], false )
+      @aruba.check_file_presence([ /hello_world.txt$/ ], true )
+      @aruba.check_file_presence([ /dir/ ], true )
+      @aruba.check_file_presence([ %r{nested/.+/} ], true )
+    end
+
+    it "is no problem to mix both" do
+      file_name = 'nested/dir/hello_world.txt'
+      file_path = File.join(@aruba.aruba.current_directory, file_name)
+
+      Aruba.platform.mkdir(File.dirname(file_path))
+      File.open(file_path, 'w') { |f| f << "" }
+
+      @aruba.check_file_presence([ file_name, /nested/  ], true )
+      @aruba.check_file_presence([ /test123/, 'asdf' ], false )
+    end
+
+    it "works with ~ in path name" do
+      file_path = File.join('~', random_string)
+
+      @aruba.with_environment 'HOME' => File.expand_path(@aruba.aruba.current_directory) do
+        Aruba.platform.mkdir(File.dirname(File.expand_path(file_path)))
+        File.open(File.expand_path(file_path), 'w') { |f| f << "" }
+
+        @aruba.check_file_presence( [ file_path ], true )
+      end
+    end
+  end
+
+  context "check file content" do
+    before :example do
+      @aruba.write_file(@file_name, "foo bar baz")
+    end
+
+    describe "#check_binary_file_content" do
+      let(:file_name) { @file_name }
+      let(:file_path) { @file_path }
+
+      let(:reference_file) { 'fixture' }
+      let(:reference_file_content) { 'foo bar baz' }
+
+      before :each do
+        @aruba.write_file(reference_file, reference_file_content)
+      end
+
+      context 'when files are the same' do
+        context 'and this is expected' do
+          it { @aruba.check_binary_file_content(file_name, reference_file) }
+          it { @aruba.check_binary_file_content(file_name, reference_file, true) }
+        end
+
+        context 'and this is not expected' do
+          it { expect { @aruba.check_binary_file_content(file_name, reference_file, false) }.to raise_error }
+        end
+      end
+
+      context 'when files are not the same' do
+        let(:reference_file_content) { 'bar' }
+
+        context 'and this is expected' do
+          it { @aruba.check_binary_file_content(file_name, reference_file, false) }
+        end
+
+        context 'and this is not expected' do
+          it { expect { @aruba.check_binary_file_content(file_name, reference_file, true) }.to raise_error }
+        end
+      end
+    end
+
+    context "#check_file_content" do
+      context "with regexp" do
+        let(:matching_content){/bar/}
+        let(:non_matching_content){/nothing/}
+        it "succeeds if file content matches" do
+          @aruba.check_file_content(@file_name, matching_content)
+          @aruba.check_file_content(@file_name, matching_content, true)
+        end
+
+        it "succeeds if file content does not match" do
+          @aruba.check_file_content(@file_name, non_matching_content, false)
+        end
+
+        it "works with ~ in path name" do
+          file_path = File.join('~', random_string)
+
+          @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
+            @aruba.write_file(file_path, "foo bar baz")
+            @aruba.check_file_content(file_path, non_matching_content, false)
+          end
+        end
+      end
+      context "with string" do
+        let(:matching_content){"foo bar baz"}
+        let(:non_matching_content){"bar"}
+        it "succeeds if file content matches" do
+          @aruba.check_file_content(@file_name, matching_content)
+          @aruba.check_file_content(@file_name, matching_content, true)
+        end
+
+        it "succeeds if file content does not match" do
+          @aruba.check_file_content(@file_name, non_matching_content, false)
+        end
+
+        it "works with ~ in path name" do
+          file_path = File.join('~', random_string)
+
+          @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
+            @aruba.write_file(file_path, "foo bar baz")
+            @aruba.check_file_content(file_path, non_matching_content, false)
+          end
+        end
+      end
+    end
+  end
+
+  context '#check_file_size' do
+    it "should check an existing file size" do
+      @aruba.write_fixed_size_file(@file_name, @file_size)
+      @aruba.check_file_size([[@file_name, @file_size]])
+    end
+
+    it "should check an existing file size and fail" do
+      @aruba.write_fixed_size_file(@file_name, @file_size)
+      expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
+    end
+
+    it "works with ~ in path name" do
+      file_path = File.join('~', random_string)
+
+      @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
+        @aruba.write_fixed_size_file(file_path, @file_size)
+        @aruba.check_file_size([[file_path, @file_size]])
+      end
+    end
+
+    it "should check an existing file size and fail" do
+      @aruba.write_fixed_size_file(@file_name, @file_size)
+      expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
+    end
+  end
+
 end

--- a/spec/aruba/api/deprecated_spec.rb
+++ b/spec/aruba/api/deprecated_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Deprecated API' do
         context 'but fails because the permissions are different' do
           let(:expected_permissions) { 0666 }
 
-          it { expect { @aruba.check_filesystem_permissions(expected_permissions, file_name, true) }.to raise_error }
+          it { expect { @aruba.check_filesystem_permissions(expected_permissions, file_name, true) }.to raise_error RSpec::Expectations::ExpectationNotMetError }
         end
       end
 
@@ -123,7 +123,7 @@ RSpec.describe 'Deprecated API' do
         context 'and fails because the permissions are the same although they should be different' do
           let(:different_permissions) { 0655 }
 
-          it { expect { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }.to raise_error }
+          it { expect { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }.to raise_error RSpec::Expectations::ExpectationNotMetError }
         end
       end
     end
@@ -204,7 +204,7 @@ RSpec.describe 'Deprecated API' do
         end
 
         context 'and this is not expected' do
-          it { expect { @aruba.check_binary_file_content(file_name, reference_file, false) }.to raise_error }
+          it { expect { @aruba.check_binary_file_content(file_name, reference_file, false) }.to raise_error RSpec::Expectations::ExpectationNotMetError }
         end
       end
 
@@ -216,7 +216,7 @@ RSpec.describe 'Deprecated API' do
         end
 
         context 'and this is not expected' do
-          it { expect { @aruba.check_binary_file_content(file_name, reference_file, true) }.to raise_error }
+          it { expect { @aruba.check_binary_file_content(file_name, reference_file, true) }.to raise_error RSpec::Expectations::ExpectationNotMetError }
         end
       end
     end
@@ -275,7 +275,7 @@ RSpec.describe 'Deprecated API' do
 
     it "should check an existing file size and fail" do
       @aruba.write_fixed_size_file(@file_name, @file_size)
-      expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
+      expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error RSpec::Expectations::ExpectationNotMetError
     end
 
     it "works with ~ in path name" do
@@ -289,7 +289,7 @@ RSpec.describe 'Deprecated API' do
 
     it "should check an existing file size and fail" do
       @aruba.write_fixed_size_file(@file_name, @file_size)
-      expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
+      expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error RSpec::Expectations::ExpectationNotMetError
     end
   end
 

--- a/spec/aruba/api/deprecated_spec.rb
+++ b/spec/aruba/api/deprecated_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe 'Deprecated API' do
+  include_context 'uses aruba API'
+
+  around do |example|
+    Aruba.platform.with_environment do
+      example.run
+    end
+  end
+
+  before do
+    allow(Aruba.platform).to receive(:deprecated)
+  end
+
+  describe "#assert_not_matching_output" do
+    before(:each){ @aruba.run_simple("echo foo", false) }
+    after(:each) { @aruba.all_commands.each(&:stop) }
+
+    it "passes when the output doesn't match a regexp" do
+      @aruba.assert_not_matching_output "bar", @aruba.all_output
+    end
+    it "fails when the output does match a regexp" do
+      expect do
+        @aruba.assert_not_matching_output "foo", @aruba.all_output
+      end . to raise_error RSpec::Expectations::ExpectationNotMetError
+    end
+  end
+end

--- a/spec/aruba/api/environment/restore_env_spec.rb
+++ b/spec/aruba/api/environment/restore_env_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'Command Environment' do
     end
   end
 
+  before do
+    allow(Aruba.platform).to receive(:deprecated)
+  end
+
   describe '#restore_env' do
     context 'when non-existing variable' do
       before :each do

--- a/spec/aruba/api/environment/restore_env_spec.rb
+++ b/spec/aruba/api/environment/restore_env_spec.rb
@@ -66,4 +66,21 @@ RSpec.describe 'Command Environment' do
       end
     end
   end
+
+  describe "#restore_env" do
+    after(:each) { @aruba.all_commands.each(&:stop) }
+    it "restores environment variable" do
+      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
+      @aruba.restore_env
+      @aruba.run "env"
+      expect(@aruba.all_output).not_to include("LONG_LONG_ENV_VARIABLE")
+    end
+    it "restores environment variable that has been set multiple times" do
+      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
+      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'false'
+      @aruba.restore_env
+      @aruba.run "env"
+      expect(@aruba.all_output).not_to include("LONG_LONG_ENV_VARIABLE")
+    end
+  end
 end

--- a/spec/aruba/api/environment/set_env_spec.rb
+++ b/spec/aruba/api/environment/set_env_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe 'Command Environment' do
     end
   end
 
+  before do
+    allow(Aruba.platform).to receive(:deprecated)
+  end
+
   describe '#set_env' do
     context 'when non-existing variable' do
       before :each do

--- a/spec/aruba/api/filesystem/file_size_spec.rb
+++ b/spec/aruba/api/filesystem/file_size_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Filesystem Api' do
 
     context 'when file does not exist' do
       let(:name) { 'non_existing_file' }
-      it { expect { size }.to raise_error }
+      it { expect { size }.to raise_error RSpec::Expectations::ExpectationNotMetError }
     end
   end
 end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'securerandom'
 require 'aruba/api'
 require 'fileutils'
 
@@ -748,33 +747,7 @@ describe Aruba::Api do
       end
     end
 
-    context '#check_file_size' do
-      it "should check an existing file size" do
-        @aruba.write_fixed_size_file(@file_name, @file_size)
-        @aruba.check_file_size([[@file_name, @file_size]])
-      end
-
-      it "should check an existing file size and fail" do
-        @aruba.write_fixed_size_file(@file_name, @file_size)
-        expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
-      end
-
-      it "works with ~ in path name" do
-        file_path = File.join('~', random_string)
-
-        @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
-          @aruba.write_fixed_size_file(file_path, @file_size)
-          @aruba.check_file_size([[file_path, @file_size]])
-        end
-      end
-
-      it "should check an existing file size and fail" do
-        @aruba.write_fixed_size_file(@file_name, @file_size)
-        expect { @aruba.check_file_size([[@file_name, @file_size + 1]]) }.to raise_error
-      end
-    end
-
-    describe '#filesystem_permissions' do
+    describe '#chmod' do
       def actual_permissions
         format( "%o" , File::Stat.new(file_path).mode )[-4,4]
       end
@@ -792,7 +765,7 @@ describe Aruba::Api do
       end
 
       before(:each) do
-        @aruba.filesystem_permissions(permissions, file_name)
+        @aruba.chmod(permissions, file_name)
       end
 
       context 'when file exists' do
@@ -811,205 +784,6 @@ describe Aruba::Api do
           let(:file_path) { File.join(@aruba.aruba.current_directory, path) }
 
           it { expect(actual_permissions).to eq('0655') }
-        end
-      end
-    end
-
-    describe '#check_filesystem_permissions' do
-      let(:file_name) { @file_name }
-      let(:file_path) { @file_path }
-
-      let(:permissions) { '0655' }
-
-      before :each do
-        @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
-      end
-
-      before(:each) do
-        File.open(file_path, 'w') { |f| f << "" }
-      end
-
-      before(:each) do
-        @aruba.filesystem_permissions(permissions, file_name)
-      end
-
-      context 'when file exists' do
-        context 'and should have permissions' do
-          context 'and permissions are given as string' do
-            it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
-          end
-
-          context 'and permissions are given as octal number' do
-            let(:permissions) { 0666 }
-
-            it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
-          end
-
-          context 'and path includes ~' do
-            let(:string) { random_string }
-            let(:file_name) { File.join('~', string) }
-            let(:file_path) { File.join(@aruba.aruba.current_directory, string) }
-
-            it { @aruba.check_filesystem_permissions(permissions, file_name, true) }
-          end
-
-          context 'but fails because the permissions are different' do
-            let(:expected_permissions) { 0666 }
-
-            it { expect { @aruba.check_filesystem_permissions(expected_permissions, file_name, true) }.to raise_error }
-          end
-        end
-
-        context 'and should not have permissions' do
-          context 'and succeeds when the difference is expected and permissions are different' do
-            let(:different_permissions) { 0666 }
-
-            it { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }
-          end
-
-          context 'and fails because the permissions are the same although they should be different' do
-            let(:different_permissions) { 0655 }
-
-            it { expect { @aruba.check_filesystem_permissions(different_permissions, file_name, false) }.to raise_error }
-          end
-        end
-      end
-    end
-
-    context '#check_file_presence' do
-      before(:each) { File.open(@file_path, 'w') { |f| f << "" } }
-
-      it "should check existence using plain match" do
-        file_name = 'nested/dir/hello_world.txt'
-        file_path = File.join(@aruba.aruba.current_directory, file_name)
-
-        Aruba.platform.mkdir(File.dirname(file_path))
-        File.open(file_path, 'w') { |f| f << "" }
-
-        @aruba.check_file_presence(file_name)
-        @aruba.check_file_presence([file_name])
-        @aruba.check_file_presence([file_name], true)
-        @aruba.check_file_presence(['asdf'], false)
-      end
-
-      it "should check existence using regex" do
-        file_name = 'nested/dir/hello_world.txt'
-        file_path = File.join(@aruba.aruba.current_directory, file_name)
-
-        Aruba.platform.mkdir(File.dirname(file_path))
-        File.open(file_path, 'w') { |f| f << "" }
-
-        @aruba.check_file_presence([ /test123/ ], false )
-        @aruba.check_file_presence([ /hello_world.txt$/ ], true )
-        @aruba.check_file_presence([ /dir/ ], true )
-        @aruba.check_file_presence([ %r{nested/.+/} ], true )
-      end
-
-      it "is no problem to mix both" do
-        file_name = 'nested/dir/hello_world.txt'
-        file_path = File.join(@aruba.aruba.current_directory, file_name)
-
-        Aruba.platform.mkdir(File.dirname(file_path))
-        File.open(file_path, 'w') { |f| f << "" }
-
-        @aruba.check_file_presence([ file_name, /nested/  ], true )
-        @aruba.check_file_presence([ /test123/, 'asdf' ], false )
-      end
-
-      it "works with ~ in path name" do
-        file_path = File.join('~', random_string)
-
-        @aruba.with_environment 'HOME' => File.expand_path(@aruba.aruba.current_directory) do
-          Aruba.platform.mkdir(File.dirname(File.expand_path(file_path)))
-          File.open(File.expand_path(file_path), 'w') { |f| f << "" }
-
-          @aruba.check_file_presence( [ file_path ], true )
-        end
-      end
-    end
-
-    context "check file content" do
-      before :example do
-        @aruba.write_file(@file_name, "foo bar baz")
-      end
-
-      describe "#check_binary_file_content" do
-        let(:file_name) { @file_name }
-        let(:file_path) { @file_path }
-
-        let(:reference_file) { 'fixture' }
-        let(:reference_file_content) { 'foo bar baz' }
-
-        before :each do
-          @aruba.write_file(reference_file, reference_file_content)
-        end
-
-        context 'when files are the same' do
-          context 'and this is expected' do
-            it { @aruba.check_binary_file_content(file_name, reference_file) }
-            it { @aruba.check_binary_file_content(file_name, reference_file, true) }
-          end
-
-          context 'and this is not expected' do
-            it { expect { @aruba.check_binary_file_content(file_name, reference_file, false) }.to raise_error }
-          end
-        end
-
-        context 'when files are not the same' do
-          let(:reference_file_content) { 'bar' }
-
-          context 'and this is expected' do
-            it { @aruba.check_binary_file_content(file_name, reference_file, false) }
-          end
-
-          context 'and this is not expected' do
-            it { expect { @aruba.check_binary_file_content(file_name, reference_file, true) }.to raise_error }
-          end
-        end
-      end
-
-      context "#check_file_content" do
-        context "with regexp" do
-          let(:matching_content){/bar/}
-          let(:non_matching_content){/nothing/}
-          it "succeeds if file content matches" do
-            @aruba.check_file_content(@file_name, matching_content)
-            @aruba.check_file_content(@file_name, matching_content, true)
-          end
-
-          it "succeeds if file content does not match" do
-            @aruba.check_file_content(@file_name, non_matching_content, false)
-          end
-
-          it "works with ~ in path name" do
-            file_path = File.join('~', random_string)
-
-            @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
-              @aruba.write_file(file_path, "foo bar baz")
-              @aruba.check_file_content(file_path, non_matching_content, false)
-            end
-          end
-        end
-        context "with string" do
-          let(:matching_content){"foo bar baz"}
-          let(:non_matching_content){"bar"}
-          it "succeeds if file content matches" do
-            @aruba.check_file_content(@file_name, matching_content)
-            @aruba.check_file_content(@file_name, matching_content, true)
-          end
-
-          it "succeeds if file content does not match" do
-            @aruba.check_file_content(@file_name, non_matching_content, false)
-          end
-
-          it "works with ~ in path name" do
-            file_path = File.join('~', random_string)
-
-            @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
-              @aruba.write_file(file_path, "foo bar baz")
-              @aruba.check_file_content(file_path, non_matching_content, false)
-            end
-          end
         end
       end
     end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1159,7 +1159,6 @@ describe Aruba::Api do
   describe "#set_environment_variable" do
     after(:each) do
       @aruba.all_commands.each(&:stop)
-      @aruba.restore_env
     end
 
     it "set environment variable" do

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1104,20 +1104,6 @@ describe Aruba::Api do
     end
   end
 
-  describe "#assert_not_matching_output" do
-    before(:each){ @aruba.run_simple("echo foo", false) }
-    after(:each) { @aruba.all_commands.each(&:stop) }
-
-    it "passes when the output doesn't match a regexp" do
-      @aruba.assert_not_matching_output "bar", @aruba.all_output
-    end
-    it "fails when the output does match a regexp" do
-      expect do
-        @aruba.assert_not_matching_output "foo", @aruba.all_output
-      end . to raise_error RSpec::Expectations::ExpectationNotMetError
-    end
-  end
-
   describe '#run' do
     before(:each){ @aruba.run 'cat' }
     after(:each) { @aruba.all_commands.each(&:stop) }

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1176,21 +1176,4 @@ describe Aruba::Api do
         to include("LONG_LONG_ENV_VARIABLE=false")
     end
   end
-
-  describe "#restore_env" do
-    after(:each) { @aruba.all_commands.each(&:stop) }
-    it "restores environment variable" do
-      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.restore_env
-      @aruba.run "env"
-      expect(@aruba.all_output).not_to include("LONG_LONG_ENV_VARIABLE")
-    end
-    it "restores environment variable that has been set multiple times" do
-      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'false'
-      @aruba.restore_env
-      @aruba.run "env"
-      expect(@aruba.all_output).not_to include("LONG_LONG_ENV_VARIABLE")
-    end
-  end
 end # Aruba::Api

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1087,7 +1087,7 @@ describe Aruba::Api do
 
         it "should announce to stdout exactly once" do
           @aruba.run_simple('echo "hello world"', false)
-          expect(@aruba.all_output).to include('hello world')
+          expect(@aruba.last_command_started.output).to include('hello world')
         end
       end
 
@@ -1098,7 +1098,7 @@ describe Aruba::Api do
           end
 
           expect(result).not_to include('hello world')
-          expect(@aruba.all_output).to include('hello world')
+          expect(@aruba.last_command_started.output).to include('hello world')
         end
       end
     end
@@ -1111,20 +1111,20 @@ describe Aruba::Api do
     it "respond to input" do
       @aruba.type "Hello"
       @aruba.type ""
-      expect(@aruba.all_output).to eq "Hello\n"
+      expect(@aruba.last_command_started).to have_output "Hello"
     end
 
     it "respond to close_input" do
       @aruba.type "Hello"
       @aruba.close_input
-      expect(@aruba.all_output).to eq "Hello\n"
+      expect(@aruba.last_command_started).to have_output "Hello"
     end
 
     it "pipes data" do
       @aruba.write_file(@file_name, "Hello\nWorld!")
       @aruba.pipe_in_file(@file_name)
       @aruba.close_input
-      expect(@aruba.all_output).to eq "Hello\nWorld!"
+      expect(@aruba.last_command_started).to have_output "Hello\nWorld!"
     end
   end
 
@@ -1164,14 +1164,16 @@ describe Aruba::Api do
     it "set environment variable" do
       @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.run "env"
-      expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE=true")
+      expect(@aruba.last_command_started.output).
+        to include("LONG_LONG_ENV_VARIABLE=true")
     end
 
     it "overwrites environment variable" do
       @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'false'
       @aruba.run "env"
-      expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE=false")
+      expect(@aruba.last_command_started.output).
+        to include("LONG_LONG_ENV_VARIABLE=false")
     end
   end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1162,14 +1162,14 @@ describe Aruba::Api do
     end
 
     it "set environment variable" do
-      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
+      @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.run "env"
       expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE=true")
     end
 
     it "overwrites environment variable" do
-      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.set_env 'LONG_LONG_ENV_VARIABLE', 'false'
+      @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
+      @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'false'
       @aruba.run "env"
       expect(@aruba.all_output).to include("LONG_LONG_ENV_VARIABLE=false")
     end

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -902,20 +902,6 @@ describe Aruba::Api do
     end
   end
 
-  describe "#run_simple" do
-    before(:each){@aruba.run_simple "true"}
-    after(:each) { @aruba.all_commands.each(&:stop) }
-    describe "get_process" do
-      it "returns a process" do
-        expect(@aruba.get_process("true")).not_to be(nil)
-      end
-
-      it "raises a descriptive exception" do
-        expect { @aruba.get_process("false") }.to raise_error CommandNotFoundError, "No command named 'false' has been started"
-      end
-    end
-  end
-
   describe 'fixtures' do
     let(:api) do
       klass = Class.new do

--- a/spec/aruba/matchers/deprecated_spec.rb
+++ b/spec/aruba/matchers/deprecated_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe 'Deprecated matchers' do
+  include_context 'uses aruba API'
+
+  before do
+    allow(Aruba.platform).to receive(:deprecated)
+  end
+
+  describe 'to_match_path_pattern' do
+    context 'when pattern is string' do
+      context 'when there is file which matches path pattern' do
+        before :each do
+          Aruba.platform.write_file(@file_path, '')
+        end
+
+        it { expect(all_paths).to match_path_pattern(expand_path(@file_name)) }
+      end
+
+      context 'when there is not file which matches path pattern' do
+        it { expect(all_paths).not_to match_path_pattern('test') }
+      end
+    end
+
+    context 'when pattern is regex' do
+      context 'when there is file which matches path pattern' do
+        before :each do
+          Aruba.platform.write_file(@file_path, '')
+        end
+
+        it { expect(all_paths).to match_path_pattern(/test/) }
+      end
+
+      context 'when there is not file which matches path pattern' do
+        it { expect(all_paths).not_to match_path_pattern(/test/) }
+      end
+    end
+  end
+end

--- a/spec/aruba/matchers/directory_spec.rb
+++ b/spec/aruba/matchers/directory_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'Directory Matchers' do
 
   describe 'to_be_an_existing_directory' do
     let(:name) { 'test.d' }
-    let(:path) { File.join(@aruba.current_directory, name) }
+    let(:path) { @aruba.expand_path(name) }
 
     context 'when directory exists' do
       before :each do
@@ -25,7 +25,7 @@ RSpec.describe 'Directory Matchers' do
 
   describe 'to_have_sub_directory' do
     let(:name) { 'test.d' }
-    let(:path) { File.join(@aruba.current_directory, name) }
+    let(:path) { @aruba.expand_path(name) }
     let(:content) { %w(subdir.1.d subdir.2.d) }
 
     context 'when directory exists' do

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Path Matchers' do
 
   describe 'to_be_an_absolute_path' do
     let(:name) { @file_name }
-    let(:path) { File.expand_path(File.join(@aruba.current_directory, name)) }
+    let(:path) { @aruba.expand_path(name) }
 
     context 'when is absolute path' do
       it { expect(path).to be_an_absolute_path }
@@ -70,7 +70,7 @@ RSpec.describe 'Path Matchers' do
 
     context 'when directory' do
       let(:name) { 'test.d' }
-      let(:path) { File.join(@aruba.current_directory, name) }
+      let(:path) { @aruba.expand_path(name) }
 
       context 'exists' do
         before :each do

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -10,36 +10,6 @@ RSpec.describe 'Path Matchers' do
     @aruba.expand_path(*args)
   end
 
-  describe 'to_match_path_pattern' do
-    context 'when pattern is string' do
-      context 'when there is file which matches path pattern' do
-        before :each do
-          Aruba.platform.write_file(@file_path, '')
-        end
-
-        it { expect(all_paths).to match_path_pattern(expand_path(@file_name)) }
-      end
-
-      context 'when there is not file which matches path pattern' do
-        it { expect(all_paths).not_to match_path_pattern('test') }
-      end
-    end
-
-    context 'when pattern is regex' do
-      context 'when there is file which matches path pattern' do
-        before :each do
-          Aruba.platform.write_file(@file_path, '')
-        end
-
-        it { expect(all_paths).to match_path_pattern(/test/) }
-      end
-
-      context 'when there is not file which matches path pattern' do
-        it { expect(all_paths).not_to match_path_pattern(/test/) }
-      end
-    end
-  end
-
   describe 'to_be_an_absolute_path' do
     let(:name) { @file_name }
     let(:path) { @aruba.expand_path(name) }

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -1,4 +1,5 @@
 require 'fileutils'
+require 'securerandom'
 
 RSpec.shared_context 'uses aruba API' do
   def random_string(options = {})


### PR DESCRIPTION
## Summary

Ensures all non-deprecated Aruba API methods and steps only use non-deprecated methods. This way, the deprecation messages are actually useful.

## Details

* Block deprecation messages for specs of deprecated methods.
* Fix deprecation messages for specs of non-deprecated methods.
* TODO: Fix deprecation messages in cucumber scenarios.

## Motivation and Context

Provide a (relatively) smooth transition from 0.14.x to upcoming 1.0.0. See also https://github.com/cucumber/aruba/issues/361#issuecomment-217751617.

## How Has This Been Tested?

Specs have been run and no warnings are observed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
