### PR TITLE
Prevent duplicate output

### DIFF
--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -209,6 +209,7 @@ module Aruba
           expect(command).to be_successfully_executed
         rescue ::RSpec::Expectations::ExpectationNotMetError => e
           aruba.announcer.activate(aruba.config.activate_announcer_on_command_failure)
+          aruba.event_bus.notify Events::CommandStopped.new(command)
           raise e
         end
       end

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -48,8 +48,6 @@ module Aruba
 
     # Stop command
     def stop(*)
-      fail Aruba::UserError, 'Please start a command first, before stopping it' if __getobj__.stopped?
-
       __getobj__.stop
       event_bus.notify Events::CommandStopped.new(self)
 
@@ -68,8 +66,6 @@ module Aruba
 
     # Start command
     def start
-      fail Aruba::UserError, 'Please stop a command first, before starting it' if __getobj__.started?
-
       __getobj__.start
       event_bus.notify Events::CommandStarted.new(self)
 

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -48,6 +48,8 @@ module Aruba
 
     # Stop command
     def stop(*)
+      fail Aruba::UserError, 'Please start a command first, before stopping it' if __getobj__.stopped?
+
       __getobj__.stop
       event_bus.notify Events::CommandStopped.new(self)
 
@@ -56,6 +58,8 @@ module Aruba
 
     # Terminate command
     def terminate(*)
+      return if __getobj__.stopped?
+
       __getobj__.terminate
       event_bus.notify Events::CommandStopped.new(self)
 
@@ -64,6 +68,8 @@ module Aruba
 
     # Start command
     def start
+      fail Aruba::UserError, 'Please stop a command first, before starting it' if __getobj__.started?
+
       __getobj__.start
       event_bus.notify Events::CommandStarted.new(self)
 

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -48,6 +48,8 @@ module Aruba
 
     # Stop command
     def stop(*)
+      return if __getobj__.stopped?
+
       __getobj__.stop
       event_bus.notify Events::CommandStopped.new(self)
 

--- a/lib/aruba/processes/debug_process.rb
+++ b/lib/aruba/processes/debug_process.rb
@@ -18,6 +18,7 @@ module Aruba
       end
 
       def start
+        @started = true
         Dir.chdir @working_directory do
           Aruba.platform.with_environment(environment) do
             @exit_status = system(command, *arguments) ? 0 : 1

--- a/lib/aruba/processes/in_process.rb
+++ b/lib/aruba/processes/in_process.rb
@@ -55,6 +55,8 @@ module Aruba
       def start
         fail "You need to call aruba.config.main_class = YourMainClass" unless main_class
 
+        @started = true
+
         Dir.chdir @working_directory do
           before_run
 

--- a/spec/aruba/command_spec.rb
+++ b/spec/aruba/command_spec.rb
@@ -24,67 +24,62 @@ RSpec.describe Aruba::Command do
   let(:stop_signal) { nil }
   let(:startup_wait_time) { 1 }
 
-  context '#started' do
-    before :each do
+  describe '#start' do
+    before do
       allow(event_bus).to receive(:notify).with(Events::CommandStarted)
     end
 
-    before :each do
-      command.start
-    end
-
     it 'leaves the command in the started state' do
+      command.start
       expect(command).to be_started
     end
   end
 
-  context '#stopped' do
-    before :each do
+  describe '#stop' do
+    before do
       allow(event_bus).to receive(:notify).with(Events::CommandStarted)
       allow(event_bus).to receive(:notify).with(Events::CommandStopped)
-    end
-
-    before :each do
       command.start
-      command.stop
     end
 
     it 'leaves the command in the stopped state' do
+      command.stop
       expect(command).to be_stopped
     end
 
     it 'notifies the event bus only once per run' do
+      command.stop
       command.stop
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end
 
     it 'prevents #terminate from notifying the event bus' do
+      command.stop
       command.terminate
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end
   end
 
-  context '#terminate' do
-    before :each do
+  describe '#terminate' do
+    before do
       allow(event_bus).to receive(:notify).with(Events::CommandStarted)
       allow(event_bus).to receive(:notify).with(Events::CommandStopped)
-    end
-
-    before :each do
       command.start
-      command.terminate
     end
 
     it 'leaves the command in the stopped state' do
+      command.terminate
       expect(command).to be_stopped
     end
 
     it 'notifies the event bus only once per run' do
       command.terminate
+      command.terminate
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end
 
     it 'prevents #stop from notifying the event bus' do
+      command.terminate
       command.stop
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end

--- a/spec/aruba/command_spec.rb
+++ b/spec/aruba/command_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+RSpec.describe Aruba::Command do
+  subject do
+    described_class.new(
+      'true',
+      event_bus: event_bus,
+      exit_timeout: exit_timeout,
+      io_wait_timeout: io_wait_timeout,
+      working_directory: working_directory,
+      environment: environment,
+      main_class: main_class,
+      stop_signal: stop_signal,
+      startup_wait_time: startup_wait_time
+    )
+  end
+
+  let(:event_bus) { instance_double('Aruba::EventBus') }
+  let(:exit_timeout) { 1 }
+  let(:io_wait_timeout) { 1 }
+  let(:working_directory) { expand_path('.') }
+  let(:environment) { ENV.to_hash }
+  let(:main_class) { nil }
+  let(:stop_signal) { nil }
+  let(:startup_wait_time) { 1 }
+
+  context '#started' do
+    before :each do
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStarted) }
+    end
+
+    before :each do
+      subject.start
+    end
+
+    it { is_expected.to be_started }
+  end
+
+  context '#stopped' do
+    before :each do
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStarted) }
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStopped) }
+    end
+
+    before :each do
+      subject.start
+      subject.stop
+    end
+
+    it { is_expected.to be_stopped }
+  end
+
+  context '#terminate' do
+    before :each do
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStarted) }
+      allow(event_bus).to receive(:notify) { |a| a.is_a?(Events::CommandStopped) }
+    end
+
+    before :each do
+      subject.start
+      subject.terminate
+    end
+
+    it { is_expected.to be_stopped }
+  end
+end

--- a/spec/aruba/command_spec.rb
+++ b/spec/aruba/command_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Aruba::Command do
-  let(:command) do
+  subject(:command) do
     described_class.new(
       'true',
       event_bus: event_bus,
@@ -27,10 +27,10 @@ RSpec.describe Aruba::Command do
   describe '#start' do
     before do
       allow(event_bus).to receive(:notify).with(Events::CommandStarted)
+      command.start
     end
 
     it 'leaves the command in the started state' do
-      command.start
       expect(command).to be_started
     end
   end
@@ -40,21 +40,17 @@ RSpec.describe Aruba::Command do
       allow(event_bus).to receive(:notify).with(Events::CommandStarted)
       allow(event_bus).to receive(:notify).with(Events::CommandStopped)
       command.start
+      command.stop
     end
 
-    it 'leaves the command in the stopped state' do
-      command.stop
-      expect(command).to be_stopped
-    end
+    it { is_expected.to be_stopped }
 
     it 'notifies the event bus only once per run' do
-      command.stop
       command.stop
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end
 
     it 'prevents #terminate from notifying the event bus' do
-      command.stop
       command.terminate
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end
@@ -65,21 +61,17 @@ RSpec.describe Aruba::Command do
       allow(event_bus).to receive(:notify).with(Events::CommandStarted)
       allow(event_bus).to receive(:notify).with(Events::CommandStopped)
       command.start
+      command.terminate
     end
 
-    it 'leaves the command in the stopped state' do
-      command.terminate
-      expect(command).to be_stopped
-    end
+    it { is_expected.to be_stopped }
 
     it 'notifies the event bus only once per run' do
-      command.terminate
       command.terminate
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end
 
     it 'prevents #stop from notifying the event bus' do
-      command.terminate
       command.stop
       expect(event_bus).to have_received(:notify).with(Events::CommandStopped).once
     end

--- a/spec/aruba/processes/in_process_spec.rb
+++ b/spec/aruba/processes/in_process_spec.rb
@@ -43,8 +43,11 @@ RSpec.describe Aruba::Processes::InProcess do
 
   describe "#stdout" do
     let(:main_class) { StdoutRunner }
-    before(:each) { process.start }
-    before(:each) { process.stop }
+
+    before do
+      process.start
+      process.stop
+    end
 
     context 'when invoked once' do
       it { expect(process.stdout).to eq "yo\n" }
@@ -57,8 +60,11 @@ RSpec.describe Aruba::Processes::InProcess do
 
   describe "#stderr" do
     let(:main_class) { StderrRunner }
-    before(:each) { process.start }
-    before(:each) { process.stop }
+
+    before do
+      process.start
+      process.stop
+    end
 
     context 'when invoked once' do
       it { expect(process.stderr).to eq "yo\n" }
@@ -70,7 +76,7 @@ RSpec.describe Aruba::Processes::InProcess do
   end
 
   describe "#stop" do
-    before(:each) { process.start }
+    before { process.start }
 
     context 'when stopped successfully' do
       it { expect { process.stop }.not_to raise_error }

--- a/spec/aruba/processes/in_process_spec.rb
+++ b/spec/aruba/processes/in_process_spec.rb
@@ -73,13 +73,23 @@ RSpec.describe Aruba::Processes::InProcess do
     before(:each) { process.start }
 
     context 'when stopped successfully' do
-      it { process.stop }
+      it { expect { process.stop }.not_to raise_error }
+
+      it 'makes the process stopped' do
+        process.stop
+        expect(process).to be_stopped
+      end
     end
   end
 
   describe "#start" do
     context "when process run succeeds" do
       it { expect { process.start }.not_to raise_error }
+
+      it 'makes the process started' do
+        process.start
+        expect(process).to be_started
+      end
     end
 
     context "when process run fails" do

--- a/spec/aruba/processes/in_process_spec.rb
+++ b/spec/aruba/processes/in_process_spec.rb
@@ -1,0 +1,91 @@
+require 'spec_helper'
+
+RSpec.describe Aruba::Processes::InProcess do
+  class Runner
+    def initialize(argv, stdin, stdout, stderr, kernel)
+      @stdout = stdout
+      @stderr = stderr
+    end
+
+    def execute!
+    end
+  end
+
+  class StdoutRunner < Runner
+    def execute!
+      @stdout.puts 'yo'
+    end
+  end
+
+  class StderrRunner < Runner
+    def execute!
+      @stderr.puts 'yo'
+    end
+  end
+
+  class FailedRunner < Runner
+    def execute!
+      raise 'Oops'
+    end
+  end
+
+  subject(:process) do
+    described_class.new(command, exit_timeout, io_wait, working_directory,
+                        environment, main_class)
+  end
+
+  let(:command) { 'foo' }
+  let(:exit_timeout) { 1 }
+  let(:io_wait) { 1 }
+  let(:working_directory) { Dir.getwd }
+  let(:environment) { ENV.to_hash.dup }
+  let(:main_class) { Runner }
+
+  describe "#stdout" do
+    let(:main_class) { StdoutRunner }
+    before(:each) { process.start }
+    before(:each) { process.stop }
+
+    context 'when invoked once' do
+      it { expect(process.stdout).to eq "yo\n" }
+    end
+
+    context 'when invoked twice' do
+      it { 2.times { expect(process.stdout).to eq "yo\n" } }
+    end
+  end
+
+  describe "#stderr" do
+    let(:main_class) { StderrRunner }
+    before(:each) { process.start }
+    before(:each) { process.stop }
+
+    context 'when invoked once' do
+      it { expect(process.stderr).to eq "yo\n" }
+    end
+
+    context 'when invoked twice' do
+      it { 2.times { expect(process.stderr).to eq "yo\n" } }
+    end
+  end
+
+  describe "#stop" do
+    before(:each) { process.start }
+
+    context 'when stopped successfully' do
+      it { process.stop }
+    end
+  end
+
+  describe "#start" do
+    context "when process run succeeds" do
+      it { expect { process.start }.not_to raise_error }
+    end
+
+    context "when process run fails" do
+      let(:main_class) { FailedRunner }
+
+      it { expect { process.start }.to raise_error RuntimeError, 'Oops' }
+    end
+  end
+end

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -42,13 +42,23 @@ RSpec.describe Aruba::Processes::SpawnProcess do
     before(:each) { process.start }
 
     context 'when stopped successfully' do
-      it { process.stop }
+      it { expect { process.stop }.not_to raise_error }
+
+      it 'makes the process stopped' do
+        process.stop
+        expect(process).to be_stopped
+      end
     end
   end
 
   describe "#start" do
     context "when process run succeeds" do
       it { expect { process.start }.not_to raise_error }
+
+      it 'makes the process started' do
+        process.start
+        expect(process).to be_started
+      end
     end
 
     context "when process run fails" do


### PR DESCRIPTION
## Summary

Ensure command output is only announced once.

## Details

During a run, `Command#stop` and `Command#terminate` are called multiple times, among other reasons to ensure all commands are actually terminated at the end of each spec or scenario.

If both general announcers and the announce-on-error functionality is used at the same time, duplicate output may still occur.

This includes changes from #399.

## Motivation and Context

This fixes #374.

## How Has This Been Tested?

Specs were added by @maxmeyer and myself to ensure stop events are only broadcast once on the event bus. The behavior was confirmed by running some of Aruba's features by hand and examining the entire output produced.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I've added tests for my code