### PR TITLE
Fix command spawning (still)

### DIFF
--- a/lib/aruba/platforms/unix_command_string.rb
+++ b/lib/aruba/platforms/unix_command_string.rb
@@ -13,7 +13,7 @@ module Aruba
 
       # Convert to array
       def to_a
-        Shellwords.split __getobj__
+        [__getobj__]
       end
 
       if RUBY_VERSION < '1.9'

--- a/lib/aruba/platforms/windows_command_string.rb
+++ b/lib/aruba/platforms/windows_command_string.rb
@@ -10,14 +10,9 @@ module Aruba
     #
     # @private
     class WindowsCommandString < SimpleDelegator
-      def initialize(cmd)
-        __setobj__ format('%s /c "%s"', Aruba.platform.which('cmd.exe'), cmd)
-      end
-
       # Convert to array
       def to_a
-        Shellwords.split( __getobj__.gsub('\\', 'ARUBA_TMP_PATHSEPARATOR') ).
-          map { |w| w.gsub('ARUBA_TMP_PATHSEPARATOR', '\\') }
+        [cmd_path, '/c', __getobj__]
       end
 
       if RUBY_VERSION < '1.9'
@@ -25,6 +20,12 @@ module Aruba
           __getobj__.to_s
         end
         alias inspect to_s
+      end
+
+      private
+
+      def cmd_path
+        Aruba.platform.which('cmd.exe')
       end
     end
   end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -57,7 +57,7 @@ module Aruba
 
         @started = true
 
-        @process = ChildProcess.build(*[command_string.to_a, arguments].flatten)
+        @process = ChildProcess.build(*command_string.to_a, *arguments)
         @stdout_file = Tempfile.new('aruba-stdout-')
         @stderr_file = Tempfile.new('aruba-stderr-')
 

--- a/spec/aruba/platforms/unix_command_string_spec.rb
+++ b/spec/aruba/platforms/unix_command_string_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+RSpec.describe Aruba::Platforms::UnixCommandString do
+  let(:command_string) { described_class.new(base_command) }
+
+  describe '#to_a' do
+    context 'with a command with a path' do
+      let(:base_command) { '/foo/bar' }
+      it { expect(command_string.to_a).to eq [base_command] }
+    end
+
+    context 'with a command with a path containing spaces' do
+      let(:base_command) { '/foo bar/baz' }
+      it { expect(command_string.to_a).to eq [base_command] }
+    end
+  end
+end

--- a/spec/aruba/platforms/windows_command_string_spec.rb
+++ b/spec/aruba/platforms/windows_command_string_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Aruba::Platforms::WindowsCommandString do
+  let(:command_string) { described_class.new(base_command) }
+  let(:cmd_path) { 'C:\Some Path\cmd.exe' }
+
+  before do
+    allow(Aruba.platform).to receive(:which).with('cmd.exe').and_return(cmd_path)
+  end
+
+  describe '#to_a' do
+    context 'with a command with a path' do
+      let(:base_command) { 'C:\Foo\Bar' }
+      it { expect(command_string.to_a).to eq [cmd_path, '/c', base_command] }
+    end
+
+    context 'with a command with a path containing spaces' do
+      let(:base_command) { 'C:\Foo Bar\Baz' }
+      it { expect(command_string.to_a).to eq [cmd_path, '/c', base_command] }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

There was a bug in how `ChildProcess.build` was called. This PR fixes this for the `still` branch, backporting the changes from #520.

## Details

Calling `#to_a` was called on UnixCommandString representing the executable, splitting the name unnecessarily.

## Motivation and Context

See #490.

## How Has This Been Tested?

A spec was added for this. This still needs to be tested on Windows.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- I've added tests for my code