### PR TITLE
Relax dependencies for contracts

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'childprocess', '~> 0.8.0'
   spec.add_runtime_dependency 'ffi', '~> 1.9', '>= 1.9.10'
   spec.add_runtime_dependency 'rspec-expectations', '~> 3.4', '>= 3.4.0'
-  spec.add_runtime_dependency 'contracts', '~> 0.14'
+  spec.add_runtime_dependency 'contracts', '~> 0.13'
   spec.add_runtime_dependency 'thor', '~> 0.19'
 
   spec.add_development_dependency 'bundler', '~> 1.11'


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Relax dependency to avoid problems with middleman gem.

<!--- Provide a general summary description of your changes -->

## Details

Middleman requires an older dependency for contracts
(https://github.com/middleman/middleman/blob/master/middleman-core/middleman-core.gemspec#L56)
than aruba. Using Aruba >=
1.0.0.pre.alpha.x with Middleman does not work. Relaxing the dependency
a bit helps to avoid that problem.

<!--- Describe your changes in detail -->

## Motivation and Context

I use middleman to generate and test proxy.pac-files. The test suite for https://github.com/fedux-org/proxy_pac_rb uses aruba and middleman.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Manually

<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
