### PR TITLE
Improve spec isolation by not blanket-including Aruba

### DIFF
--- a/spec/aruba/api/deprecated_spec.rb
+++ b/spec/aruba/api/deprecated_spec.rb
@@ -302,7 +302,7 @@ RSpec.describe 'Deprecated API' do
     end
 
     it "raises a descriptive exception" do
-      expect { @aruba.get_process("false") }.to raise_error CommandNotFoundError, "No command named 'false' has been started"
+      expect { @aruba.get_process("false") }.to raise_error Aruba::CommandNotFoundError, "No command named 'false' has been started"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,3 @@ else
   Dir.glob(::File.expand_path('../support/*.rb', __FILE__)).each { |f| require_relative f }
   Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
 end
-
-# Avoid writing "describe LocalPac::MyClass do [..]" but "describe MyClass do [..]"
-include Aruba


### PR DESCRIPTION
## Summary

Improve spec isolation by not blanket-including Aruba

## Details

Don't do `include Aruba` in the spec helper.

## Motivation and Context

Less confusion in specs between modules and methods provided by the test environment and Ruby on the one hand, and Aruba on the other. Mainly just a back-port of a fix that's already on master.

## How Has This Been Tested?

Travis.

## Types of changes

- Refactoring (cleanup of code base without changing any existing functionality)