### PR TITLE
Restore Bundler disabling functionality

### DIFF
--- a/features/03_testing_frameworks/cucumber/disable_bunder.feature
+++ b/features/03_testing_frameworks/cucumber/disable_bunder.feature
@@ -1,0 +1,18 @@
+Feature: Disable Bundler environment
+  Use the @disable-bundler tag to escape from your project's Gemfile.
+
+  Background:
+    Given I use the fixture "cli-app"
+
+  Scenario: Clear the Bundler environment
+
+    Given a file named "features/run.feature" with:
+    """
+    Feature: My Feature
+      @disable-bundler
+      Scenario: Check environment
+        When I run `env`
+        Then the output should not match /^BUNDLE_GEMFILE=/
+    """
+    When I run `cucumber`
+    Then the features should all pass

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -11,6 +11,7 @@ require 'aruba/api/commands'
 require 'aruba/api/environment'
 require 'aruba/api/filesystem'
 require 'aruba/api/text'
+require 'aruba/api/bundler'
 
 Aruba.platform.require_matching_files('../matchers/**/*.rb', __FILE__)
 
@@ -23,5 +24,6 @@ module Aruba
     include Aruba::Api::Environment
     include Aruba::Api::Filesystem
     include Aruba::Api::Text
+    include Aruba::Api::Bundler
   end
 end

--- a/lib/aruba/api/bundler.rb
+++ b/lib/aruba/api/bundler.rb
@@ -1,0 +1,16 @@
+require 'aruba/api/environment'
+
+module Aruba
+  module Api
+    module Bundler
+      include Environment
+
+      # Unset variables used by bundler
+      def unset_bundler_env_vars
+        %w[RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH BUNDLE_GEMFILE].each do |key|
+          delete_environment_variable(key)
+        end
+      end
+    end
+  end
+end

--- a/spec/aruba/api/bundler_spec.rb
+++ b/spec/aruba/api/bundler_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+require 'aruba/api'
+
+RSpec.describe Aruba::Api::Bundler do
+  include_context 'uses aruba API'
+
+  describe '#unset_bundler_env_vars' do
+    it "sets up Aruba's environment to clear Bundler's variables" do
+      @aruba.unset_bundler_env_vars
+
+      expect(@aruba.aruba.environment['BUNDLE_PATH']).to be_nil
+      expect(@aruba.aruba.environment['BUNDLE_GEMFILE']).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fix `@disable-bundler` hook

## Details

Restores the `unset_bundler_env_vars` method used by the `@disable-bundler` hook and adds documentation.

## Motivation and Context

#526.

## How Has This Been Tested?

Specs and a feature file have been added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Update documentation

## Checklist:

- [x] I've added tests for my code