### PR TITLE
Ensure env is done before inspecting output

### DIFF
--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -979,7 +979,7 @@ describe Aruba::Api do
 
     it "set environment variable" do
       @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.run_command "env"
+      @aruba.run_command_and_stop "env"
       expect(@aruba.last_command_started.output)
         .to include("LONG_LONG_ENV_VARIABLE=true")
     end
@@ -987,7 +987,7 @@ describe Aruba::Api do
     it "overwrites environment variable" do
       @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
       @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'false'
-      @aruba.run_command "env"
+      @aruba.run_command_and_stop "env"
       expect(@aruba.last_command_started.output)
         .to include("LONG_LONG_ENV_VARIABLE=false")
     end


### PR DESCRIPTION
## Summary

Fixes an intermittent build failure.

## Details

Ensures the `env` command is done before inspecting its output.

## Motivation and Context

Inspecting output without waiting for the command to be done sometimes causes the spec to fail because the desired output hasn't been produced yet. This caused intermittent Travis build failures. This problem is hard to reproduce locally.

## How Has This Been Tested?

I made the change similar to how other tests are done in the same spec file. Travis will be the judge.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)