### PR TITLE
Restore expand_path behavior for absolute paths

### DIFF
--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -163,7 +163,8 @@ module Aruba
           path.to_s
         else
           directory = File.join(aruba.root_directory, aruba.current_directory)
-          ArubaPath.new(File.join(*[directory, dir_string, file_name].compact)).expand_path.to_s
+          directory = File.expand_path(dir_string, directory) if dir_string
+          File.expand_path(file_name, directory)
         end
       end
       # rubocop:enable Metrics/MethodLength

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -654,6 +654,10 @@ describe Aruba::Api do
         it { expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path) }
       end
 
+      context 'when file_path is given' do
+        it { expect(@aruba.expand_path(@file_path)).to eq @file_path }
+      end
+
       context 'when path contains "."' do
         it { expect(@aruba.expand_path('.')).to eq File.expand_path(aruba.current_directory) }
       end


### PR DESCRIPTION
## Summary

Fixes the behaviour of `#expand_path` when called with an absolute path.

## Details

Uses `File.expand_path` which has the desired behaviour.

## Motivation and Context

Fixes #486.

## How Has This Been Tested?

A spec for this case was added to the test suite.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- I've added tests for my code