### PR TITLE
Clean up cuke tags

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -13,9 +13,6 @@ ignore_opts = []
 ignore_opts <<  '--tags ~@ignore'
 ignore_opts <<  '--tags ~@unsupported-on-platform-java'    if RUBY_PLATFORM.include? 'java'
 ignore_opts <<  '--tags ~@unsupported-on-platform-mri'     if !RUBY_PLATFORM.include? 'java'
-ignore_opts <<  '--tags ~@unsupported-on-platform-windows' if FFI::Platform.windows?
-ignore_opts <<  '--tags ~@unsupported-on-platform-unix'    if FFI::Platform.unix?
-ignore_opts <<  '--tags ~@unsupported-on-platform-mac'     if FFI::Platform.mac?
 ignore_opts <<  '--tags ~@unsupported-on-ruby-older-2'     if RUBY_VERSION < '2'
 ignore_opts = ignore_opts.join(' ')
 %>

--- a/cucumber.yml
+++ b/cucumber.yml
@@ -11,9 +11,6 @@ java_wip_opts     = "--tags @wip-jruby-java-1.6:3" if defined?(JRUBY_VERSION) &&
 
 ignore_opts = []
 ignore_opts <<  '--tags ~@ignore'
-ignore_opts <<  '--tags ~@unsupported-on-platform-java'    if RUBY_PLATFORM.include? 'java'
-ignore_opts <<  '--tags ~@unsupported-on-platform-mri'     if !RUBY_PLATFORM.include? 'java'
-ignore_opts <<  '--tags ~@unsupported-on-ruby-older-2'     if RUBY_VERSION < '2'
 ignore_opts = ignore_opts.join(' ')
 %>
 default: <%= std_opts %> --tags ~@wip <%= java_default_opts %> <%= ignore_opts %>

--- a/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
@@ -279,8 +279,8 @@ Feature: Stop commands
     When I run `cucumber`
     Then the features should all pass
 
-  @requires-ruby-platform-mri
-  Scenario: STDERR/STDOUT is written normally with MRI-Ruby if output was written in "signal"-handler
+  @unsupported-on-platform-java
+  Scenario: STDERR/STDOUT is written normally if output was written in "signal"-handler
     Given an executable named "bin/aruba-test-cli1" with:
     """bash
     #!/bin/bash
@@ -311,3 +311,4 @@ Feature: Stop commands
     """
     When I run `cucumber`
     Then the features should all pass
+

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -81,7 +81,7 @@ Before '@requires-ruby-platform-java' do |scenario|
   end
 end
 
-Before '@requires-ruby-platform-mri' do |scenario|
+Before '@unsupported-on-platform-java' do |scenario|
   # leave if not java
   next unless RUBY_PLATFORM.include? 'java'
 


### PR DESCRIPTION
## Summary

Clean up set of internally used cuke tags and their implementation.

## Details

* Remove one of the ways to indicate need for MRI platform
* Use only `hooks.rb` to define platform-related tag handling.
* Remove unused tags.

## Motivation and Context

Clean up stuff.

## How Has This Been Tested?

Travis.

## Types of changes

- Refactoring (cleanup of codebase without changing any existing functionality)