### PR TITLE
Loosen dependency on childprocess

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'http://github.com/cucumber/aruba'
 
   spec.add_runtime_dependency 'cucumber', '~> 2.4', '>= 2.4.0'
-  spec.add_runtime_dependency 'childprocess', '~> 0.8.0'
+  spec.add_runtime_dependency 'childprocess', ['>= 0.6.3', '< 0.10.0']
   spec.add_runtime_dependency 'ffi', '~> 1.9', '>= 1.9.10'
   spec.add_runtime_dependency 'rspec-expectations', '~> 3.4', '>= 3.4.0'
   spec.add_runtime_dependency 'contracts', '~> 0.13'


### PR DESCRIPTION
## Summary

Like it says on the tin.

## Details

Allows all versions of childprocess that we can reasonable expect to work with aruba according to the [childprocess changelog](https://github.com/enkessler/childprocess/blob/master/CHANGELOG.md)

## Motivation and Context

Allows latest childprocess to be used with Aruba (like already is the case for 0.14.x).

## How Has This Been Tested?

We're currently lacking tests for checking if the lowest required versions for dependencies still work. Other than that: Travis.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
