### PR TITLE
[docs] YARD: avoid warnings and check the docs

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,5 +1,8 @@
 --output doc/yard
 --exclude features/
+--exclude bin/bootstrap
+--exclude bin/test
+--exclude license
 --verbose
 --markup-provider kramdown
 --markup markdown

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,13 @@ group :development, :test do
   # Code Coverage
   gem 'simplecov', '~> 0.10'
 
+  # API docs generation
+  gem 'yard', '~>0.9.9'
+
+  if RUBY_VERSION >= '2.3.0'
+    gem 'yard-junk', '~> 0'
+  end
+
   # Test api
   gem 'rspec', '~> 3.4'
   gem 'fuubar', '~> 2.2.0'

--- a/Rakefile
+++ b/Rakefile
@@ -72,6 +72,13 @@ namespace :lint do
   task :licenses do
     sh 'bundle exec license_finder'
   end
+
+  begin
+    require 'yard-junk/rake'
+    YardJunk::Rake.define_task
+  rescue LoadError
+    warn 'yard-junk requires Ruby 2.3.0. Rake task lint:yard:junk not loaded.'
+  end
 end
 
 namespace :rubygem do

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -234,7 +234,7 @@ module Aruba
       # @param [Hash] options
       #   Options for aruba
       #
-      # @option options [TrueClass,FalseClass] fail_on_error
+      # @option options [Boolean] fail_on_error
       #   Should aruba fail on error?
       #
       # @option options [Integer] exit_timeout

--- a/lib/aruba/api/command.rb
+++ b/lib/aruba/api/command.rb
@@ -119,16 +119,16 @@ module Aruba
       # @param [Hash] opts
       #   Options
       #
-      # @option [Integer] exit_timeout
+      # @option opts [Integer] exit_timeout
       #   If the timeout is reached the command will be killed
       #
-      # @option [Integer] io_wait_timeout
+      # @option opts [Integer] io_wait_timeout
       #   Wait for IO to finish
       #
-      # @option [Integer] startup_wait_time
+      # @option opts [Integer] startup_wait_time
       #   Wait for a command to start
       #
-      # @option [String] stop_signal
+      # @option opts [String] stop_signal
       #   Use signal to stop command
       #
       # @yield [SpawnProcess]
@@ -234,13 +234,13 @@ module Aruba
       # @param [Hash] options
       #   Options for aruba
       #
-      # @option [TrueClass,FalseClass] fail_on_error
+      # @option options [TrueClass,FalseClass] fail_on_error
       #   Should aruba fail on error?
       #
-      # @option [Integer] exit_timeout
+      # @option options [Integer] exit_timeout
       #   Timeout for execution
       #
-      # @option [Integer] io_wait_timeout
+      # @option options [Integer] io_wait_timeout
       #   Timeout for IO - STDERR, STDOUT
       #
       # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -116,7 +116,7 @@ module Aruba
       #   The command to by run
       #
       # @see #cmd
-      # @deprectated
+      # @deprecated
       def run_interactive(cmd)
         Aruba.platform.deprecated('The use of "#run_interactive" is deprecated. You can simply use "run" instead')
 
@@ -208,15 +208,11 @@ module Aruba
       # @deprecated
       # Check the file size of paths
       #
-      # @params [Hash] paths_and_sizes
+      # @param [Hash] paths_and_sizes
       #   A hash containing the path (key) and the expected size (value)
       #
       # @example
-      #
-      #   paths_and_sizes = {
-      #     'file' => 10
-      #   }
-      #
+      #   paths_and_sizes = { 'file' => 10 }
       #   check_file_size(paths_and_sizes)
       #
       def check_file_size(paths_and_sizes)

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -556,7 +556,7 @@ module Aruba
       #
       # Full compare arg1 and arg2
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If arg1 is exactly the same as arg2 return true, otherwise false
       def assert_exact_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_exact_output" is deprecated. Use "expect(command).to have_output \'exact\'" instead. There are also special matchers for "stdout" and "stderr"')
@@ -569,7 +569,7 @@ module Aruba
       #
       # Partial compare arg1 and arg2
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If arg2 contains arg1 return true, otherwise false
       def assert_partial_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_partial_output" is deprecated. Use "expect(command).to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
@@ -582,7 +582,7 @@ module Aruba
       #
       # Regex Compare arg1 and arg2
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If arg2 matches arg1 return true, otherwise false
       def assert_matching_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_matching_output" is deprecated. Use "expect(command).to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
@@ -595,7 +595,7 @@ module Aruba
       #
       # Negative regex compare arg1 and arg2
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If arg2 does not match arg1 return true, otherwise false
       def assert_not_matching_output(expected, actual)
         Aruba.platform.deprecated('The use of "#assert_not_matching_output" is deprecated. Use "expect(command).not_to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
@@ -608,7 +608,7 @@ module Aruba
       #
       # Negative partial compare arg1 and arg2
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If arg2 does not match/include arg1 return true, otherwise false
       def assert_no_partial_output(unexpected, actual)
         Aruba.platform.deprecated('The use of "#assert_no_partial_output" is deprecated. Use "expect(command).not_to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
@@ -625,7 +625,7 @@ module Aruba
       #
       # Partial compare output of interactive command and arg1
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If output of interactive command includes arg1 return true, otherwise false
       def assert_partial_output_interactive(expected)
         Aruba.platform.deprecated('The use of "#assert_partial_output_interactive" is deprecated. Use "expect(last_command_started).to have_output /partial/" instead. There are also special matchers for "stdout" and "stderr"')
@@ -637,7 +637,7 @@ module Aruba
       #
       # Check if command succeeded and if arg1 is included in output
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If exit status is 0 and arg1 is included in output return true, otherwise false
       def assert_passing_with(expected)
         Aruba.platform.deprecated('The use of "#assert_passing_with" is deprecated. Use "expect(all_commands).to all(be_successfully_executed).and include_an_object(have_output(/partial/))" or something similar instead. There are also special matchers for "stdout" and "stderr"')
@@ -650,7 +650,7 @@ module Aruba
       #
       # Check if command failed and if arg1 is included in output
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If exit status is not equal 0 and arg1 is included in output return true, otherwise false
       def assert_failing_with(expected)
         Aruba.platform.deprecated('The use of "#assert_passing_with" is deprecated. Use "expect(all_commands).not_to include_an_object(be_successfully_executed).and include_an_object(have_output(/partial/))" or something similar instead. There are also special matchers for "stdout" and "stderr"')
@@ -663,7 +663,7 @@ module Aruba
       #
       # Check exit status of process
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   If arg1 is true, return true if command was successful
       #   If arg1 is false, return true if command failed
       def assert_success(success)

--- a/lib/aruba/api/environment.rb
+++ b/lib/aruba/api/environment.rb
@@ -13,6 +13,8 @@ module Aruba
       #
       # @param [String] value
       #   The value of the environment variable. Needs to be a string.
+      #
+      # @return [self]
       def set_environment_variable(name, value)
         name = name.to_s
         value = value.to_s
@@ -33,6 +35,8 @@ module Aruba
       #
       # @param [String] value
       #   The value of the environment variable. Needs to be a string.
+      #
+      # @return [self]
       def append_environment_variable(name, value)
         name = name.to_s
         value = value.to_s
@@ -53,6 +57,8 @@ module Aruba
       #
       # @param [String] value
       #   The value of the environment variable. Needs to be a string.
+      #
+      # @return [self]
       def prepend_environment_variable(name, value)
         name = name.to_s
         value = value.to_s
@@ -68,11 +74,10 @@ module Aruba
 
       # Remove existing environment variable
       #
-      # @param [String] key
+      # @param [String] name
       #   The name of the environment variable as string, e.g. 'HOME'
       #
-      # @param [String] value
-      #   The value of the environment variable. Needs to be a string.
+      # @return [self]
       def delete_environment_variable(name)
         name = name.to_s
 

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -40,8 +40,10 @@ module Aruba
 
       # Check if file exist and is executable
       #
-      # @param [String] file
-      #   The file which should exist
+      # @param [String] path
+      #   The path which should exist and be executable
+      #
+      # @return [Boolean]
       def executable?(path)
         path = expand_path(path)
 
@@ -50,16 +52,14 @@ module Aruba
 
       # Check if path is absolute
       #
-      # @return [TrueClass, FalseClass]
-      #   Result of check
+      # @return [Boolean]
       def absolute?(path)
         ArubaPath.new(path).absolute?
       end
 
       # Check if path is relative
       #
-      # @return [TrueClass, FalseClass]
-      #   Result of check
+      # @return [Boolean]
       def relative?(path)
         ArubaPath.new(path).relative?
       end
@@ -69,7 +69,7 @@ module Aruba
       # @return [Array]
       #   List of files and directories
       def all_paths
-        list('.').map { |p| expand_path(p) }
+        list('.').map { |path| expand_path(path) }
       end
 
       # Return all existing files in current directory
@@ -128,10 +128,10 @@ module Aruba
       # The method does not check if file already exists. If the file name is a
       # path the method will create all neccessary directories.
       #
-      # @param [String] file_name
+      # @param [String] name
       #   The name of the file
       #
-      # @param [String] file_content
+      # @param [String] content
       #   The content which should be written to the file
       def write_file(name, content)
         Aruba.platform.create_file(expand_path(name), content, false)
@@ -252,10 +252,10 @@ module Aruba
       # The method does not check if file already exists. If the file name is a
       # path the method will create all neccessary directories.
       #
-      # @param [String] file_name
+      # @param [String] name
       #   The name of the file
       #
-      # @param [Integer] file_size
+      # @param [Integer] size
       #   The size of the file
       def write_fixed_size_file(name, size)
         Aruba.platform.create_fixed_size_file(expand_path(name), size, false)
@@ -297,8 +297,8 @@ module Aruba
                  mode
                end
 
-        args.each { |p| raise "Expected #{p} to be present" unless exist?(p) }
-        paths = args.map { |p| expand_path(p) }
+        args.each { |path| raise "Expected #{path} to be present" unless exist?(path) }
+        paths = args.map { |path| expand_path(path) }
 
         Aruba.platform.chmod(mode, paths, options)
 
@@ -342,7 +342,7 @@ module Aruba
                     {}
                   end
 
-        args = args.map { |p| expand_path(p) }
+        args = args.map { |path| expand_path(path) }
 
         Aruba.platform.rm(args, options)
       end
@@ -370,12 +370,11 @@ module Aruba
       # @param [Array, Path] paths
       #   The paths
       #
-      # @result [FileSize]
+      # @return [FileSize]
       #   Bytes on disk
-
       def disk_usage(*paths)
         expect(paths.flatten).to Aruba::Matchers.all be_an_existing_path
-        expanded = paths.flatten.map { |p| ArubaPath.new(expand_path(p)) }
+        expanded = paths.flatten.map { |path| ArubaPath.new(expand_path(path)) }
 
         # TODO: change the API so that you could set something like
         # aruba.config.fs_allocation_unit_size directly
@@ -394,6 +393,9 @@ module Aruba
       end
 
       # Get size of file
+      #
+      # @param [String] name
+      #   File name
       #
       # @return [Numeric]
       #   The size of the file

--- a/lib/aruba/api/text.rb
+++ b/lib/aruba/api/text.rb
@@ -36,9 +36,7 @@ module Aruba
         text.chomp
       end
 
-      # @experimental
-      #
-      # Replace variables in command string
+      # Replace variables in command string (experimental)
       #
       # @param [#to_s] text
       #   The text to parse

--- a/lib/aruba/aruba_path.rb
+++ b/lib/aruba/aruba_path.rb
@@ -48,8 +48,7 @@ module Aruba
     # @example
     #   path = ArubaPath.new 'path/to/dir.d'
     #   path.pop
-    #   puts path
-    #   # => path/to
+    #   puts path # => path/to
     def pop
       @delegate_sd_obj.pop
     end
@@ -60,9 +59,8 @@ module Aruba
     #   The count of file name parts
     #
     # @example
-    #
-    # path = ArubaPath.new('path/to/file.txt')
-    # path.depth # => 3
+    #   path = ArubaPath.new('path/to/file.txt')
+    #   path.depth # => 3
     #
     def depth
       __getobj__.each_filename.to_a.size

--- a/lib/aruba/hooks.rb
+++ b/lib/aruba/hooks.rb
@@ -18,7 +18,7 @@ module Aruba
     # @param [String, Symbol] label
     #   The name of the hook
     #
-    # @para [Proc] block
+    # @param [Proc] block
     #   The block which should be run for the hook
     def append(label, block)
       if store.key?(label.to_sym) && store[label.to_sym].respond_to?(:<<)

--- a/lib/aruba/matchers/command/be_successfully_executed.rb
+++ b/lib/aruba/matchers/command/be_successfully_executed.rb
@@ -6,7 +6,7 @@ require 'aruba/matchers/command/have_finished_in_time'
 # @!method be_successfuly_executed
 #   This matchers checks if execution of <command> was successful
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command was not successful

--- a/lib/aruba/matchers/command/have_exit_status.rb
+++ b/lib/aruba/matchers/command/have_exit_status.rb
@@ -4,7 +4,7 @@
 #   @param [Integer] status
 #     The value of the exit status
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command does not have exit status

--- a/lib/aruba/matchers/command/have_finished_in_time.rb
+++ b/lib/aruba/matchers/command/have_finished_in_time.rb
@@ -4,7 +4,7 @@ require 'rspec/expectations/version'
 #   This matchers checks if <command> run too long. Say the timeout is 10
 #   seconds and it takes <command> to finish in 15. This matchers will succeed.
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command not to run too long

--- a/lib/aruba/matchers/command/have_output.rb
+++ b/lib/aruba/matchers/command/have_output.rb
@@ -1,7 +1,7 @@
 # @!method have_output
 #   This matchers checks if <command> has created output
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command has not created output

--- a/lib/aruba/matchers/command/have_output_on_stderr.rb
+++ b/lib/aruba/matchers/command/have_output_on_stderr.rb
@@ -1,7 +1,7 @@
 # @!method have_output_on_stderr
 #   This matchers checks if <command> has created output on stderr
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command has not created output on stderr

--- a/lib/aruba/matchers/command/have_output_on_stdout.rb
+++ b/lib/aruba/matchers/command/have_output_on_stdout.rb
@@ -1,7 +1,7 @@
 # @!method have_output_on_stdout
 #   This matchers checks if <command> has created output on stdout
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command has not created output on stdout

--- a/lib/aruba/matchers/command/have_output_size.rb
+++ b/lib/aruba/matchers/command/have_output_size.rb
@@ -4,7 +4,7 @@
 #   @param [String] output
 #     The content which should be checked
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if output does not have size

--- a/lib/aruba/matchers/directory/be_an_existing_directory.rb
+++ b/lib/aruba/matchers/directory/be_an_existing_directory.rb
@@ -3,7 +3,7 @@ require 'rspec/expectations/version'
 # @!method be_an_existing_directory
 #   This matchers checks if <directory> exists in filesystem
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if directory does not exist

--- a/lib/aruba/matchers/directory/have_sub_directory.rb
+++ b/lib/aruba/matchers/directory/have_sub_directory.rb
@@ -6,7 +6,7 @@ require 'rspec/expectations/version'
 #   @param [Array] sub_directory
 #      A list of sub-directory relative to current directory
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if directory does not have sub-directory

--- a/lib/aruba/matchers/file/be_a_command_found_in_path.rb
+++ b/lib/aruba/matchers/file/be_a_command_found_in_path.rb
@@ -3,7 +3,7 @@ require 'rspec/expectations/version'
 # @!method be_a_command_found_in_path
 #   This matchers checks if <command> can be found in path
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if command was not found in PATH

--- a/lib/aruba/matchers/file/be_an_existing_executable.rb
+++ b/lib/aruba/matchers/file/be_an_existing_executable.rb
@@ -4,7 +4,7 @@ require 'shellwords'
 # @!method be_an_existing_executable
 #   This matchers checks if <file> exists in filesystem
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if file does not exist

--- a/lib/aruba/matchers/file/be_an_existing_file.rb
+++ b/lib/aruba/matchers/file/be_an_existing_file.rb
@@ -3,7 +3,7 @@ require 'rspec/expectations/version'
 # @!method be_an_existing_file
 #   This matchers checks if <file> exists in filesystem
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if file does not exist

--- a/lib/aruba/matchers/file/have_file_content.rb
+++ b/lib/aruba/matchers/file/have_file_content.rb
@@ -7,7 +7,7 @@ require 'rspec/expectations/version'
 #   @param [String, Regexp, Matcher] content
 #     Specifies the content of the file
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if file does not exist

--- a/lib/aruba/matchers/file/have_file_size.rb
+++ b/lib/aruba/matchers/file/have_file_size.rb
@@ -6,7 +6,7 @@ require 'rspec/expectations/version'
 #   @param [Fixnum] size
 #     The size to check
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if path does not have size

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -9,7 +9,7 @@ require 'fileutils'
 #     The name of the file which should be compared with the file in the
 #     `expect()`-call.
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if file1 is not equal file2

--- a/lib/aruba/matchers/path/a_path_matching_pattern.rb
+++ b/lib/aruba/matchers/path/a_path_matching_pattern.rb
@@ -7,7 +7,7 @@ require 'rspec/expectations/version'
 #   @param [String, Regexp, Matcher] pattern
 #     Specifies the pattern
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if pattern does not match

--- a/lib/aruba/matchers/path/be_an_absolute_path.rb
+++ b/lib/aruba/matchers/path/be_an_absolute_path.rb
@@ -3,7 +3,7 @@ require 'rspec/expectations/version'
 # @!method be_an_absolute_path
 #   This matchers checks if <path> exists in filesystem
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if path is not absolute

--- a/lib/aruba/matchers/path/be_an_existing_path.rb
+++ b/lib/aruba/matchers/path/be_an_existing_path.rb
@@ -3,7 +3,7 @@ require 'rspec/expectations/version'
 # @!method be_an_existing_path
 #   This matchers checks if <path> exists in filesystem
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if path does not exist

--- a/lib/aruba/matchers/path/have_permissions.rb
+++ b/lib/aruba/matchers/path/have_permissions.rb
@@ -6,7 +6,7 @@ require 'rspec/expectations/version'
 #   @param [Fixnum, String] permissions
 #     The permissions as octal number, e.g. `0700`, or String, e.g. `'0700'`
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if file has permissions

--- a/lib/aruba/matchers/path/match_path_pattern.rb
+++ b/lib/aruba/matchers/path/match_path_pattern.rb
@@ -4,7 +4,7 @@
 #   @param [String, Regexp] pattern
 #     The pattern to use.
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if there are no files/directories which match the pattern

--- a/lib/aruba/matchers/rspec_matcher_include_regexp.rb
+++ b/lib/aruba/matchers/rspec_matcher_include_regexp.rb
@@ -4,7 +4,7 @@
 #   @param [Regexp] regexp
 #     The regular expression to use
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
 #     false:
 #     * if regexp does not match

--- a/lib/aruba/matchers/string/include_output_string.rb
+++ b/lib/aruba/matchers/string/include_output_string.rb
@@ -1,18 +1,17 @@
 # @!method include_output_string(string)
 #   This matchers checks if the output string of a command includes string.
 #
-#   @param [Integer] status
-#     The value of the exit status
+#   @param [String] string
+#     The value of the output string
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
-#     false:
+#     False:
 #     * if the output string does not include string
-#     true:
+#     True:
 #     * if the output string includes string
 #
 #   @example Use matcher
-#
 #     RSpec.describe do
 #       it { expect(last_command_started).to have_output an_output_string_including string) }
 #       it { expect(last_command_started).to have_output include_output_string string) }

--- a/lib/aruba/matchers/string/match_output_string.rb
+++ b/lib/aruba/matchers/string/match_output_string.rb
@@ -1,18 +1,17 @@
 # @!method match_output_string(string)
 #   This matchers checks if the output string of a command matches regular expression.
 #
-#   @param [Integer] status
-#     The value of the exit status
+#   @param [String] string
+#     The value of the output string
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean] The result
 #
-#     false:
+#     False:
 #     * if the output string does not match regex
-#     true:
+#     True:
 #     * if the output string matches regex
 #
 #   @example Use matcher
-#
 #     RSpec.describe do
 #       it { expect(last_command_started).to have_output an_output_string_matching regex) }
 #       it { expect(last_command_started).to have_output match_output_string regex) }

--- a/lib/aruba/matchers/string/output_string_eq.rb
+++ b/lib/aruba/matchers/string/output_string_eq.rb
@@ -1,18 +1,17 @@
 # @!method output_string_eq(string)
 #   This matchers checks if the output string of a command includes string.
 #
-#   @param [Integer] status
-#     The value of the exit status
+#   @param [String] string
+#     The value of the output string
 #
-#   @return [TrueClass, FalseClass] The result
+#   @return [Boolean]
 #
-#     false:
+#     False:
 #     * if the output string does not include string
-#     true:
+#     True:
 #     * if the output string includes string
 #
 #   @example Use matcher
-#
 #     RSpec.describe do
 #       it { expect(last_command_started).to have_output output_string_eq string) }
 #       it { expect(last_command_started).to have_output an_output_string_begin_eq string) }

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -154,7 +154,7 @@ module Aruba
 
       # Activate a channel
       #
-      # @param [Symbol] channel
+      # @param [Symbol] chns
       #   The name of the channel to activate
       def activate(*chns)
         chns.flatten.each { |c| channels[c.to_sym] = true }

--- a/lib/aruba/platforms/aruba_file_creator.rb
+++ b/lib/aruba/platforms/aruba_file_creator.rb
@@ -15,7 +15,7 @@ module Aruba
       # @param [Object] content
       #   The content of the file
       #
-      # @param [TrueClass, FalseClass] check_presence (false)
+      # @param [Boolean] check_presence (false)
       #   Check if file exist
       def call(path, content, check_presence = false)
         fail "Expected #{path} to be present" if check_presence && !Aruba.platform.file?(path)

--- a/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
+++ b/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
@@ -19,7 +19,7 @@ module Aruba
       # @param [Numeric] size
       #   The size of the file
       #
-      # @param [TrueClass, FalseClass] check_presence (false)
+      # @param [Boolean] check_presence (false)
       #   Check if file exist
       def call(path, size, check_presence)
         fail "Expected #{path} to be present" if check_presence && !Aruba.platform.file?(path)

--- a/lib/aruba/platforms/aruba_logger.rb
+++ b/lib/aruba/platforms/aruba_logger.rb
@@ -10,11 +10,31 @@ module Aruba
 
     # Create logger
     #
-    # @param [Logger] logger (::Logger.new( $stderr ))
-    #   The logger with should be used to output data
+    # @param [Hash] opts
+    #   Options
+    #
+    # @option opts [Symbol] :default_mode Log level
     def initialize(opts = {})
       @mode = opts.fetch(:default_mode, :info)
     end
+
+    # @!method fatal(msg)
+    # Log a fatal level log message
+
+    # @!method warn(msg)
+    # Log a warn level log message
+
+    # @!method debug(msg)
+    # Log a debug level log message
+
+    # @!method info(msg)
+    # Log an info level log message
+
+    # @!method error(msg)
+    # Log an error level log message
+
+    # @!method unknown(msg)
+    # Log an unknown level log message
 
     [:fatal, :warn, :debug, :info, :error, :unknown].each do |m|
       define_method m do |msg|

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -195,7 +195,7 @@ module Aruba
 
       # Check if command is relative
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   true
       #     * bin/command.sh
       #
@@ -209,7 +209,7 @@ module Aruba
 
       # Check if command is relative
       #
-      # @return [TrueClass, FalseClass]
+      # @return [Boolean]
       #   true
       #     * command.sh
       #

--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -5,33 +5,28 @@ module Aruba
   # Platforms
   module Platforms
     # Windows is case-insensitive when it accesses its environment variables.
-    # That means that at the Windows command line:
     #
-    #  C:>set Path
-    #  C:>Path=.;.\bin;c:\rubys\ruby-2.1.6-p336\bin;
-    #  C:>set PATH
-    #  C:>Path=.;.\bin;c:\rubys\ruby-2.1.6-p336\bin;
+    # To work around this we turn all of the environment variable keys to
+    # upper-case so that aruba is ensured that accessing environment variables
+    # with upper-case keys will always work. See the following examples.
     #
-    # If you access environment variables through ENV, you can access values no
-    # matter the case of the key:
+    # @example Setting Windows environment variables using mixed case
+    #   C:>set Path
+    #   C:>Path=.;.\bin;c:\rubys\ruby-2.1.6-p336\bin;
+    #   C:>set PATH
+    #   C:>Path=.;.\bin;c:\rubys\ruby-2.1.6-p336\bin;
     #
-    #  irb: > ENV["Path"]
-    #  => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
-    #  irb: > ENV["Path"]
-    #  => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
+    # @example If you access environment variables through ENV, you can access values no matter the case of the key:
+    #     ENV["Path"] # => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
+    #     ENV["PATH"] # => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
     #
-    # But if you copy the ENV to a hash, Ruby treats the keys as case sensitive:
-    #
-    #  irb: > env_copy = ENV.to_hash
-    #  => {"ALLUSERSPROFILE"=>"C:\\ProgramData", "ANSICON"=>"119x1000 (119x58)", "ANSICON_DEF"=>"7",  APPDATA"=>"C:\\Users\\blorf\\AppData\\Roaming", ....}
-    #  irb: > env["Path"]
-    #  => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
-    #  irb: > env["PATH"]
-    #  => nil
-    #
-    # Thus we turn all of the environment variable keys to upper case so that
-    # aruba is ensured that accessing environment variables with upper case keys
-    # will always work.
+    # @example But if you copy the ENV to a hash, Ruby treats the keys as case sensitive:
+    #   env_copy = ENV.to_hash
+    #   # => {"ALLUSERSPROFILE"=>"C:\\ProgramData", "ANSICON"=>"119x1000 (119x58)", "ANSICON_DEF"=>"7",  APPDATA"=>"C:\\Users\\blorf\\AppData\\Roaming", ....}
+    #   env["Path"]
+    #   # => ".;.\bin;c:\rubys\ruby-2.1.6-p336\bin;"
+    #   env["PATH"]
+    #   # => nil
     class WindowsEnvironmentVariables < UnixEnvironmentVariables
       def initialize(env = ENV.to_hash)
         @actions = []

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -25,17 +25,29 @@ module Aruba
 
       # Create process
       #
-      # @params [String] cmd
+      # @param [String] cmd
       #   Command string
       #
-      # @params [Integer] exit_timeout
+      # @param [Integer] exit_timeout
       #   The timeout until we expect the command to be finished
       #
-      # @params [Integer] io_wait_timeout
+      # @param [Integer] io_wait_timeout
       #   The timeout until we expect the io to be finished
       #
-      # @params [String] working_directory
+      # @param [String] working_directory
       #   The directory where the command will be executed
+      #
+      # @param [Hash] environment
+      #   Environment variables
+      #
+      # @param [Class] main_class
+      #   E.g. Cli::App::Runner
+      #
+      # @param [String] stop_signal
+      #   Name of signal to send to stop process. E.g. 'HUP'.
+      #
+      # @param [Integer] startup_wait_time
+      #   The amount of seconds to wait after Aruba has started a command.
       def initialize(cmd, exit_timeout, io_wait_timeout, working_directory, environment = ENV.to_hash.dup, main_class = nil, stop_signal = nil, startup_wait_time = 0)
         super
 


### PR DESCRIPTION
This PR improves the YARD documentation annotations.

  - fix some typos in directives
  - fix some copy and paste errors in names of things
  - avoid using p as a local variable name

Found all these using the yard-junk gem.