### PR TITLE
Renamed `#have_same_file_content_like` matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG][2].
 * Make forgetting setup_aruba a hard failure ([#510] by [mvz])
 * Improve documentation for users and developers ([#454], [#456], [#457], [#460],
   [#459], [#461], [#475], [#494] by [olleolleolle], [maxmeyer], [mvz])
-* Deprecated `have_same_file_content_like` and `a_file_with_same_content_like` matchers, in favour of `have_same_file_content_as` and `a_file_with_same_content_as`. ([#485] by XtraSimplicity)
+* Deprecated `have_same_file_content_like` and `a_file_with_same_content_like` matchers, in favour of `have_same_file_content_as` and `a_file_with_same_content_as`. ([#555](https://github.com/cucumber/aruba/pull/555) by [XtraSimplicity](https://github.com/xtrasimplicity))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG][2].
 * Make forgetting setup_aruba a hard failure ([#510] by [mvz])
 * Improve documentation for users and developers ([#454], [#456], [#457], [#460],
   [#459], [#461], [#475], [#494] by [olleolleolle], [maxmeyer], [mvz])
-* Deprecated `have_same_file_content_like` and `a_file_with_same_content_like` matchers, in favour of `have_same_file_content_as` and `a_file_with_same_content_as`. ([#555](https://github.com/cucumber/aruba/pull/555) by [XtraSimplicity](https://github.com/xtrasimplicity))
+* Removed `have_same_file_content_like` and `a_file_with_same_content_like` matchers, in favour of `have_same_file_content_as` and `a_file_with_same_content_as`. ([#555](https://github.com/cucumber/aruba/pull/555) by [XtraSimplicity](https://github.com/xtrasimplicity))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG][2].
 * Make forgetting setup_aruba a hard failure ([#510] by [mvz])
 * Improve documentation for users and developers ([#454], [#456], [#457], [#460],
   [#459], [#461], [#475], [#494] by [olleolleolle], [maxmeyer], [mvz])
+* Deprecated `have_same_file_content_like` and `a_file_with_same_content_like` matchers, in favour of `have_same_file_content_as` and `a_file_with_same_content_as`. ([#485] by XtraSimplicity)
 
 ### Removed
 

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -174,9 +174,9 @@ end
 
 Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?be equal to file "([^"]*)"/) do |file, negated, reference_file|
   if negated
-    expect(file).not_to have_same_file_content_like(reference_file)
+    expect(file).not_to have_same_file_content_as(reference_file)
   else
-    expect(file).to have_same_file_content_like(reference_file)
+    expect(file).to have_same_file_content_as(reference_file)
   end
 end
 

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -19,7 +19,7 @@ require 'fileutils'
 #
 #     RSpec.describe do
 #       it { expect(file1).to have_same_file_content_as(file2) }
-#       it { expect(files).to include a_file_with_same_content_like(file2) }
+#       it { expect(files).to include a_file_with_same_content_as(file2) }
 #     end
 RSpec::Matchers.define :have_same_file_content_as do |expected|
   match do |actual|
@@ -43,20 +43,3 @@ RSpec::Matchers.define :have_same_file_content_as do |expected|
 end
 
 RSpec::Matchers.alias_matcher :a_file_with_same_content_as, :have_same_file_content_as
-
-# Deprecated matchers
-module DeprecatedMatchers
-  def have_same_file_content_like(expected)
-    RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
-
-    have_same_file_content_as(expected)
-  end
-
-  def a_file_with_same_content_like(expected)
-    RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
-
-    a_file_with_same_content_as(expected)
-  end
-end
-
-RSpec::Matchers.send(:include, DeprecatedMatchers)

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -1,8 +1,7 @@
 require 'rspec/expectations/version'
-
 require 'fileutils'
 
-# @!method have_same_file_content_like(file_name)
+# @!method have_same_file_content_as(file_name)
 #   This matchers checks if <file1> has the same content like <file2>
 #
 #   @param [String] file_name
@@ -19,10 +18,10 @@ require 'fileutils'
 #   @example Use matcher
 #
 #     RSpec.describe do
-#       it { expect(file1).to have_same_file_content_like(file2) }
+#       it { expect(file1).to have_same_file_content_as(file2) }
 #       it { expect(files).to include a_file_with_same_content_like(file2) }
 #     end
-RSpec::Matchers.define :have_same_file_content_like do |expected|
+RSpec::Matchers.define :have_same_file_content_as do |expected|
   match do |actual|
     stop_all_commands
 
@@ -43,4 +42,23 @@ RSpec::Matchers.define :have_same_file_content_like do |expected|
   end
 end
 
-RSpec::Matchers.alias_matcher :a_file_with_same_content_like, :have_same_file_content_like
+RSpec::Matchers.alias_matcher :a_file_with_same_content_as, :have_same_file_content_as
+
+# Deprecated matchers
+module DeprecatedMatchers
+  def have_same_file_content_like(expected)
+    RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
+
+    have_same_file_content_as(expected)
+  end
+
+  def a_file_with_same_content_like(expected)
+    RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
+
+    a_file_with_same_content_as(expected)
+  end
+end
+
+RSpec.configure do |config|
+  config.include DeprecatedMatchers
+end

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -45,14 +45,18 @@ end
 RSpec::Matchers.alias_matcher :a_file_with_same_content_as, :have_same_file_content_as
 
 # Deprecated matchers
-def have_same_file_content_like(expected)
-  RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
+module DeprecatedMatchers
+  def have_same_file_content_like(expected)
+    RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
 
-  have_same_file_content_as(expected)
+    have_same_file_content_as(expected)
+  end
+
+  def a_file_with_same_content_like(expected)
+    RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
+
+    a_file_with_same_content_as(expected)
+  end
 end
 
-def a_file_with_same_content_like(expected)
-  RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
-
-  a_file_with_same_content_as(expected)
-end
+RSpec::Matchers.send(:include, DeprecatedMatchers)

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -1,6 +1,5 @@
 require 'rspec/expectations/version'
 require 'fileutils'
-require 'rspec/core' unless defined? RSpec.configure
 
 # @!method have_same_file_content_as(file_name)
 #   This matchers checks if <file1> has the same content like <file2>
@@ -46,20 +45,14 @@ end
 RSpec::Matchers.alias_matcher :a_file_with_same_content_as, :have_same_file_content_as
 
 # Deprecated matchers
-module DeprecatedMatchers
-  def have_same_file_content_like(expected)
-    RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
+def have_same_file_content_like(expected)
+  RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
 
-    have_same_file_content_as(expected)
-  end
-
-  def a_file_with_same_content_like(expected)
-    RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
-
-    a_file_with_same_content_as(expected)
-  end
+  have_same_file_content_as(expected)
 end
 
-RSpec.configure do |config|
-  config.include DeprecatedMatchers
+def a_file_with_same_content_like(expected)
+  RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
+
+  a_file_with_same_content_as(expected)
 end

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -1,5 +1,6 @@
 require 'rspec/expectations/version'
 require 'fileutils'
+require 'rspec/core' unless defined? RSpec.configure
 
 # @!method have_same_file_content_as(file_name)
 #   This matchers checks if <file1> has the same content like <file2>

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -189,14 +189,6 @@ RSpec.describe 'File Matchers' do
     end
   end
 
-  describe "a_file_with_same_content_as" do
-    it 'calls have_same_file_content_as' do
-      expect(self).to receive(:have_same_file_content_as)
-
-      a_file_with_same_content_as 'a'
-    end
-  end
-
 
   describe 'to_have_file_size' do
     context 'when file exists' do

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -146,20 +146,46 @@ RSpec.describe 'File Matchers' do
       end
     end
   end
+  
+  describe "include a_file_with_same_content_as" do
+    let(:reference_file) { 'fixture' }
+    let(:reference_file_content) { 'foo bar baz' }
+    let(:file_with_same_content) { 'file_a.txt' }
+    let(:file_with_different_content) { 'file_b.txt' }
 
-  describe "to have_same_file_content_like" do
-    it 'calls have_same_file_content_as' do
-      expect(self).to receive(:have_same_file_content_as)
-
-      have_same_file_content_like 'a'
+    before :each do
+      @aruba.write_file(file_with_same_content, reference_file_content)
+      @aruba.write_file(reference_file, reference_file_content)
+      @aruba.write_file(file_with_different_content, 'Some different content here...')
     end
-  end
+    
+    context 'when the array of files includes a file with the same content' do
+      let(:files) { [file_with_different_content, file_with_same_content] }
 
-  describe "a_file_with_same_content_like" do
-    it 'calls have_same_file_content_as' do
-      expect(self).to receive(:have_same_file_content_as)
+      context 'and this is expected' do
+        it { expect(files).to include a_file_with_same_content_as reference_file }
+      end
 
-      a_file_with_same_content_like 'a'
+      context 'and this is not expected' do
+        it do
+          expect { expect(files).not_to include a_file_with_same_content_as reference_file }
+        end
+      end
+      
+    end
+
+    context 'when the array of files does not include a file with the same content' do
+      let(:files) { [file_with_different_content] }
+
+      context 'and this is expected' do
+        it { expect(files).not_to include a_file_with_same_content_as reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(files).to include a_file_with_same_content_as reference_file }
+        end
+      end
     end
   end
 

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe 'File Matchers' do
     end
   end
 
-  describe "to have_same_file_content_like" do
+  describe "to have_same_file_content_as" do
     let(:file_name) { @file_name }
     let(:file_path) { @file_path }
 
@@ -120,12 +120,12 @@ RSpec.describe 'File Matchers' do
       let(:reference_file_content) { 'foo bar baz' }
 
       context 'and this is expected' do
-        it { expect(file_name).to have_same_file_content_like reference_file }
+        it { expect(file_name).to have_same_file_content_as reference_file }
       end
 
       context 'and this is not expected' do
         it do
-          expect { expect(file_name).not_to have_same_file_content_like reference_file }
+          expect { expect(file_name).not_to have_same_file_content_as reference_file }
             .to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
@@ -135,17 +135,42 @@ RSpec.describe 'File Matchers' do
       let(:reference_file_content) { 'bar' }
 
       context 'and this is expected' do
-        it { expect(file_name).not_to have_same_file_content_like reference_file }
+        it { expect(file_name).not_to have_same_file_content_as reference_file }
       end
 
       context 'and this is not expected' do
         it do
-          expect { expect(file_name).to have_same_file_content_like reference_file }
+          expect { expect(file_name).to have_same_file_content_as reference_file }
             .to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end
   end
+
+  describe "to have_same_file_content_like" do
+    it 'calls have_same_file_content_as' do
+      expect(self).to receive(:have_same_file_content_as)
+
+      have_same_file_content_like 'a'
+    end
+  end
+
+  describe "a_file_with_same_content_like" do
+    it 'calls have_same_file_content_as' do
+      expect(self).to receive(:have_same_file_content_as)
+
+      a_file_with_same_content_like 'a'
+    end
+  end
+
+  describe "a_file_with_same_content_as" do
+    it 'calls have_same_file_content_as' do
+      expect(self).to receive(:have_same_file_content_as)
+
+      a_file_with_same_content_as 'a'
+    end
+  end
+
 
   describe 'to_have_file_size' do
     context 'when file exists' do


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Removed `have_same_file_content_like` and `a_file_with_same_content_like` matchers, and added `have_same_file_content_as` and `a_file_with_same_content_as`, as per https://github.com/cucumber/aruba/issues/485. The previous methods are deprecated in the HEAD of the `still` branch.

## Details



## Motivation and Context
To make it easier to understand what the matcher does.

## How Has This Been Tested?

Added specs to ensure that the renamed methods are called.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.