### PR TITLE
Mark scenarios requiring external commands

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/run_commands_which_require_a_shell.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/run_commands_which_require_a_shell.feature
@@ -4,13 +4,15 @@ Feature: Running shell commands
   - `When I run the following script:`
 
   Or you can run shell commands with:
-  - `I run the following (bash|zsh|...shell)? commands`
-  - `I run the following (bash|zsh|...shell)? commands (in|with) \`interpreter\``
-  - `I run the following (bash|zsh|...shell)? commands (in|with) \`/path/to/interpreter\``
+  - `I run the following (commands|script)`
+  - `I run the following (commands|script) (in|with) \`interpreter\``
+  - `I run the following (commands|script) (in|with) \`/path/to/interpreter\``
 
   Background:
     Given I use a fixture named "cli-app"
 
+  @requires-ruby
+  @requires-python
   Scenario: Creating and running scripts
     Given a file named "features/shell.feature" with:
     """
@@ -50,6 +52,7 @@ Feature: Running shell commands
     When I run `cucumber`
     Then the features should all pass
 
+  @requires-bash
   Scenario: Running bash commands
     Given a file named "features/shell.feature" with:
     """
@@ -64,6 +67,7 @@ Feature: Running shell commands
     When I run `cucumber`
     Then the features should all pass
 
+  @requires-zsh
   Scenario: Running zsh commands
     Given a file named "features/shell.feature" with:
     """
@@ -78,6 +82,7 @@ Feature: Running shell commands
     When I run `cucumber`
     Then the features should all pass
 
+  @requires-ruby
   Scenario: Running ruby commands
     Given a file named "features/shell.feature" with:
     """
@@ -92,13 +97,14 @@ Feature: Running shell commands
     When I run `cucumber`
     Then the features should all pass
 
+  @requires-python
   Scenario: Running python commands
     Given a file named "features/shell.feature" with:
     """
     Feature: Running scripts
-      Scenario: Running ruby commands
+      Scenario: Running python commands
         When I run the following commands with `python`:
-        \"\"\"ruby
+        \"\"\"python
         print("Hello, Aruba!")
         \"\"\"
         Then the output should contain exactly "Hello, Aruba!"
@@ -106,6 +112,7 @@ Feature: Running shell commands
     When I run `cucumber`
     Then the features should all pass
 
+  @requires-zsh
   Scenario: Running commands if full path to interpreter is given
     Given a file named "features/shell.feature" with:
     """
@@ -127,6 +134,7 @@ Feature: Running shell commands
     When I run `cucumber`
     Then the features should all pass
 
+  @requires-zsh
   Scenario: Running commands if only the name of interpreter is given
     Given a file named "features/shell.feature" with:
     """

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -13,14 +13,13 @@ When(/^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/)do |cmd, secs|
 end
 
 When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do |shell, commands|
-  prepend_environment_variable('PATH', expand_path('bin') + File::PATH_SEPARATOR)
+  full_path = expand_path('bin/myscript')
 
   Aruba.platform.mkdir(expand_path('bin'))
   shell ||= Aruba.platform.default_shell
 
-  Aruba::ScriptFile.new(:interpreter => shell, :content => commands,
-                        :path => expand_path('bin/myscript')).call
-  step 'I run `myscript`'
+  Aruba::ScriptFile.new(:interpreter => shell, :content => commands, :path => full_path).call
+  step "I run `#{full_path}`"
 end
 
 When(/^I run `([^`]*)` interactively$/)do |cmd|

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -18,7 +18,7 @@ When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do
   Aruba.platform.mkdir(expand_path('bin'))
   shell ||= Aruba.platform.default_shell
 
-  Aruba::ScriptFile.new(:interpreter => shell, :content => commands, :path => full_path).call
+  Aruba::ScriptFile.new(interpreter: shell, content: commands, path: full_path).call
   step "I run `#{full_path}`"
 end
 


### PR DESCRIPTION
## Summary

Fixes #513 

## Details

To avoid cucumber failures, marks scenarios requiring zsh, bash, python and ruby as such.

Also, avoids changing PATH when running ad-hoc scripts.

## Motivation and Context

See #513.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
