### PR TITLE
FIx syntax to work with old rubies

### DIFF
--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -25,8 +25,8 @@ module Aruba
       # This will only clean up aruba's working directory to remove all
       # artifacts of your tests. This does NOT clean up the current working
       # directory.
-      def setup_aruba(clobber: true)
-        Aruba::Setup.new(aruba).call(clobber: clobber)
+      def setup_aruba(clobber = true)
+        Aruba::Setup.new(aruba).call(clobber)
 
         self
       end

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -21,7 +21,7 @@ After do
 end
 
 Before('@no-clobber') do
-  setup_aruba(clobber: false)
+  setup_aruba(false)
 end
 
 Before('~@no-clobber') do

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -57,7 +57,7 @@ module Aruba
 
         @started = true
 
-        @process = ChildProcess.build(*command_string.to_a, *arguments)
+        @process = ChildProcess.build(*[command_string.to_a, arguments].flatten)
         @stdout_file = Tempfile.new('aruba-stdout-')
         @stderr_file = Tempfile.new('aruba-stderr-')
 

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -10,10 +10,10 @@ module Aruba
       @runtime = runtime
     end
 
-    def call(clobber: true)
+    def call(clobber = true)
       return if runtime.setup_already_done?
 
-      working_directory(clobber: clobber)
+      working_directory(clobber)
       events
 
       runtime.setup_done
@@ -23,7 +23,7 @@ module Aruba
 
     private
 
-    def working_directory(clobber: true)
+    def working_directory(clobber = true)
       if clobber
         Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
       end


### PR DESCRIPTION
## Summary

The syntax in #529 and #490 is not compatible with Ruby 1.8.3. This PR fixes that.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)