### PR TITLE
Make "have_output_size" accept a process, not a string

### DIFF
--- a/features/05_use_rspec_matchers/command/have_output_size.feature
+++ b/features/05_use_rspec_matchers/command/have_output_size.feature
@@ -1,0 +1,24 @@
+Feature: Check command has output of size
+
+  Background:
+    Given I use a fixture named "cli-app"
+
+  Scenario: Check if command output has expected size
+    Given an executable named "bin/aruba-test-cli" with:
+    """
+    #!/bin/bash
+    # No trailing newline
+    echo string
+    """
+    And a file named "spec/output_spec.rb" with:
+    """
+    require 'spec_helper'
+
+    RSpec.describe 'Command with output', :type => :aruba do
+      before(:each) { run_command('aruba-test-cli') }
+
+      it { expect(last_command_started).to have_output_size 6 }
+    end
+    """
+    When I run `rspec`
+    Then the specs should all pass

--- a/features/05_use_rspec_matchers/command/have_output_size.feature
+++ b/features/05_use_rspec_matchers/command/have_output_size.feature
@@ -1,5 +1,8 @@
 Feature: Check command has output of size
 
+  The matcher sanitizes the output of your command before checking the output
+  size.
+
   Background:
     Given I use a fixture named "cli-app"
 
@@ -7,7 +10,6 @@ Feature: Check command has output of size
     Given an executable named "bin/aruba-test-cli" with:
     """
     #!/bin/bash
-    # No trailing newline
     echo string
     """
     And a file named "spec/output_spec.rb" with:

--- a/lib/aruba/matchers/command/have_output_size.rb
+++ b/lib/aruba/matchers/command/have_output_size.rb
@@ -18,10 +18,15 @@
 #     end
 RSpec::Matchers.define :have_output_size do |expected|
   match do |actual|
-    next false unless actual.respond_to? :size
+    @old_actual = actual
 
-    @actual = actual.size
-    values_match? expected, @actual
+    next false unless @old_actual.respond_to? :output
+
+    @old_actual.stop
+
+    @actual = sanitize_text(actual.output).size
+
+    values_match? expected.to_i, @actual
   end
 
   description { "output has size #{description_of expected}" }

--- a/spec/aruba/matchers/command/have_output_size_spec.rb
+++ b/spec/aruba/matchers/command/have_output_size_spec.rb
@@ -8,7 +8,11 @@ RSpec.describe 'Output Matchers' do
   end
 
   describe '#to_have_output_size' do
-    let(:obj) { 'string' }
+    let(:obj) { double('Process') }
+
+    before(:each) do
+      allow(obj).to receive(:output).and_return('string')
+    end
 
     context 'when has size' do
       context 'when is string' do


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Make the `have_output_size`-matcher work on a process output

<!--- Provide a general summary description of your changes -->

## Details

This PR makes the matcher accept a process object and work on its output.

<!--- Describe your changes in detail -->

## Motivation and Context

In "Aruba" most API calls are about processes and checking their behaviour. The `have_output_size` matcher works on a string. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

New tests were added.

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
