### PR TITLE
Allow slashes in file matching regex

### DIFF
--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -156,7 +156,7 @@ Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?contain exactly:$/) do 
   end
 end
 
-Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?match %r<([^\/]*)>$/) do |file, negated, content|
+Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?match %r<([^>]*)>$/) do |file, negated, content|
   if negated
     expect(file).not_to have_file_content file_content_matching(content)
   else


### PR DESCRIPTION
## Summary

Fixes #424 by allowing slashes in file content matching regexes.

## Motivation and Context

There seems to be no reason that slashes need to be disallowed in `%r` regex literals, and this prevents the not uncommon case of wanting to assert that a file's contents include file paths.

## How Has This Been Tested?

We've been running this patch in our testing environment for over a year, where it has definitely been working. Our Cucumber features contain expectations that match on file paths that include slashes.

I ran the aruba tests according to the instructions in https://github.com/cucumber/aruba/blob/master/CONTRIBUTING.md#getting-started-as-a-contributor. The only tests that failed were the Cucumber features that required `zsh`, which I don't have installed on my system.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I'm not sure if this change requires a test, since it's so simple, but please let me know if you'd prefer that I add a test.