### PR TITLE
fix @no-clobber breaking process management (closes 

### DIFF
--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -25,8 +25,8 @@ module Aruba
       # This will only clean up aruba's working directory to remove all
       # artifacts of your tests. This does NOT clean up the current working
       # directory.
-      def setup_aruba
-        Aruba::Setup.new(aruba).call
+      def setup_aruba(clobber: true)
+        Aruba::Setup.new(aruba).call(clobber: clobber)
 
         self
       end

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -20,6 +20,10 @@ After do
   aruba.command_monitor.clear
 end
 
+Before('@no-clobber') do
+  setup_aruba(clobber: false)
+end
+
 Before('~@no-clobber') do
   setup_aruba
 end

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -10,10 +10,10 @@ module Aruba
       @runtime = runtime
     end
 
-    def call
+    def call(clobber: true)
       return if runtime.setup_already_done?
 
-      working_directory
+      working_directory(clobber: clobber)
       events
 
       runtime.setup_done
@@ -23,8 +23,10 @@ module Aruba
 
     private
 
-    def working_directory
-      Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
+    def working_directory(clobber: true)
+      if clobber
+        Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
+      end
       Aruba.platform.mkdir File.join(runtime.config.root_directory, runtime.config.working_directory)
       Aruba.platform.chdir runtime.config.root_directory
     end


### PR DESCRIPTION
## Summary

When a scenario has @no-clobber, Aruba would not call Setup#call *at all*, which causes the
process monitor to not be listening to process events.

## Details

Changed Setup#call to accept a 'clobber' argument and set it according to whether there is @no-clobber or ~@no-clobber.

## Motivation and Context

Closes #527

## How Has This Been Tested?

**THERE ARE NO TESTS YET** I'm just not sure where it is appropriate to test for this. It's weird to do this in a cucumber feature, as it's testing a regression and not a feature, but then we should check that @no-clobber and process monitoring work (which can only be done in cucumber). It's going to look weird in the cucumber.pro site, no ?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
