### PR TITLE
Add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - type-of-issue/slow-burner
+# Label to use when marking an issue as stale
+staleLabel: status/stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed in a week if no further activity occurs.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because of inactivity.
+  You can support the Cucumber core team on [opencollective](https://opencollective.com/cucumber).


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

This adds the stale bot to the aruba repository to monitor/cleanup our issues.

<!--- Provide a general summary description of your changes -->

## Motivation and Context

If there's no  conversation going on in a PR/issue, it litters our issue tracker. I hope that this encourage people to quickly come to an end. I know that there are a lot of issues tracking long running changes. I also added a configuration option to the config file, which make it possible to tag those issues. Most configuration is taken from https://github.com/cucumber/cucumber/blob/master/.github/stale.yml