### PR TITLE
Still Branch: Deprecated `have_same_file_content_like` and `a_file_with_same_content_like` matchers

### DIFF
--- a/lib/aruba/matchers/deprecated.rb
+++ b/lib/aruba/matchers/deprecated.rb
@@ -1,0 +1,15 @@
+module DeprecatedMatchers
+  def have_same_file_content_like(expected)
+    RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
+
+    have_same_file_content_as(expected)
+  end
+
+  def a_file_with_same_content_like(expected)
+    RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
+
+    a_file_with_same_content_as(expected)
+  end
+end
+
+RSpec::Matchers.send(:include, DeprecatedMatchers)

--- a/lib/aruba/matchers/deprecated.rb
+++ b/lib/aruba/matchers/deprecated.rb
@@ -1,15 +1,1 @@
-module DeprecatedMatchers
-  def have_same_file_content_like(expected)
-    RSpec.deprecate('`have_same_file_content_like`', replacement: '`have_same_file_content_as`')
-
-    have_same_file_content_as(expected)
-  end
-
-  def a_file_with_same_content_like(expected)
-    RSpec.deprecate('`a_file_with_same_content_like`', replacement: '`a_file_with_same_content_as`')
-
-    a_file_with_same_content_as(expected)
-  end
-end
-
-RSpec::Matchers.send(:include, DeprecatedMatchers)
+Aruba.platform.require_matching_files('../deprecated/**/*.rb', __FILE__)

--- a/lib/aruba/matchers/deprecated/file.rb
+++ b/lib/aruba/matchers/deprecated/file.rb
@@ -1,0 +1,11 @@
+def have_same_file_content_like(expected)
+  RSpec.deprecate('`have_same_file_content_like`', :replacement => '`have_same_file_content_as`')
+
+  have_same_file_content_as(expected)
+end
+
+def a_file_with_same_content_like(expected)
+  RSpec.deprecate('`a_file_with_same_content_like`', :replacement => '`a_file_with_same_content_as`')
+
+  a_file_with_same_content_as(expected)
+end

--- a/lib/aruba/matchers/deprecated/file.rb
+++ b/lib/aruba/matchers/deprecated/file.rb
@@ -1,11 +1,15 @@
-def have_same_file_content_like(expected)
-  RSpec.deprecate('`have_same_file_content_like`', :replacement => '`have_same_file_content_as`')
+module RSpec
+  module Matchers
+    def have_same_file_content_like(expected)
+      RSpec.deprecate('`have_same_file_content_like`', :replacement => '`have_same_file_content_as`')
 
-  have_same_file_content_as(expected)
-end
+      have_same_file_content_as(expected)
+    end
 
-def a_file_with_same_content_like(expected)
-  RSpec.deprecate('`a_file_with_same_content_like`', :replacement => '`a_file_with_same_content_as`')
+    def a_file_with_same_content_like(expected)
+      RSpec.deprecate('`a_file_with_same_content_like`', :replacement => '`a_file_with_same_content_as`')
 
-  a_file_with_same_content_as(expected)
+      a_file_with_same_content_as(expected)
+    end
+  end
 end

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -2,7 +2,7 @@ require 'rspec/expectations/version'
 
 require 'fileutils'
 
-# @!method have_same_file_content_like(file_name)
+# @!method have_same_file_content_as(file_name)
 #   This matchers checks if <file1> has the same content like <file2>
 #
 #   @param [String] file_name
@@ -19,10 +19,10 @@ require 'fileutils'
 #   @example Use matcher
 #
 #     RSpec.describe do
-#       it { expect(file1).to have_same_file_content_like(file2) }
-#       it { expect(files).to include a_file_with_same_content_like(file2) }
+#       it { expect(file1).to have_same_file_content_as(file2) }
+#       it { expect(files).to include a_file_with_same_content_as(file2) }
 #     end
-RSpec::Matchers.define :have_same_file_content_like do |expected|
+RSpec::Matchers.define :have_same_file_content_as do |expected|
   match do |actual|
     stop_all_commands
 
@@ -44,5 +44,5 @@ RSpec::Matchers.define :have_same_file_content_like do |expected|
 end
 
 if RSpec::Expectations::Version::STRING >= '3.0'
-  RSpec::Matchers.alias_matcher :a_file_with_same_content_like, :have_same_file_content_like
+  RSpec::Matchers.alias_matcher :a_file_with_same_content_as, :have_same_file_content_as
 end

--- a/spec/aruba/matchers/deprecated_spec.rb
+++ b/spec/aruba/matchers/deprecated_spec.rb
@@ -57,8 +57,7 @@ RSpec.describe 'Deprecated matchers' do
 
       context 'and this is not expected' do
         it do
-          expect { expect(file_name).not_to have_same_file_content_like reference_file }
-            .to raise_error RSpec::Expectations::ExpectationNotMetError
+          expect { expect(file_name).not_to have_same_file_content_like reference_file }.to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end
@@ -72,8 +71,7 @@ RSpec.describe 'Deprecated matchers' do
 
       context 'and this is not expected' do
         it do
-          expect { expect(file_name).to have_same_file_content_like reference_file }
-            .to raise_error RSpec::Expectations::ExpectationNotMetError
+          expect { expect(file_name).to have_same_file_content_like reference_file }.to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end

--- a/spec/aruba/matchers/deprecated_spec.rb
+++ b/spec/aruba/matchers/deprecated_spec.rb
@@ -36,4 +36,88 @@ RSpec.describe 'Deprecated matchers' do
       end
     end
   end
+
+  describe "to have_same_file_content_like" do
+    let(:file_name) { @file_name }
+    let(:file_path) { @file_path }
+
+    let(:reference_file) { 'fixture' }
+
+    before :each do
+      @aruba.write_file(@file_name, "foo bar baz")
+      @aruba.write_file(reference_file, reference_file_content)
+    end
+
+    context 'when files are the same' do
+      let(:reference_file_content) { 'foo bar baz' }
+
+      context 'and this is expected' do
+        it { expect(file_name).to have_same_file_content_like reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(file_name).not_to have_same_file_content_like reference_file }
+            .to raise_error RSpec::Expectations::ExpectationNotMetError
+        end
+      end
+    end
+
+    context 'when files are not the same' do
+      let(:reference_file_content) { 'bar' }
+
+      context 'and this is expected' do
+        it { expect(file_name).not_to have_same_file_content_like reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(file_name).to have_same_file_content_like reference_file }
+            .to raise_error RSpec::Expectations::ExpectationNotMetError
+        end
+      end
+    end
+  end
+
+  describe "include a_file_with_same_content_like" do
+    let(:reference_file) { 'fixture' }
+    let(:reference_file_content) { 'foo bar baz' }
+    let(:file_with_same_content) { 'file_a.txt' }
+    let(:file_with_different_content) { 'file_b.txt' }
+
+    before :each do
+      @aruba.write_file(file_with_same_content, reference_file_content)
+      @aruba.write_file(reference_file, reference_file_content)
+      @aruba.write_file(file_with_different_content, 'Some different content here...')
+    end
+    
+    context 'when the array of files includes a file with the same content' do
+      let(:files) { [file_with_different_content, file_with_same_content] }
+
+      context 'and this is expected' do
+        it { expect(files).to include a_file_with_same_content_like reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(files).not_to include a_file_with_same_content_like reference_file }
+        end
+      end
+      
+    end
+
+    context 'when the array of files does not include a file with the same content' do
+      let(:files) { [file_with_different_content] }
+
+      context 'and this is expected' do
+        it { expect(files).not_to include a_file_with_same_content_like reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(files).to include a_file_with_same_content_like reference_file }
+        end
+      end
+    end
+  end
 end

--- a/spec/aruba/matchers/deprecated_spec.rb
+++ b/spec/aruba/matchers/deprecated_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe 'Deprecated matchers' do
 
       context 'and this is not expected' do
         it do
-          expect { expect(files).not_to include a_file_with_same_content_like reference_file }
+          expect { expect(files).not_to include a_file_with_same_content_like reference_file }.to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
       
@@ -113,7 +113,7 @@ RSpec.describe 'Deprecated matchers' do
 
       context 'and this is not expected' do
         it do
-          expect { expect(files).to include a_file_with_same_content_like reference_file }
+          expect { expect(files).to include a_file_with_same_content_like reference_file }.to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -124,4 +124,88 @@ RSpec.describe 'File Matchers' do
       it { expect(@file_name).not_to have_file_size(0) }
     end
   end
+
+  describe "to have_same_file_content_as" do
+    let(:file_name) { @file_name }
+    let(:file_path) { @file_path }
+
+    let(:reference_file) { 'fixture' }
+
+    before :each do
+      @aruba.write_file(@file_name, "foo bar baz")
+      @aruba.write_file(reference_file, reference_file_content)
+    end
+
+    context 'when files are the same' do
+      let(:reference_file_content) { 'foo bar baz' }
+
+      context 'and this is expected' do
+        it { expect(file_name).to have_same_file_content_as reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(file_name).not_to have_same_file_content_as reference_file }
+            .to raise_error RSpec::Expectations::ExpectationNotMetError
+        end
+      end
+    end
+
+    context 'when files are not the same' do
+      let(:reference_file_content) { 'bar' }
+
+      context 'and this is expected' do
+        it { expect(file_name).not_to have_same_file_content_as reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(file_name).to have_same_file_content_as reference_file }
+            .to raise_error RSpec::Expectations::ExpectationNotMetError
+        end
+      end
+    end
+  end
+
+  describe "include a_file_with_same_content_as" do
+    let(:reference_file) { 'fixture' }
+    let(:reference_file_content) { 'foo bar baz' }
+    let(:file_with_same_content) { 'file_a.txt' }
+    let(:file_with_different_content) { 'file_b.txt' }
+
+    before :each do
+      @aruba.write_file(file_with_same_content, reference_file_content)
+      @aruba.write_file(reference_file, reference_file_content)
+      @aruba.write_file(file_with_different_content, 'Some different content here...')
+    end
+    
+    context 'when the array of files includes a file with the same content' do
+      let(:files) { [file_with_different_content, file_with_same_content] }
+
+      context 'and this is expected' do
+        it { expect(files).to include a_file_with_same_content_as reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(files).not_to include a_file_with_same_content_as reference_file }
+        end
+      end
+      
+    end
+
+    context 'when the array of files does not include a file with the same content' do
+      let(:files) { [file_with_different_content] }
+
+      context 'and this is expected' do
+        it { expect(files).not_to include a_file_with_same_content_as reference_file }
+      end
+
+      context 'and this is not expected' do
+        it do
+          expect { expect(files).to include a_file_with_same_content_as reference_file }
+        end
+      end
+    end
+  end
 end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -145,8 +145,7 @@ RSpec.describe 'File Matchers' do
 
       context 'and this is not expected' do
         it do
-          expect { expect(file_name).not_to have_same_file_content_as reference_file }
-            .to raise_error RSpec::Expectations::ExpectationNotMetError
+          expect { expect(file_name).not_to have_same_file_content_as reference_file }.to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end
@@ -160,8 +159,7 @@ RSpec.describe 'File Matchers' do
 
       context 'and this is not expected' do
         it do
-          expect { expect(file_name).to have_same_file_content_as reference_file }
-            .to raise_error RSpec::Expectations::ExpectationNotMetError
+          expect { expect(file_name).to have_same_file_content_as reference_file }.to raise_error RSpec::Expectations::ExpectationNotMetError
         end
       end
     end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
Deprecated `have_same_file_content_like` and `a_file_with_same_content_like` matchers, and added `have_same_file_content_as` and `a_file_with_same_content_as matchers`, onto the `still` branch.

This is a modified version of https://github.com/cucumber/aruba/pull/555, applied to the `still` branch rather than `master`.
<!--- Provide a general summary description of your changes -->

## Details

<!--- Describe your changes in detail -->

## Motivation and Context
To make it easier to understand what the matchers do.

## How Has This Been Tested?
Added specs to ensure that the old and new matchers function correctly.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cucumber/aruba/557)
<!-- Reviewable:end -->
