### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: ruby
 script: bundle exec rake test
-install: bin/bootstrap --path vendor/bundle --without development debug
+bundler_args: --without development debug
 
 jobs:
   include:


### PR DESCRIPTION
## Summary

Fix Travis build by using default install task.

## Details

Travis can't seem to find Bundler's exe file. Perhaps this is due to our custom install step?

## Motivation and Context

All Travis builds are failing.

## How Has This Been Tested?

By opening this pull request.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
