### PR TITLE
Fix some rubocop offenses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -253,14 +253,6 @@ Style/Encoding:
     - 'fixtures/empty-app/cli-app.gemspec'
     - 'spec/spec_helper.rb'
 
-# Offense count: 3
-# Configuration parameters: MinBodyLength.
-Style/GuardClause:
-  Exclude:
-    - 'features/support/env.rb'
-    - 'lib/aruba/api/command.rb'
-    - 'lib/aruba/colorizer.rb'
-
 # Offense count: 2
 Style/IdenticalConditionalBranches:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -286,13 +286,6 @@ Style/GuardClause:
     - 'lib/aruba/api/command.rb'
     - 'lib/aruba/colorizer.rb'
 
-# Offense count: 130
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles, UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  Enabled: false
-
 # Offense count: 2
 Style/IdenticalConditionalBranches:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -316,12 +316,6 @@ Style/RaiseArgs:
   Exclude:
     - 'features/support/env.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/RedundantConditional:
-  Exclude:
-    - 'lib/aruba/api/command.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 Style/RedundantSelf:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -143,31 +143,6 @@ Lint/UnneededDisable:
   Exclude:
     - 'lib/aruba/event_bus/name_resolver.rb'
 
-# Offense count: 8
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.
-Lint/UnusedBlockArgument:
-  Exclude:
-    - 'lib/aruba/cucumber/file.rb'
-    - 'lib/aruba/matchers/file/have_file_size.rb'
-    - 'lib/aruba/matchers/path/have_permissions.rb'
-    - 'lib/aruba/platforms/announcer.rb'
-    - 'spec/aruba/api_spec.rb'
-
-# Offense count: 11
-# Cop supports --auto-correct.
-# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
-Lint/UnusedMethodArgument:
-  Exclude:
-    - 'lib/aruba/api/filesystem.rb'
-    - 'lib/aruba/platforms/announcer.rb'
-    - 'lib/aruba/platforms/local_environment.rb'
-    - 'lib/aruba/platforms/unix_which.rb'
-    - 'lib/aruba/platforms/windows_which.rb'
-    - 'lib/aruba/processes/spawn_process.rb'
-    - 'lib/aruba/tasks/docker_helpers.rb'
-    - 'spec/aruba/processes/basic_process_spec.rb'
-
 # Offense count: 2
 Lint/UselessAssignment:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -367,15 +367,3 @@ Style/SignalException:
 # SupportedStyles: single_quotes, double_quotes
 Style/StringLiterals:
   Enabled: false
-
-# Offense count: 8
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, SupportedStyles.
-# SupportedStyles: all_comparison_operators, equality_operators_only
-Style/YodaCondition:
-  Exclude:
-    - 'lib/aruba/api/command.rb'
-    - 'lib/aruba/api/core.rb'
-    - 'lib/aruba/initializer.rb'
-    - 'lib/aruba/platforms/announcer.rb'
-    - 'spec/support/shared_contexts/aruba.rb'

--- a/features/step_definitions/aruba_dev_steps.rb
+++ b/features/step_definitions/aruba_dev_steps.rb
@@ -22,7 +22,7 @@ Then /^aruba should fail with "([^"]*)"$/ do |error_message|
 end
 
 Then /^the following step should fail with Spec::Expectations::ExpectationNotMetError:$/ do |multiline_step|
-  expect{steps multiline_step.to_s}.to raise_error(RSpec::Expectations::ExpectationNotMetError)
+  expect { steps multiline_step.to_s }.to raise_error(RSpec::Expectations::ExpectationNotMetError)
 end
 
 Given(/^the default executable$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,11 +12,10 @@ require 'aruba/cucumber'
 require 'rspec/expectations'
 
 Before do |scenario|
-  command_name = if scenario.respond_to?(:feature) && scenario.respond_to?(:name)
-                   "#{scenario.feature.name} #{scenario.name}"
-                 else
-                   raise TypeError.new("Don't know how to extract command name from #{scenario.class}")
-                 end
+  unless scenario.respond_to?(:feature) && scenario.respond_to?(:name)
+    raise TypeError, "Don't know how to extract command name from #{scenario.class}"
+  end
+  command_name = "#{scenario.feature.name} #{scenario.name}"
 
   # Used in simplecov_setup so that each scenario has a different name and their coverage results are merged instead
   # of overwriting each other as 'Cucumber Features'

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -148,15 +148,15 @@ module Aruba
 
         command = Command.new(
           cmd,
-          :mode              => mode,
-          :exit_timeout      => exit_timeout,
-          :io_wait_timeout   => io_wait_timeout,
-          :working_directory => working_directory,
-          :environment       => environment.to_hash,
-          :main_class        => main_class,
-          :stop_signal       => stop_signal,
-          :startup_wait_time => startup_wait_time,
-          :event_bus         => event_bus
+          mode: mode,
+          exit_timeout: exit_timeout,
+          io_wait_timeout: io_wait_timeout,
+          working_directory: working_directory,
+          environment: environment.to_hash,
+          main_class: main_class,
+          stop_signal: stop_signal,
+          startup_wait_time: startup_wait_time,
+          event_bus: event_bus
         )
 
         aruba.config.before(:command, self, command)

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -194,7 +194,7 @@ module Aruba
       #
       def run_command_and_stop(cmd, opts = {})
         fail_on_error = if opts.key?(:fail_on_error)
-                          opts.delete(:fail_on_error) == true ? true : false
+                          opts.delete(:fail_on_error) == true
                         else
                           true
                         end

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -218,7 +218,7 @@ module Aruba
       # @param [String] input
       #   The input for the command
       def type(input)
-        return close_input if "" == input
+        return close_input if input == ""
         last_command_started.write(input << "\n")
       end
 

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -202,14 +202,14 @@ module Aruba
         command = run_command(cmd, opts)
         command.stop
 
-        if fail_on_error
-          begin
-            expect(command).to have_finished_in_time
-            expect(command).to be_successfully_executed
-          rescue ::RSpec::Expectations::ExpectationNotMetError => e
-            aruba.announcer.activate(aruba.config.activate_announcer_on_command_failure)
-            raise e
-          end
+        return unless fail_on_error
+
+        begin
+          expect(command).to have_finished_in_time
+          expect(command).to be_successfully_executed
+        rescue ::RSpec::Expectations::ExpectationNotMetError => e
+          aruba.announcer.activate(aruba.config.activate_announcer_on_command_failure)
+          raise e
         end
       end
 

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -55,7 +55,7 @@ module Aruba
             aruba.current_directory << dir
             new_directory = expand_path('.')
 
-            aruba.event_bus.notify Events::ChangedWorkingDirectory.new(:old => old_directory, :new => new_directory)
+            aruba.event_bus.notify Events::ChangedWorkingDirectory.new(old: old_directory, new: new_directory)
 
             old_dir = Aruba.platform.getwd
 
@@ -80,7 +80,7 @@ module Aruba
         aruba.current_directory << dir
         new_directory = expand_path('.')
 
-        aruba.event_bus.notify Events::ChangedWorkingDirectory.new(:old => old_directory, :new => new_directory)
+        aruba.event_bus.notify Events::ChangedWorkingDirectory.new(old: old_directory, new: new_directory)
 
         self
       end

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -141,7 +141,7 @@ module Aruba
           # rubocop:enable Metrics/LineLength
 
           path
-        elsif '~' == prefix
+        elsif prefix == '~'
           path = with_environment do
             ArubaPath.new(File.expand_path(file_name))
           end

--- a/lib/aruba/api/environment.rb
+++ b/lib/aruba/api/environment.rb
@@ -23,7 +23,7 @@ module Aruba
         aruba.environment[name] = value
         new_environment = aruba.environment.to_h
 
-        aruba.event_bus.notify Events::AddedEnvironmentVariable.new(:old => old_environment, :new => new_environment, :changed => { :name => name, :value => value })
+        aruba.event_bus.notify Events::AddedEnvironmentVariable.new(old: old_environment, new: new_environment, changed: { name: name, value: value })
 
         self
       end
@@ -45,7 +45,7 @@ module Aruba
         aruba.environment.append name, value
         new_environment = aruba.environment.to_h
 
-        aruba.event_bus.notify Events::ChangedEnvironmentVariable.new(:old => old_environment, :new => new_environment, :changed => { :name => name, :value => value })
+        aruba.event_bus.notify Events::ChangedEnvironmentVariable.new(old: old_environment, new: new_environment, changed: { name: name, value: value })
 
         self
       end
@@ -67,7 +67,7 @@ module Aruba
         aruba.environment.prepend name, value
         new_environment = aruba.environment.to_h
 
-        aruba.event_bus.notify Events::ChangedEnvironmentVariable.new(:old => old_environment, :new => new_environment, :changed => { :name => name, :value => value })
+        aruba.event_bus.notify Events::ChangedEnvironmentVariable.new(old: old_environment, new: new_environment, changed: { name: name, value: value })
 
         self
       end
@@ -85,7 +85,7 @@ module Aruba
         aruba.environment.delete name
         new_environment = aruba.environment.to_h
 
-        aruba.event_bus.notify Events::DeletedEnvironmentVariable.new(:old => old_environment, :new => new_environment, :changed => { :name => name, :value => '' })
+        aruba.event_bus.notify Events::DeletedEnvironmentVariable.new(old: old_environment, new: new_environment, changed: { name: name, value: '' })
 
         self
       end

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -354,7 +354,7 @@ module Aruba
       #
       # @yield
       #   Pass the content of the given file to this block
-      def with_file_content(file, &block)
+      def with_file_content(file)
         expect(file).to be_an_existing_path
 
         content = read(file).join("\n")

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -72,7 +72,7 @@ module Aruba
         define_method("#{name}=") { |v| find_option(name).value = v }
 
         # Add reader
-        option_reader name, :contract => { None => contract.values.first }
+        option_reader name, contract: { None => contract.values.first }
       end
 
       private
@@ -80,7 +80,7 @@ module Aruba
       def add_option(name, value = nil)
         return if known_options.key?(name)
 
-        known_options[name] = Option.new(:name => name, :value => value)
+        known_options[name] = Option.new(name: name, value: value)
 
         self
       end

--- a/lib/aruba/cli.rb
+++ b/lib/aruba/cli.rb
@@ -18,7 +18,7 @@ module Aruba
     end
 
     desc 'init', 'Initialize aruba'
-    option :test_framework, :default => 'cucumber', :enum => %w(cucumber rspec minitest), :desc => 'Choose which test framework to use'
+    option :test_framework, default: 'cucumber', enum: %w(cucumber rspec minitest), desc: 'Choose which test framework to use'
     def init
       Aruba::Initializer.new.call(options[:test_framework])
     end

--- a/lib/aruba/colorizer.rb
+++ b/lib/aruba/colorizer.rb
@@ -4,34 +4,34 @@ module Aruba
   module AnsiColor
     # :stopdoc:
     ATTRIBUTES = [
-      [ :clear        ,   0 ],
-      [ :reset        ,   0 ],     # synonym for :clear
-      [ :bold         ,   1 ],
-      [ :dark         ,   2 ],
-      [ :italic       ,   3 ],     # not widely implemented
-      [ :underline    ,   4 ],
-      [ :underscore   ,   4 ],     # synonym for :underline
-      [ :blink        ,   5 ],
-      [ :rapid_blink  ,   6 ],     # not widely implemented
-      [ :negative     ,   7 ],     # no reverse because of String#reverse
-      [ :concealed    ,   8 ],
-      [ :strikethrough,   9 ],     # not widely implemented
-      [ :black        ,  30 ],
-      [ :red          ,  31 ],
-      [ :green        ,  32 ],
-      [ :yellow       ,  33 ],
-      [ :blue         ,  34 ],
-      [ :magenta      ,  35 ],
-      [ :cyan         ,  36 ],
-      [ :white        ,  37 ],
-      [ :on_black     ,  40 ],
-      [ :on_red       ,  41 ],
-      [ :on_green     ,  42 ],
-      [ :on_yellow    ,  43 ],
-      [ :on_blue      ,  44 ],
-      [ :on_magenta   ,  45 ],
-      [ :on_cyan      ,  46 ],
-      [ :on_white     ,  47 ]
+      [:clear,   0],
+      [:reset,   0], # synonym for :clear
+      [:bold,   1],
+      [:dark,   2],
+      [:italic, 3], # not widely implemented
+      [:underline, 4],
+      [:underscore, 4], # synonym for :underline
+      [:blink, 5],
+      [:rapid_blink, 6], # not widely implemented
+      [:negative, 7], # no reverse because of String#reverse
+      [:concealed, 8],
+      [:strikethrough, 9], # not widely implemented
+      [:black, 30],
+      [:red, 31],
+      [:green, 32],
+      [:yellow, 33],
+      [:blue, 34],
+      [:magenta, 35],
+      [:cyan, 36],
+      [:white, 37],
+      [:on_black, 40],
+      [:on_red, 41],
+      [:on_green, 42],
+      [:on_yellow, 43],
+      [:on_blue, 44],
+      [:on_magenta, 45],
+      [:on_cyan, 46],
+      [:on_white, 47]
     ].freeze
 
     ATTRIBUTE_NAMES = ATTRIBUTES.transpose.first

--- a/lib/aruba/colorizer.rb
+++ b/lib/aruba/colorizer.rb
@@ -74,10 +74,10 @@ module Aruba
     COLORED_REGEXP = /\e\[(?:[34][0-7]|[0-9])?m/
 
     def self.included(klass)
-      if klass == String
-        ATTRIBUTES.delete(:clear)
-        ATTRIBUTE_NAMES.delete(:clear)
-      end
+      return unless klass == String
+
+      ATTRIBUTES.delete(:clear)
+      ATTRIBUTE_NAMES.delete(:clear)
     end
 
     # Returns an uncolored version of the string, that is all

--- a/lib/aruba/config_wrapper.rb
+++ b/lib/aruba/config_wrapper.rb
@@ -30,7 +30,7 @@ module Aruba
     # If one method ends with "=", e.g. ":option1=", then notify the event
     # queue, that the user changes the value of "option1"
     def method_missing(name, *args, &block)
-      event_bus.notify Events::ChangedConfiguration.new(:changed => { :name => name.to_s.gsub(/=$/, ''), :value => args.first }) if name.to_s.end_with? '='
+      event_bus.notify Events::ChangedConfiguration.new(changed: { name: name.to_s.gsub(/=$/, ''), value: args.first }) if name.to_s.end_with? '='
 
       config.send(name, *args, &block)
     end

--- a/lib/aruba/configuration.rb
+++ b/lib/aruba/configuration.rb
@@ -17,39 +17,39 @@ module Aruba
   #
   # This defines the configuration options of aruba
   class Configuration < BasicConfiguration
-    option_reader :root_directory, :contract => { None => String }, :default => Dir.getwd
+    option_reader :root_directory, contract: { None => String }, default: Dir.getwd
 
-    option_accessor :working_directory, :contract => { Aruba::Contracts::RelativePath => Aruba::Contracts::RelativePath }, :default => 'tmp/aruba'
+    option_accessor :working_directory, contract: { Aruba::Contracts::RelativePath => Aruba::Contracts::RelativePath }, default: 'tmp/aruba'
 
-    option_reader :fixtures_path_prefix, :contract => { None => String }, :default => ?%
+    option_reader :fixtures_path_prefix, contract: { None => String }, default: '%'
 
-    option_accessor :exit_timeout, :contract => { Num => Num }, :default => 15
-    option_accessor :stop_signal, :contract => { Maybe[String] => Maybe[String] }, :default => nil
-    option_accessor :io_wait_timeout, :contract => { Num => Num }, :default => 0.1
-    option_accessor :startup_wait_time, :contract => { Num => Num }, :default => 0
-    option_accessor :fixtures_directories, :contract => { Array => ArrayOf[String] }, :default => %w(features/fixtures spec/fixtures test/fixtures fixtures)
-    option_accessor :command_runtime_environment, :contract => { Hash => Hash }, :default => ENV.to_hash
+    option_accessor :exit_timeout, contract: { Num => Num }, default: 15
+    option_accessor :stop_signal, contract: { Maybe[String] => Maybe[String] }, default: nil
+    option_accessor :io_wait_timeout, contract: { Num => Num }, default: 0.1
+    option_accessor :startup_wait_time, contract: { Num => Num }, default: 0
+    option_accessor :fixtures_directories, contract: { Array => ArrayOf[String] }, default: %w(features/fixtures spec/fixtures test/fixtures fixtures)
+    option_accessor :command_runtime_environment, contract: { Hash => Hash }, default: ENV.to_hash
     # rubocop:disable Metrics/LineLength
-    option_accessor(:command_search_paths, :contract => { ArrayOf[String] => ArrayOf[String] }) { |config| [File.join(config.root_directory.value, 'bin'), File.join(config.root_directory.value, 'exe')] }
+    option_accessor(:command_search_paths, contract: { ArrayOf[String] => ArrayOf[String] }) { |config| [File.join(config.root_directory.value, 'bin'), File.join(config.root_directory.value, 'exe')] }
     # rubocop:enable Metrics/LineLength
-    option_accessor :remove_ansi_escape_sequences, :contract => { Bool => Bool }, :default => true
+    option_accessor :remove_ansi_escape_sequences, contract: { Bool => Bool }, default: true
     # rubocop:disable Metrics/LineLength
-    option_accessor :command_launcher, :contract => { Aruba::Contracts::Enum[:in_process, :spawn, :debug] => Aruba::Contracts::Enum[:in_process, :spawn, :debug] }, :default => :spawn
-    option_accessor :main_class, :contract => { Class => Maybe[Class] }, :default => nil
+    option_accessor :command_launcher, contract: { Aruba::Contracts::Enum[:in_process, :spawn, :debug] => Aruba::Contracts::Enum[:in_process, :spawn, :debug] }, default: :spawn
+    option_accessor :main_class, contract: { Class => Maybe[Class] }, default: nil
 
-    option_accessor :home_directory, :contract => { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] } do |config|
+    option_accessor :home_directory, contract: { Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] => Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] } do |config|
       File.join(config.root_directory.value, config.working_directory.value)
     end
 
-    option_accessor :log_level, :contract => { Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] => Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] }, :default => :info
+    option_accessor :log_level, contract: { Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] => Aruba::Contracts::Enum[:fatal, :warn, :debug, :info, :error, :unknown, :silent] }, default: :info
 
     # TODO: deprecate this value and replace with "filesystem allocation unit"
     # equal to 4096 by default. "filesystem allocation unit" would represent
     # the actual MINIMUM space taken in bytes by a 1-byte file
-    option_accessor :physical_block_size, :contract => { Aruba::Contracts::IsPowerOfTwo => Aruba::Contracts::IsPowerOfTwo }, :default => 512
-    option_accessor :console_history_file, :contract => { String => String }, :default => '~/.aruba_history'
+    option_accessor :physical_block_size, contract: { Aruba::Contracts::IsPowerOfTwo => Aruba::Contracts::IsPowerOfTwo }, default: 512
+    option_accessor :console_history_file, contract: { String => String }, default: '~/.aruba_history'
 
-    option_accessor :activate_announcer_on_command_failure, :contract => { ArrayOf[Symbol] => ArrayOf[Symbol] }, :default => []
+    option_accessor :activate_announcer_on_command_failure, contract: { ArrayOf[Symbol] => ArrayOf[Symbol] }, default: []
   end
 end
 

--- a/lib/aruba/console.rb
+++ b/lib/aruba/console.rb
@@ -20,10 +20,10 @@ module Aruba
 
       IRB.conf[:PROMPT] = {}
       IRB.conf[:PROMPT][:ARUBA] = {
-        :PROMPT_I => '%N:%03n:%i> ',
-        :PROMPT_S => '%N:%03n:%i%l ',
-        :PROMPT_C => '%N:%03n:%i* ',
-        :RETURN => "# => %s\n"
+        PROMPT_I: '%N:%03n:%i> ',
+        PROMPT_S: '%N:%03n:%i%l ',
+        PROMPT_C: '%N:%03n:%i* ',
+        RETURN: "# => %s\n"
       }
       IRB.conf[:PROMPT_MODE] = :ARUBA
 

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -2,14 +2,14 @@ require 'aruba/generators/script_file'
 
 When(/^I run `([^`]*)`$/)do |cmd|
   cmd = sanitize_text(cmd)
-  run_command_and_stop(cmd, :fail_on_error => false)
+  run_command_and_stop(cmd, fail_on_error: false)
 end
 
 ## I successfully run `echo -n "Hello"`
 ## I successfully run `sleep 29` for up to 30 seconds
 When(/^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/)do |cmd, secs|
   cmd = sanitize_text(cmd)
-  run_command_and_stop(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_i)
+  run_command_and_stop(cmd, fail_on_error: true, exit_timeout: secs && secs.to_i)
 end
 
 When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do |shell, commands|
@@ -68,7 +68,7 @@ When(/^I stop the command(?: started last)? if (output|stdout|stderr) contains:$
   begin
     Timeout.timeout(aruba.config.exit_timeout) do
       loop do
-        output = last_command_started.public_send channel.to_sym, :wait_for_io => 0
+        output = last_command_started.public_send channel.to_sym, wait_for_io: 0
 
         output   = sanitize_text(output)
         expected = sanitize_text(expected)

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -1,13 +1,13 @@
 require 'aruba/generators/script_file'
 
-When(/^I run `([^`]*)`$/)do |cmd|
+When(/^I run `([^`]*)`$/) do |cmd|
   cmd = sanitize_text(cmd)
   run_command_and_stop(cmd, fail_on_error: false)
 end
 
 ## I successfully run `echo -n "Hello"`
 ## I successfully run `sleep 29` for up to 30 seconds
-When(/^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/)do |cmd, secs|
+When(/^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/) do |cmd, secs|
   cmd = sanitize_text(cmd)
   run_command_and_stop(cmd, fail_on_error: true, exit_timeout: secs && secs.to_i)
 end
@@ -22,13 +22,13 @@ When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do
   run_command_and_stop(Shellwords.escape(full_path), fail_on_error: false)
 end
 
-When(/^I run `([^`]*)` interactively$/)do |cmd|
+When(/^I run `([^`]*)` interactively$/) do |cmd|
   cmd = sanitize_text(cmd)
   @interactive = run_command(cmd)
 end
 
 # Merge interactive and background after refactoring with event queue
-When(/^I run `([^`]*)` in background$/)do |cmd|
+When(/^I run `([^`]*)` in background$/) do |cmd|
   run_command(sanitize_text(cmd))
 end
 

--- a/lib/aruba/cucumber/environment.rb
+++ b/lib/aruba/cucumber/environment.rb
@@ -1,4 +1,4 @@
-Given(/^a mocked home directory$/)do
+Given(/^a mocked home directory$/) do
   set_environment_variable 'HOME', expand_path('.')
 end
 

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -67,11 +67,11 @@ When(/^I append to "([^"]*)" with "([^"]*)"$/) do |file_name, file_content|
 end
 
 When(/^I remove (?:a|the) (?:file|directory)(?: named)? "([^"]*)"( with full force)?$/) do |name, force_remove|
-  remove(name, :force => force_remove.nil? ? false : true)
+  remove(name, force: force_remove.nil? ? false : true)
 end
 
 Given(/^(?:a|the) (?:file|directory)(?: named)? "([^"]*)" does not exist$/) do |name|
-  remove(name, :force => true)
+  remove(name, force: true)
 end
 
 When(/^I cd to "([^"]*)"$/) do |dir|

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -3,11 +3,11 @@ Given(/^I use (?:a|the) fixture(?: named)? "([^"]*)"$/) do |name|
   cd name
 end
 
-Given(/^I copy (?:a|the) (file|directory)(?: (?:named|from))? "([^"]*)" to "([^"]*)"$/) do |file_or_directory, source, destination|
+Given(/^I copy (?:a|the) (?:file|directory)(?: (?:named|from))? "([^"]*)" to "([^"]*)"$/) do |source, destination|
   copy source, destination
 end
 
-Given(/^I move (?:a|the) (file|directory)(?: (?:named|from))? "([^"]*)" to "([^"]*)"$/) do |file_or_directory, source, destination|
+Given(/^I move (?:a|the) (?:file|directory)(?: (?:named|from))? "([^"]*)" to "([^"]*)"$/) do |source, destination|
   move source, destination
 end
 

--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -68,7 +68,7 @@ module Aruba
 
       no_commands do
         def self.match?(framework)
-          :rspec == framework.downcase.to_sym
+          framework.downcase.to_sym == :rspec
         end
       end
 
@@ -109,7 +109,7 @@ module Aruba
 
       no_commands do
         def self.match?(framework)
-          :cucumber == framework.downcase.to_sym
+          framework.downcase.to_sym == :cucumber
         end
       end
 
@@ -134,7 +134,7 @@ module Aruba
 
       no_commands do
         def self.match?(framework)
-          :minitest == framework.downcase.to_sym
+          framework.downcase.to_sym == :minitest
         end
       end
 

--- a/lib/aruba/matchers/file/have_file_size.rb
+++ b/lib/aruba/matchers/file/have_file_size.rb
@@ -33,11 +33,11 @@ RSpec::Matchers.define :have_file_size do |expected|
     values_match?(@expected, @actual)
   end
 
-  failure_message do |actual|
+  failure_message do |_actual|
     format("expected that file \"%s\" has size \"%s\", but has \"%s\"", @old_actual, @actual, @expected)
   end
 
-  failure_message_when_negated do |actual|
+  failure_message_when_negated do |_actual|
     format("expected that file \"%s\" does not have size \"%s\", but has \"%s\"", @old_actual, @actual, @expected)
   end
 end

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -31,7 +31,7 @@ RSpec::Matchers.define :have_same_file_content_like do |expected|
     @actual = expand_path(actual)
     @expected = expand_path(expected)
 
-    FileUtils.compare_file(@actual,@expected)
+    FileUtils.compare_file(@actual, @expected)
   end
 
   failure_message do |actual|

--- a/lib/aruba/matchers/path/have_permissions.rb
+++ b/lib/aruba/matchers/path/have_permissions.rb
@@ -50,11 +50,11 @@ RSpec::Matchers.define :have_permissions do |expected|
     values_match? @expected, @actual
   end
 
-  failure_message do |actual|
+  failure_message do |_actual|
     format("expected that path \"%s\" has permissions \"%s\", but has \"%s\".", @old_actual, @expected, @actual)
   end
 
-  failure_message_when_negated do |actual|
+  failure_message_when_negated do |_actual|
     format("expected that path \"%s\" does not have permissions \"%s\", but has \"%s\".", @old_actual, @expected, @actual)
   end
 end

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -27,25 +27,32 @@ module Aruba
     #   Aruba.announcer.announce(:my_channel, 'my message')
     #
     class Announcer
+      # Base Announcer class
+      class BaseAnnouncer
+        def mode?(m)
+          mode == m
+        end
+      end
+
       # Announcer using Kernel.puts
-      class KernelPutsAnnouncer
+      class KernelPutsAnnouncer < BaseAnnouncer
         def announce(message)
           Kernel.puts message
         end
 
-        def mode?(m)
-          :kernel_puts == m
+        def mode
+          :kernel_puts
         end
       end
 
       # Announcer using Main#puts
-      class PutsAnnouncer
+      class PutsAnnouncer < BaseAnnouncer
         def announce(message)
           puts message
         end
 
-        def mode?(m)
-          :puts == m
+        def mode
+          :puts
         end
       end
 
@@ -112,9 +119,16 @@ module Aruba
       # @param [Symbol] m
       #   The mode to set
       def mode=(m)
-        @announcer = @announcers.find { |_a| f.mode? m.to_sym }
+        @announcer = @announcers.find { |a| a.mode? m.to_sym }
 
         self
+      end
+
+      # Fecth mode of announcer
+      #
+      # @return [Symbol] The current announcer mode
+      def mode
+        @announcer.mode
       end
 
       # Check if channel is activated

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -86,7 +86,7 @@ module Aruba
         output_format :timeout, '# %s-timeout: %s seconds'
         output_format :wait_time, '# %s: %s seconds'
         # rubocop:disable Metrics/LineLength
-        output_format :command_filesystem_status, proc { |status| format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS", Aruba.platform.simple_table(status.to_h, :sort => false)) }
+        output_format :command_filesystem_status, proc { |status| format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS", Aruba.platform.simple_table(status.to_h, sort: false)) }
         # rubocop:enable Metrics/LineLength
       end
 

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -112,7 +112,7 @@ module Aruba
       # @param [Symbol] m
       #   The mode to set
       def mode=(m)
-        @announcer = @announcers.find { |a| f.mode? m.to_sym }
+        @announcer = @announcers.find { |_a| f.mode? m.to_sym }
 
         self
       end
@@ -146,7 +146,7 @@ module Aruba
       # @yield
       #   If block is given, that one is called and the return value is used as
       #   message to be announced.
-      def announce(channel, *args, &block)
+      def announce(channel, *args)
         channel = channel.to_sym
 
         the_output_format = if output_formats.key? channel

--- a/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
+++ b/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
@@ -26,7 +26,7 @@ module Aruba
 
         Aruba.platform.mkdir(File.dirname(path))
 
-        File.open(path, "wb"){ |f| f.seek(size - 1); f.write("\0") }
+        File.open(path, "wb") { |f| f.seek(size - 1); f.write("\0") }
 
         self
       end

--- a/lib/aruba/platforms/filesystem_status.rb
+++ b/lib/aruba/platforms/filesystem_status.rb
@@ -30,7 +30,7 @@ module Aruba
 
       # Return permissions
       def mode
-        format("%o", status.mode)[-4,4].gsub(/^0*/, '')
+        format("%o", status.mode)[-4, 4].gsub(/^0*/, '')
       end
 
       # Return owner

--- a/lib/aruba/platforms/filesystem_status.rb
+++ b/lib/aruba/platforms/filesystem_status.rb
@@ -49,14 +49,14 @@ module Aruba
       #   A hash of values
       def to_h
         {
-          :owner      => owner,
-          :group      => group,
-          :mode       => mode,
-          :executable => executable?,
-          :ctime      => ctime,
-          :atime      => atime,
-          :mtime      => mtime,
-          :size       => size
+          owner: owner,
+          group: group,
+          mode: mode,
+          executable: executable?,
+          ctime: ctime,
+          atime: atime,
+          mtime: mtime,
+          size: size
         }
       end
     end

--- a/lib/aruba/platforms/local_environment.rb
+++ b/lib/aruba/platforms/local_environment.rb
@@ -13,7 +13,7 @@ module Aruba
       #
       # @yield
       #   The block of code which should with local ENV
-      def call(env, &block)
+      def call(env)
         old_env = ENV.to_hash.dup
 
         ENV.clear

--- a/lib/aruba/platforms/simple_table.rb
+++ b/lib/aruba/platforms/simple_table.rb
@@ -34,11 +34,11 @@ module Aruba
         if RUBY_VERSION < '2'
           rows = []
 
-          hash.each do |k,v|
+          hash.each do |k, v|
             rows << format("# %-#{name_size}s => %s", k, v)
           end
         else
-          rows = hash.each_with_object([]) do |(k,v), a|
+          rows = hash.each_with_object([]) do |(k, v), a|
             a << format("# %-#{name_size}s => %s", k, v)
           end
         end

--- a/lib/aruba/platforms/simple_table.rb
+++ b/lib/aruba/platforms/simple_table.rb
@@ -17,7 +17,7 @@ module Aruba
       def initialize(hash, opts)
         @hash = hash
         @opts = {
-          :sort => true
+          sort: true
         }.merge opts
       end
 

--- a/lib/aruba/platforms/unix_environment_variables.rb
+++ b/lib/aruba/platforms/unix_environment_variables.rb
@@ -133,7 +133,7 @@ module Aruba
         name  = name.to_s
         value = self[name].to_s + value.to_s
 
-        actions << UpdateAction.new(name => value )
+        actions << UpdateAction.new(name => value)
 
         value
       end

--- a/lib/aruba/platforms/unix_which.rb
+++ b/lib/aruba/platforms/unix_which.rb
@@ -23,7 +23,7 @@ module Aruba
           Aruba.platform.absolute_path?(program) || Aruba.platform.relative_command?(program)
         end
 
-        def call(program, path)
+        def call(program, _path)
           return File.expand_path(program) if Aruba.platform.executable?(program)
 
           nil

--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -31,11 +31,11 @@ module Aruba
       def initialize(env = ENV.to_hash)
         @actions = []
 
-        @env = env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
+        @env = env.each_with_object({}) { |(k, v), a| a[k.to_s.upcase] = v }
       end
 
       def update(other_env, &block)
-        other_env = other_env.each_with_object({}) { |(k,v), a| a[k.to_s.upcase] = v }
+        other_env = other_env.each_with_object({}) { |(k, v), a| a[k.to_s.upcase] = v }
 
         super(other_env, &block)
       end

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -95,7 +95,7 @@ module Aruba
       private
 
       def windows_executable_extentions
-        ENV['PATHEXT'] ? format('.{%s}', ENV['PATHEXT'].tr(';', ',').tr('.','')).downcase : '.{exe,com,bat}'
+        ENV['PATHEXT'] ? format('.{%s}', ENV['PATHEXT'].tr(';', ',').tr('.', '')).downcase : '.{exe,com,bat}'
       end
     end
   end

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -23,7 +23,7 @@ module Aruba
           Aruba.platform.absolute_path?(program) || Aruba.platform.relative_command?(program)
         end
 
-        def call(program, path)
+        def call(program, _path)
           # Expand `#path_exts`
           found = Dir[program].first
 

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -109,8 +109,8 @@ module Aruba
 
       def inspect
         # rubocop:disable Style/UnneededInterpolation
-        out = truncate("#{stdout(:wait_for_io => 0).inspect}", 35)
-        err = truncate("#{stderr(:wait_for_io => 0).inspect}", 35)
+        out = truncate("#{stdout(wait_for_io: 0).inspect}", 35)
+        err = truncate("#{stderr(wait_for_io: 0).inspect}", 35)
         # rubocop:enable Style/UnneededInterpolation
 
         fmt = '#<%s:%s commandline="%s": stdout=%s stderr=%s>'

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -19,7 +19,7 @@ module Aruba
     # @private
     class SpawnProcess < BasicProcess
       # Use as default launcher
-      def self.match?(mode)
+      def self.match?(_mode)
         true
       end
 
@@ -260,7 +260,7 @@ module Aruba
         Aruba.platform.command_string.new(cmd)
       end
 
-      def wait_for_io(time_to_wait, &block)
+      def wait_for_io(time_to_wait)
         sleep time_to_wait.to_i
         yield
       end

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -5,7 +5,7 @@ require 'aruba/api'
 require 'aruba/version'
 
 RSpec.configure do |config|
-  config.include Aruba::Api, :type => :aruba
+  config.include Aruba::Api, type: :aruba
 
   # Setup environment for aruba
   config.around :each do |example|

--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -49,7 +49,7 @@ module Aruba
 
       @environment.update(@config.command_runtime_environment)
 
-      @command_monitor = opts.fetch(:command_monitor, Aruba.platform.command_monitor.new(:announcer => @announcer))
+      @command_monitor = opts.fetch(:command_monitor, Aruba.platform.command_monitor.new(announcer: @announcer))
 
       @logger = opts.fetch(:logger, Aruba.platform.logger.new)
       @logger.mode = @config.log_level

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -25,7 +25,7 @@ module Aruba
 
     def working_directory(clobber = true)
       if clobber
-        Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), :force => true
+        Aruba.platform.rm File.join(runtime.config.root_directory, runtime.config.working_directory), force: true
       end
       Aruba.platform.mkdir File.join(runtime.config.root_directory, runtime.config.working_directory)
       Aruba.platform.chdir runtime.config.root_directory

--- a/lib/aruba/tasks/docker_helpers.rb
+++ b/lib/aruba/tasks/docker_helpers.rb
@@ -13,7 +13,7 @@ module Aruba
       @instance = instance
     end
 
-    def method_missing(m, *args, &block)
+    def method_missing(m, *_args)
       @file.public_send m, instance
     end
 

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -285,7 +285,7 @@ describe Aruba::Api do
         end
 
         context 'when is forced to delete file' do
-          let(:options) { { :force => true } }
+          let(:options) { { force: true } }
 
           it_behaves_like 'a non-existing file'
         end
@@ -330,7 +330,7 @@ describe Aruba::Api do
         end
 
         context 'when is forced to delete directory' do
-          let(:options) { { :force => true } }
+          let(:options) { { force: true } }
 
           it_behaves_like 'a non-existing directory'
         end
@@ -376,7 +376,7 @@ describe Aruba::Api do
 
           context 'and the mtime should be set statically' do
             let(:time) { Time.parse('2014-01-01 10:00:00') }
-            let(:options) { { :mtime => Time.parse('2014-01-01 10:00:00') } }
+            let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
 
             it_behaves_like 'an existing file'
             it { expect(File.mtime(path)).to eq time }
@@ -403,7 +403,7 @@ describe Aruba::Api do
 
           context 'and the mtime should be set statically' do
             let(:time) { Time.parse('2014-01-01 10:00:00') }
-            let(:options) { { :mtime => Time.parse('2014-01-01 10:00:00') } }
+            let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
 
             it_behaves_like 'an existing directory'
             it { Array(path).each { |p| expect(File.mtime(p)).to eq time } }

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -124,7 +124,7 @@ describe Aruba::Api do
   end
 
   describe '#read' do
-    let(:name) { 'test.txt'}
+    let(:name) { 'test.txt' }
     let(:path) { File.join(@aruba.aruba.current_directory, name) }
     let(:content) { 'asdf' }
 
@@ -199,7 +199,7 @@ describe Aruba::Api do
         end
 
         context 'when normal file' do
-          it { expect{ @aruba.list(name) }.to raise_error ArgumentError }
+          it { expect { @aruba.list(name) }.to raise_error ArgumentError }
         end
       end
 
@@ -217,7 +217,7 @@ describe Aruba::Api do
             let(:existing_files) { @aruba.list(name) }
             let(:expected_files) { content.map { |c| File.join(name, c) }.sort }
 
-            it { expect(expected_files - existing_files).to be_empty}
+            it { expect(expected_files - existing_files).to be_empty }
           end
 
           context 'when path contains ~' do
@@ -228,7 +228,7 @@ describe Aruba::Api do
             let(:existing_files) { @aruba.list(name) }
             let(:expected_files) { content.map { |c| File.join(string, c) } }
 
-            it { expect(expected_files - existing_files).to be_empty}
+            it { expect(expected_files - existing_files).to be_empty }
           end
         end
 
@@ -241,7 +241,7 @@ describe Aruba::Api do
   end
 
   describe '#remove' do
-    let(:name) { 'test.txt'}
+    let(:name) { 'test.txt' }
     let(:path) { File.join(@aruba.aruba.current_directory, name) }
     let(:options) { {} }
 
@@ -658,7 +658,7 @@ describe Aruba::Api do
         end
 
         context 'when source is non-existing' do
-          it { expect { @aruba.copy source, destination }.to raise_error ArgumentError}
+          it { expect { @aruba.copy source, destination }.to raise_error ArgumentError }
         end
       end
     end
@@ -763,7 +763,7 @@ describe Aruba::Api do
 
     describe '#chmod' do
       def actual_permissions
-        format( "%o" , File::Stat.new(file_path).mode )[-4,4]
+        format("%o", File::Stat.new(file_path).mode)[-4, 4]
       end
 
       let(:file_name) { @file_name }
@@ -935,7 +935,7 @@ describe Aruba::Api do
   end
 
   describe '#run_command' do
-    before(:each){ @aruba.run_command 'cat' }
+    before(:each) { @aruba.run_command 'cat' }
     after(:each) { @aruba.all_commands.each(&:stop) }
 
     it "respond to input" do

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -625,7 +625,7 @@ describe Aruba::Api do
                 @aruba.copy source, destination
               end
 
-              it { source.each { |s| expect(destination_files).to all be_an_existing_file } }
+              it { expect(destination_files).to all be_an_existing_file }
             end
 
             context 'when destination is not a directory' do

--- a/spec/aruba/hooks_spec.rb
+++ b/spec/aruba/hooks_spec.rb
@@ -10,8 +10,8 @@ describe Aruba::Hooks do
 
   it 'executes a stored hook that takes multiple arguments' do
     hook_values = []
-    subject.append :hook_label, lambda { |a,b,c| hook_values = [a,b,c] }
+    subject.append :hook_label, lambda { |a, b, c| hook_values = [a, b, c] }
     subject.execute :hook_label, self, 1, 2, 3
-    expect(hook_values).to eq [1,2,3]
+    expect(hook_values).to eq [1, 2, 3]
   end
 end

--- a/spec/aruba/in_config_wrapper_spec.rb
+++ b/spec/aruba/in_config_wrapper_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe Aruba::InConfigWrapper do
     end
 
     context 'when one tries to pass arguments to option' do
-      it { expect{ wrapper.opt('arg') }.to raise_error ArgumentError, 'Options take no argument' }
+      it { expect { wrapper.opt('arg') }.to raise_error ArgumentError, 'Options take no argument' }
     end
   end
 
   context 'when option is not defined' do
-    it { expect{ wrapper.opt }.to raise_error ArgumentError, 'Option "opt" is unknown. Please use only earlier defined options' }
+    it { expect { wrapper.opt }.to raise_error ArgumentError, 'Option "opt" is unknown. Please use only earlier defined options' }
   end
 end

--- a/spec/aruba/platform/simple_table_spec.rb
+++ b/spec/aruba/platform/simple_table_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe '.simple_table' do
   context 'when valid hash' do
     let(:hash) do
       {
-        :key1 => 'value',
-        :key2 => 'value'
+        key1: 'value',
+        key2: 'value'
       }
     end
     let(:rows) { ['# key1 => value', '# key2 => value'] }

--- a/spec/aruba/platforms/announcer_spec.rb
+++ b/spec/aruba/platforms/announcer_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+require 'aruba/platforms/announcer'
+
+RSpec.describe Aruba::Platforms::Announcer do
+  let(:announcer) { described_class.new }
+
+  describe '#mode=' do
+    it 'sets the mode to :puts' do
+      announcer.mode = :puts
+      expect(announcer.mode).to eq :puts
+    end
+
+    it 'sets the mode to :kernel_puts' do
+      announcer.mode = :kernel_puts
+      expect(announcer.mode).to eq :kernel_puts
+    end
+  end
+end

--- a/spec/aruba/platforms/command_monitor_spec.rb
+++ b/spec/aruba/platforms/command_monitor_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Aruba::CommandMonitor do
   subject do
-    described_class.new(:announcer => announcer)
+    described_class.new(announcer: announcer)
   end
 
   let(:announcer) { instance_double(Aruba::Platforms::Announcer) }

--- a/spec/aruba/processes/basic_process_spec.rb
+++ b/spec/aruba/processes/basic_process_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe Aruba::Processes::BasicProcess do
         super(*args)
       end
 
-      def stdout(*args)
+      def stdout(*_args)
         @stdout
       end
 
-      def stderr(*args)
+      def stderr(*_args)
         @stderr
       end
     end.new(stdout, stderr, cmd, exit_timeout, io_wait_timeout, working_directory)

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Aruba::Processes::SpawnProcess do
     context "when process run fails" do
       let(:command) { 'does_not_exists' }
 
-      it { expect {process.start}.to raise_error Aruba::LaunchError }
+      it { expect { process.start }.to raise_error Aruba::LaunchError }
     end
 
     context "with a childprocess launch error" do

--- a/spec/aruba/rspec_spec.rb
+++ b/spec/aruba/rspec_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-RSpec.describe 'RSpec Integration', :type => :aruba do
+RSpec.describe 'RSpec Integration', type: :aruba do
   describe 'Configuration' do
     subject(:config) { aruba.config }
 
-    context 'when io_wait_timeout is 0.5', :io_wait_timeout => 0.5 do
+    context 'when io_wait_timeout is 0.5', io_wait_timeout: 0.5 do
       it { expect(config.io_wait_timeout).to eq 0.5 }
     end
 

--- a/spec/support/configs/rspec.rb
+++ b/spec/support/configs/rspec.rb
@@ -2,7 +2,7 @@ require 'rspec/core'
 require 'aruba/api'
 
 RSpec.configure do |config|
-  config.filter_run :focus => true
+  config.filter_run focus: true
 
   config.run_all_when_everything_filtered = true
 

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -32,7 +32,7 @@ RSpec.shared_context 'uses aruba API' do
     @file_path = @aruba.expand_path(@file_name)
     @aruba.setup_aruba
 
-    raise "We must work with relative paths, everything else is dangerous" if ?/ == @aruba.aruba.current_directory[0]
+    raise "We must work with relative paths, everything else is dangerous" if @aruba.aruba.current_directory[0] == ?/
   end
 end
 

--- a/spec/support/shared_examples/configuration.rb
+++ b/spec/support/shared_examples/configuration.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'a basic configuration' do
   subject(:config) do
     Class.new(described_class) do
-      option_accessor :use_test, :contract => { Contracts::Bool => Contracts::Bool }, :default => false
+      option_accessor :use_test, contract: { Contracts::Bool => Contracts::Bool }, default: false
     end.new
   end
 
@@ -13,7 +13,7 @@ RSpec.shared_examples 'a basic configuration' do
     subject(:config) { config_klass.new }
 
     before :each do
-      config_klass.option_reader :new_opt, :contract => { Contracts::Num => Contracts::Num }, :default => 1
+      config_klass.option_reader :new_opt, contract: { Contracts::Num => Contracts::Num }, default: 1
     end
 
     context 'when value is read' do
@@ -26,7 +26,7 @@ RSpec.shared_examples 'a basic configuration' do
 
     context 'when block is defined' do
       before :each do
-        config_klass.option_reader :new_opt2, :contract => { Contracts::Num => Contracts::Num } do |c|
+        config_klass.option_reader :new_opt2, contract: { Contracts::Num => Contracts::Num } do |c|
           c.new_opt.value + 1
         end
       end
@@ -37,7 +37,7 @@ RSpec.shared_examples 'a basic configuration' do
     context 'when block and default value is defined' do
       it do
         expect do
-          config_klass.option_accessor :new_opt2, :contract => { Contracts::Num => Contracts::Num }, :default => 2 do |c|
+          config_klass.option_accessor :new_opt2, contract: { Contracts::Num => Contracts::Num }, default: 2 do |c|
             c.new_opt.value + 1
           end
         end.to raise_error ArgumentError, 'Either use block or default value'
@@ -51,7 +51,7 @@ RSpec.shared_examples 'a basic configuration' do
     subject(:config) { config_klass.new }
 
     before :each do
-      config_klass.option_accessor :new_opt, :contract => { Contracts::Num => Contracts::Num }, :default => 1
+      config_klass.option_accessor :new_opt, contract: { Contracts::Num => Contracts::Num }, default: 1
     end
 
     context 'when default is used' do
@@ -66,7 +66,7 @@ RSpec.shared_examples 'a basic configuration' do
 
     context 'when block is defined' do
       before :each do
-        config_klass.option_accessor :new_opt2, :contract => { Contracts::Num => Contracts::Num } do |c|
+        config_klass.option_accessor :new_opt2, contract: { Contracts::Num => Contracts::Num } do |c|
           c.new_opt.value + 1
         end
       end
@@ -77,7 +77,7 @@ RSpec.shared_examples 'a basic configuration' do
     context 'when block and default value is defined' do
       it do
         expect do
-          config_klass.option_accessor :new_opt2, :contract => { Contracts::Num => Contracts::Num }, :default => 2 do |c|
+          config_klass.option_accessor :new_opt2, contract: { Contracts::Num => Contracts::Num }, default: 2 do |c|
             c.new_opt1 + 1
           end
         end.to raise_error ArgumentError, 'Either use block or default value'

--- a/spec/support/shared_examples/configuration.rb
+++ b/spec/support/shared_examples/configuration.rb
@@ -21,7 +21,7 @@ RSpec.shared_examples 'a basic configuration' do
     end
 
     context 'when one tries to write a value' do
-      it { expect{ config.new_opt = 1}.to raise_error NoMethodError }
+      it { expect { config.new_opt = 1 }.to raise_error NoMethodError }
     end
 
     context 'when block is defined' do


### PR DESCRIPTION
## Summary

Fix some rubocop offenses

## Details

Mostly autocorrects by RuboCop, activated by removing some of the items from `.rubocop_todo.yml`.

## Motivation and Context

Continuous improvement of the code uniformity and quality.

## How Has This Been Tested?

Travis.

## Types of changes

- Refactoring (cleanup of codebase withouth changing any existing functionality)