### PR TITLE
Use known-good osx_image for old Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,12 @@ jobs:
       os: linux
     - rvm: 2.0.0
       os: osx
+      osx_image: xcode8
     - rvm: 1.9.3
       os: linux
     - rvm: 1.9.3
       os: osx
+      osx_image: xcode8
     - rvm: jruby
       os: linux
     - rvm: jruby-9.1.13.0
@@ -52,10 +54,6 @@ jobs:
     - rvm: ruby-head
     - rvm: jruby
     - rvm: jruby-9.1.13.0
-    - rvm: 1.9.3
-      os: osx
-    - rvm: 2.0.0
-      os: osx
   fast_finish: true
 
 branches:


### PR DESCRIPTION
## Summary

Fix the build for Ruby 2.0.0 and 1.9.3 on OSX.

## Details

Ruby 2.0.0 and 1.9.3 cannot be installed on the default Travis CI OS X images. Use the xcode8 image instead, which uses OS X version 10.11 and Xcode version 8gm.

## Motivation and Context

These builds were ignored and continuously failing, almost at the start of the build, making them effectively useless.

## How Has This Been Tested?

These settings yielded succesful builds in the experimental pull request #534.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)