### PR TITLE
Make forgetting setup_aruba a hard failure

### DIFF
--- a/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
+++ b/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
@@ -90,7 +90,7 @@ Feature: Getting started with RSpec and aruba
 
     Running `setup_aruba` removes `tmp/aruba`, creates a new one `tmp/aruba`
     and make it the working directory. Running it within a `before(:all)`-hook,
-    run some `aruba`-method and then run `setup_arub` again within a
+    run some `aruba`-method and then run `setup_aruba` again within a
     `before(:each)`-hook, will remove the files/directories created within the
     `before(:all)`-hook.
 
@@ -111,67 +111,6 @@ Feature: Getting started with RSpec and aruba
       before(:all) { write_file 'file.txt', 'Hello World' }
 
       it { expect('file.txt').to be_an_existing_file }
-    end
-    """
-    When I run `rspec`
-    Then the specs should all pass
-
-  Scenario: Setup aruba before use any of it's methods
-
-    From 1.0.0 it will be required, that you setup aruba before you use it.
-
-    Given a file named "spec/spec_helper.rb" with:
-    """
-    require 'aruba/api'
-
-    RSpec.configure do |config|
-      config.include Aruba::Api
-    end
-    """
-    And a file named "spec/getting_started_spec.rb" with:
-    """
-    require 'spec_helper'
-
-    RSpec.describe 'Custom Integration of aruba' do
-      let(:file) { 'file.txt' }
-
-      before(:each) { setup_aruba }
-
-      it { expect(true).to be true }
-    end
-    """
-    And an empty file named "tmp/aruba/garbage.txt"
-    When I run `rspec`
-    Then the specs should all pass
-    And the file "tmp/aruba/garbage.txt" should not exist anymore
-
-  Scenario: Fail-safe use if "setup_aruba" is not used
-
-    If you forgot to run `setup_aruba` before the first method of aruba is
-    used, you might see an error. Although we did our best to prevent this.
-
-    Make sure that you run `setup_aruba` before any method of aruba is used. At
-    best before each and every test.
-
-    This will be not supported anymore from 1.0.0 on.
-
-    Given a file named "spec/spec_helper.rb" with:
-    """
-    require 'aruba/api'
-
-    RSpec.configure do |config|
-      config.include Aruba::Api
-    end
-    """
-    And a file named "spec/getting_started_spec.rb" with:
-    """
-    require 'spec_helper'
-
-    RSpec.describe 'Custom Integration of aruba' do
-      let(:file) { 'file.txt' }
-
-      it { expect { write_file file, 'Hello World' }.not_to raise_error }
-      it { expect(aruba.current_directory.directory?).to be true }
     end
     """
     When I run `rspec`

--- a/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
+++ b/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
@@ -9,17 +9,17 @@ Feature: Getting started with RSpec and aruba
     `spec_helper.rb`. After that you only need to flag your tests with `type:
     :aruba` and some things are set up for.
 
-    The simple integration adds some `before(:each)`-hooks for you:
+    The simple integration adds some `before(:each)` hooks for you:
 
       \* Setup Aruba Test directory
       \* Clear environment (ENV)
-      \* Make HOME-variable configurable via `arub.config.home_directory`
-      \* Configure `aruba` via `RSpec`-metadata
-      \* Activate announcers based on `RSpec`-metadata
+      \* Make HOME variable configurable via `arub.config.home_directory`
+      \* Configure `aruba` via `RSpec` metadata
+      \* Activate announcers based on `RSpec` metadata
 
-    Be careful, if you are going to use a `before(:all)`-hook to set up
-    files/directories. Those will be deleted by the `setup_aruba`-call within
-    the `before(:each)`-hook. Look for some custom integration further down the
+    Be careful, if you are going to use a `before(:all)` hook to set up
+    files/directories. Those will be deleted by the `setup_aruba` call within
+    the `before(:each)` hook. Look for some custom integration further down the
     documentation for a solution.
 
     Given a file named "spec/spec_helper.rb" with:
@@ -81,18 +81,18 @@ Feature: Getting started with RSpec and aruba
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Custom Integration using before(:all)-hook
+  Scenario: Custom Integration using before(:all) hook
 
-    You can even use `aruba` within a `before(:all)`-hook. But again, make sure
+    You can even use `aruba` within a `before(:all)` hook. But again, make sure
     that `setup_aruba` is run before you use any method of `aruba`. Using
-    `setup_aruba` both in `before(:all)`- and `before(:each)`-hook is not
-    possible and therefor not supported:
+    `setup_aruba` both in a `before(:all)` and a `before(:each)` hook is not
+    possible and therefore not supported:
 
-    Running `setup_aruba` removes `tmp/aruba`, creates a new one `tmp/aruba`
-    and make it the working directory. Running it within a `before(:all)`-hook,
-    run some `aruba`-method and then run `setup_aruba` again within a
-    `before(:each)`-hook, will remove the files/directories created within the
-    `before(:all)`-hook.
+    Running `setup_aruba` removes `tmp/aruba`, creates a new `tmp/aruba`, and
+    makes that the working directory. Running it within a `before(:all)` hook,
+    running some `aruba` method and, then running `setup_aruba` again within a
+    `before(:each)` hook, will remove the files and directories created within
+    the `before(:all)` hook.
 
     Given a file named "spec/spec_helper.rb" with:
     """

--- a/features/04_aruba_api/core/expand_path.feature
+++ b/features/04_aruba_api/core/expand_path.feature
@@ -38,7 +38,7 @@ Feature: Expand paths with aruba
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Warn if aruba's working directory does not exist
+  Scenario: Raise an error if aruba's working directory does not exist
     Given a file named "spec/expand_path_spec.rb" with:
     """ruby
     require 'spec_helper'
@@ -48,7 +48,7 @@ Feature: Expand paths with aruba
 
       let(:path) { 'path/to/dir' }
 
-      it { expect { expand_path(path) }.to output(/working directory does not exist/).to_stderr }
+      it { expect { expand_path(path) }.to raise_error(/working directory does not exist/) }
     end
     """
     When I run `rspec`

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -127,7 +127,7 @@ module Aruba
         fail ArgumentError, message unless file_name.is_a?(String) && !file_name.empty?
 
         # rubocop:disable Metrics/LineLength
-        aruba.logger.warn %(`aruba`'s working directory does not exist. Maybe you forgot to run `setup_aruba` before using it's API. This warning will be an error from 1.0.0) unless Aruba.platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
+        fail %(Aruba's working directory does not exist. Maybe you forgot to run `setup_aruba` before using it's API.) unless Aruba.platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
         # rubocop:enable Metrics/LineLength
 
         prefix = file_name[0]

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -127,7 +127,7 @@ module Aruba
         fail ArgumentError, message unless file_name.is_a?(String) && !file_name.empty?
 
         # rubocop:disable Metrics/LineLength
-        fail %(Aruba's working directory does not exist. Maybe you forgot to run `setup_aruba` before using it's API.) unless Aruba.platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
+        fail %(Aruba's working directory does not exist. Maybe you forgot to run `setup_aruba` before using its API.) unless Aruba.platform.directory? File.join(aruba.config.root_directory, aruba.config.working_directory)
         # rubocop:enable Metrics/LineLength
 
         prefix = file_name[0]


### PR DESCRIPTION
## Summary

Make forgetting `setup_aruba` a hard failure

## Details

Forgetting to run `setup_aruba` resulted in a warning announcing that it would be a hard failure in 1.0.0. Kind of like 'deprecated', but with a twist. This PR makes the hard failure happen.

## Motivation and Context

Part of getting ready for 1.0.0.

## How Has This Been Tested?

Scenarios that relied on the old behavior have been removed. The hard failure is not tested explicitly.

## Types of changes

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update documentation

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
