### PR TITLE
Travis: use latest JRuby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ jobs:
       osx_image: xcode8
     - rvm: jruby
       os: linux
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.16.0
       os: linux
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.16.0
       os: osx
     - stage: lint
       script: bundle exec rake lint
@@ -53,7 +53,7 @@ jobs:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby
-    - rvm: jruby-9.1.13.0
+    - rvm: jruby-9.1.16.0
   fast_finish: true
 
 branches:


### PR DESCRIPTION
## Summary

This PR updates the CI matrix to use latest JRuby.

## Details

http://jruby.org/2018/02/21/jruby-9-1-16-0.html

## Motivation and Context

Latest generally available JRuby's got more fixes.

While reading a PR, I visited Travis to view the results, and the JRuby version used was quite old.

## How Has This Been Tested?

Using Travis.

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase withouth changing any existing functionality)
- [ ] Update documentation

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
