### PR TITLE
Fix final OSX build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby
     - rvm: jruby-9.1.13.0
+    - rvm: 1.9.3
+      os: osx
+    - rvm: 2.0.0
+      os: osx
   fast_finish: true
 branches:
   only:

--- a/bin/console
+++ b/bin/console
@@ -2,15 +2,6 @@
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-require 'pry'
+require 'aruba/console'
 
-require 'aruba/api'
-
-module Aruba
-  class MyConsole
-    include Aruba::Api
-  end
-end
-
-include Aruba
-Pry.start MyConsole.new
+Aruba::Console.new.start

--- a/features/02_configure_aruba/home_directory.feature
+++ b/features/02_configure_aruba/home_directory.feature
@@ -20,9 +20,9 @@ Feature: Configure the home directory to be used with aruba
     end
     """
     When I successfully run `cucumber`
-    Then the output should contain:
+    Then the output should match:
     """
-    The default value is "/home/
+    The default value is "/.*/tmp/aruba"
     """
 
   Scenario: Set to current working directory
@@ -56,9 +56,9 @@ Feature: Configure the home directory to be used with aruba
     end
     """
     Then I successfully run `cucumber`
-    Then the output should contain:
+    Then the output should match:
     """
-    The default value is "/home/
+    The default value is "/.*/tmp/aruba"
     """
 
   Scenario: Set to some other path (deprecated)

--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -46,6 +46,7 @@ Feature: Debug your command in cucumber-test-run
     When I successfully run `cucumber`
     Then the features should all pass
 
+  @requires-readline
   Scenario: You can use a debug repl in your cli program
 
     If you want to debug a strange error, which only occures in one of your

--- a/features/06_use_aruba_cli/open_console.feature
+++ b/features/06_use_aruba_cli/open_console.feature
@@ -3,7 +3,6 @@ Feature: Aruba Console
   Background:
     Given a mocked home directory
 
-  @requires-readline
   Scenario: Start console
     Given I run `aruba console` interactively
     When I close the stdin stream
@@ -13,7 +12,6 @@ Feature: Aruba Console
     """
 
   @unsupported-on-platform-java
-  @requires-readline
   Scenario: Show help
     Given I run `aruba console` interactively
     And I type "aruba_help"
@@ -32,7 +30,6 @@ Feature: Aruba Console
     """
 
   @unsupported-on-platform-java
-  @requires-readline
   Scenario: Show methods
     Given I run `aruba console` interactively
     And I type "aruba_methods"
@@ -47,7 +44,6 @@ Feature: Aruba Console
     """
 
   @unsupported-on-platform-java
-  @requires-readline
   Scenario: Has history
     Given I run `aruba console` interactively
     And I type "aruba_methods"

--- a/features/06_use_aruba_cli/open_console.feature
+++ b/features/06_use_aruba_cli/open_console.feature
@@ -3,6 +3,7 @@ Feature: Aruba Console
   Background:
     Given a mocked home directory
 
+  @requires-readline
   Scenario: Start console
     Given I run `aruba console` interactively
     When I close the stdin stream
@@ -12,6 +13,7 @@ Feature: Aruba Console
     """
 
   @unsupported-on-platform-java
+  @requires-readline
   Scenario: Show help
     Given I run `aruba console` interactively
     And I type "aruba_help"
@@ -30,6 +32,7 @@ Feature: Aruba Console
     """
 
   @unsupported-on-platform-java
+  @requires-readline
   Scenario: Show methods
     Given I run `aruba console` interactively
     And I type "aruba_methods"
@@ -44,6 +47,7 @@ Feature: Aruba Console
     """
 
   @unsupported-on-platform-java
+  @requires-readline
   Scenario: Has history
     Given I run `aruba console` interactively
     And I type "aruba_methods"

--- a/features/07_development_of_aruba/run-aruba-console.feature
+++ b/features/07_development_of_aruba/run-aruba-console.feature
@@ -4,6 +4,7 @@ Feature: Running the interactive "aruba" developer console
   I want to use the interactive aruba console
   In order to try out the "aruba" api
 
+  @requires-readline
   Scenario: Running aruba interactively
 
     This starts a pry console with "aruba"'s api loaded.

--- a/features/07_development_of_aruba/run-aruba-console.feature
+++ b/features/07_development_of_aruba/run-aruba-console.feature
@@ -4,10 +4,9 @@ Feature: Running the interactive "aruba" developer console
   I want to use the interactive aruba console
   In order to try out the "aruba" api
 
-  @requires-readline
   Scenario: Running aruba interactively
 
-    This starts a pry console with "aruba"'s api loaded.
+    This starts an IRB console with "aruba"'s api loaded.
 
     When I run `bin/console` interactively
     And I type "exit"

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -106,7 +106,6 @@ end
 Before '@requires-readline' do
   begin
     require 'readline'
-    next
   rescue LoadError
     if Cucumber::VERSION < '2'
       skip_invoke!

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -103,6 +103,19 @@ Before '@unsupported-on-platform-windows' do |scenario|
   end
 end
 
+Before '@requires-readline' do
+  begin
+    require 'readline'
+    next
+  rescue LoadError
+    if Cucumber::VERSION < '2'
+      skip_invoke!
+    else
+      skip_this_scenario
+    end
+  end
+end
+
 Before '@unsupported-on-platform-unix' do |scenario|
   # leave if not windows
   next unless FFI::Platform.unix?


### PR DESCRIPTION
## Summary

This fixes/skips the cucumber scenarios failing on OSX.

## Details

The following bits need fixing:

* [x] $HOME is not in `/home` on OSX, so features that assume that need updating
* [x] Readline doesn't seem to be available on OSX for CRuby versions 1.9.3 and 2.0.0.
* ~Anything else that may turn up :-)~

~I have trimmed `.travis.yml` to be nice to Travis while this is still WIP. I'll remove that commit at the end.~

## Motivation and Context

Making master green ...

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
