### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,11 @@ group :debug do
     gem 'pry-debugger', '~> 0.2.3'
   end
 
-  gem 'pry-doc', '~> 0.8.0'
+  if RUBY_VERSION < '2'
+    gem 'pry-doc', '~> 0.8.0'
+  else
+    gem 'pry-doc', '~> 0.11.1'
+  end
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ group :development, :test do
   if RUBY_VERSION < '2.3'
     gem 'license_finder', '~> 2.0'
   else
-    gem 'license_finder', '~> 3.0', '>= 3.0.2'
+    gem 'license_finder', '~> 3.0.2'
   end
 
   # Upload documentation

--- a/Gemfile
+++ b/Gemfile
@@ -77,7 +77,7 @@ group :development, :test do
   # Upload documentation
   # gem 'relish', '~> 0.7.1'
 
-  gem 'minitest', '~> 5.8.0'
+  gem 'minitest', '~> 5.10.3'
 
   gem 'json', '~>2.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,6 @@ group :development, :test do
     gem 'travis-yaml'
 
     # Reporting
-    gem 'bcat', '~> 0.6.2'
     gem 'kramdown', '~> 1.14'
   end
 

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   end
 
   # Run development and test tasks
-  gem 'rake', '~> 10.4.2'
+  gem 'rake', '~> 12.2.1'
 
   if RUBY_VERSION >= '2.0.0'
     # Lint travis yaml

--- a/Gemfile
+++ b/Gemfile
@@ -31,9 +31,9 @@ end
 group :development, :test do
   # we use this to demonstrate interactive debugging within our feature tests
   if RUBY_VERSION >= '2'
-    gem 'pry', '~> 0.10.1'
+    gem 'pry', '~> 0.11.2'
   else
-    gem 'pry', '~>0.9.12'
+    gem 'pry', '~> 0.9.12'
   end
 
   # Run development and test tasks

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'http://github.com/cucumber/aruba'
 
   spec.add_runtime_dependency 'cucumber', '~> 2.4', '>= 2.4.0'
-  spec.add_runtime_dependency 'childprocess', '~> 0.7.1'
+  spec.add_runtime_dependency 'childprocess', '~> 0.8.0'
   spec.add_runtime_dependency 'ffi', '~> 1.9', '>= 1.9.10'
   spec.add_runtime_dependency 'rspec-expectations', '~> 3.4', '>= 3.4.0'
   spec.add_runtime_dependency 'contracts', '~> 0.14'


### PR DESCRIPTION
## Summary

Updates dependencies, except on cucumber, rubocop, and license_finder.

## Details

* Aruba does not yet seem to work with cucumber 3.0.
* I'd like to update RuboCop, but the newer version checks many more things and I don't want to pollute the test output.
* license_finder 3.1 and 4.0 seem to be accidental releases that are broken.

## Motivation and Context

It's good to have up-to-date dependencies for the 1.0 release.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
