### PR TITLE
Fix @no-clobber behavior

### DIFF
--- a/features/01_getting_started_with_aruba/cleanup_working_directory.feature
+++ b/features/01_getting_started_with_aruba/cleanup_working_directory.feature
@@ -8,61 +8,48 @@ Feature: Cleanup Aruba Working Directory
   Background:
     Given I use a fixture named "cli-app"
 
-  Scenario: Changes in the filesystem
-
-    This assumes you use the default configuration, having `tmp/aruba` as your
-    default working directory in your project root.
-
-    Given a file named "tmp/aruba/file.txt" with "content"
-    And a directory named "tmp/aruba/dir.d"
-    And a file named "features/flushing.feature" with:
+  Scenario: Clean up artifacts and pwd from a previous scenario
+    Given a file named "features/cleanup.feature" with:
     """
     Feature: Check
-      Scenario: Check
-        Then a file named "file.txt" does not exist
-        And a directory named "dir.d" does not exist
+      Scenario: Check #1
+        Given a file named "file.txt" with "content"
+        And a directory named "dir.d"
+        Then a file named "file.txt" should exist
+        And a directory named "dir.d" should exist
+        When I cd to "dir.d"
+        And I run `pwd`
+        Then the output should match %r</tmp/aruba/dir.d$>
+
+      Scenario: Check #2
+        Then a file named "file.txt" should not exist
+        And a directory named "dir.d" should not exist
+        When I run `pwd`
+        Then the output should match %r</tmp/aruba$>
     """
     When I run `cucumber`
     Then the features should all pass
 
   Scenario: Do not clobber before run
+    The `@no-clobber` tag stops Aruba from clearing out its scratch directory.
+    Other setup steps are still performed, such as setting the current working
+    directory.
+
     Given a file named "tmp/aruba/file.txt" with "content"
     And a directory named "tmp/aruba/dir.d"
-    And a file named "features/flushing.feature" with:
-    """
-    Feature: Check
-      @no-clobber
-      Scenario: Check
-        Then a file named "file.txt" should exist
-        And a directory named "dir.d" should exist
-    """
-    When I run `cucumber`
-    Then the features should all pass
-
-  Scenario: Cleanup and verify the previous scenario
-    Given a file named "features/flushing.feature" with:
+    And a file named "features/cleanup.feature" with:
     """
     Feature: Check
       Scenario: Check #1
-        Given a file named "tmp/aruba/file.txt" with "content"
-        And a directory named "tmp/aruba/dir.d"
+        Given a file named "file.txt" with "content"
+        And a directory named "dir.d"
+        Then a file named "file.txt" should exist
+        And a directory named "dir.d" should exist
 
+      @no-clobber
       Scenario: Check #2
-        Then a file named "file.txt" should not exist
-        And a directory named "dir.d" should not exist
-    """
-    When I run `cucumber`
-    Then the features should all pass
-
-  Scenario:  Current directory from previous scenario is reseted
-    Given a file named "features/non-existence.feature" with:
-    """
-    Feature: Reset
-      Scenario: Reset #1
-        Given a directory named "dir1"
-        When I cd to "dir1"
-
-      Scenario: Reset #2
+        Then a file named "file.txt" should exist
+        And a directory named "dir.d" should exist
         When I run `pwd`
         Then the output should match %r</tmp/aruba$>
     """

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -25,8 +25,8 @@ module Aruba
       # This will only clean up aruba's working directory to remove all
       # artifacts of your tests. This does NOT clean up the current working
       # directory.
-      def setup_aruba
-        Aruba::Setup.new(aruba).call
+      def setup_aruba(clobber: true)
+        Aruba::Setup.new(aruba).call(clobber: clobber)
 
         self
       end

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -25,8 +25,8 @@ module Aruba
       # This will only clean up aruba's working directory to remove all
       # artifacts of your tests. This does NOT clean up the current working
       # directory.
-      def setup_aruba(clobber: true)
-        Aruba::Setup.new(aruba).call(clobber: clobber)
+      def setup_aruba(clobber = true)
+        Aruba::Setup.new(aruba).call(clobber)
 
         self
       end

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -19,7 +19,7 @@ After do
 end
 
 Before('@no-clobber') do
-  setup_aruba(clobber: false)
+  setup_aruba(false)
 end
 
 Before('~@no-clobber') do

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -18,6 +18,10 @@ After do
   aruba.command_monitor.clear
 end
 
+Before('@no-clobber') do
+  setup_aruba(clobber: false)
+end
+
 Before('~@no-clobber') do
   setup_aruba
 end

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -10,10 +10,10 @@ module Aruba
       @runtime = runtime
     end
 
-    def call
+    def call(clobber: true)
       return if runtime.setup_already_done?
 
-      working_directory
+      working_directory(clobber: clobber)
       events
 
       runtime.setup_done
@@ -23,8 +23,10 @@ module Aruba
 
     private
 
-    def working_directory
-      Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
+    def working_directory(clobber: true)
+      if clobber
+        Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
+      end
       Aruba.platform.mkdir File.join(runtime.config.root_directory, runtime.config.working_directory)
       Aruba.platform.chdir runtime.config.root_directory
     end

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -10,10 +10,10 @@ module Aruba
       @runtime = runtime
     end
 
-    def call(clobber: true)
+    def call(clobber = true)
       return if runtime.setup_already_done?
 
-      working_directory(clobber: clobber)
+      working_directory(clobber)
       events
 
       runtime.setup_done
@@ -23,7 +23,7 @@ module Aruba
 
     private
 
-    def working_directory(clobber: true)
+    def working_directory(clobber = true)
       if clobber
         Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
       end


### PR DESCRIPTION
## Summary

Ensure setup is run even if files are not clobbered.

## Details

See #529.

## Motivation and Context

Fixes #527.

## How Has This Been Tested?

Scenarios were updated to demonstrate that setup is also run when `@no-clobber` is set, but files are not clobbered.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update documentation

## Checklist:

- [x] I've added tests for my code