### PR TITLE
Make have_file_content diffable

### DIFF
--- a/lib/aruba/matchers/file/have_file_content.rb
+++ b/lib/aruba/matchers/file/have_file_content.rb
@@ -54,6 +54,8 @@ RSpec::Matchers.define :have_file_content do |expected|
     values_match?(@expected, @actual)
   end
 
+  diffable if expected.is_a? String
+
   description { "have file content: #{description_of expected}" }
 end
 


### PR DESCRIPTION
## Summary
This makes the `have_file_content` matcher `diffable` in cases when it's useful, without breaking existing behavior. 

## Details
Custom RSpec matchers aren't `diffable` by default. You have to manually specify that a matcher should be diffable. This change makes this `have_file_content` matcher `diffable`. In particular, it's important for files to be diffable, since they're likely going to be several lines, and RSpec will abbreviate the expectation / actual with a darned `...`.

## Motivation and Context

I'm a core team member for [Hanami](hanamirb.org), and we used to use MiniTest for everything. We have since changed all our internal test suites to RSpec, but the generated projects still use MiniTest. I'm working on changing that, and there are a number of changes to generated files.

A big part of the Hanami ethos is to be good Ruby ecosystem citizens. We want the whole Ruby community to work well together, since it's in all of our interests. This PR will help us (it's already helped me solve my problem locally) and I'm sure it'll help others too. 🌸 

## How Has This Been Tested?

I did _not_ add a test for this, since I wasn't sure how file generation worked. I did make sure that the tests did not fail (that's why I added `.is_a?(String)`. Another approach I played with, which worked, was only showing the diff if the file was longer than one line.)

I'm happy to add a test for the `diffable` behavior, I just need a little direction at this point :)

## Screenshots:

Before:
![screen shot 2018-05-02 at 19 19 46](https://user-images.githubusercontent.com/632942/39556490-d5ea257c-4e3d-11e8-831a-327f39650414.png)


After:
![screen shot 2018-05-02 at 19 19 02](https://user-images.githubusercontent.com/632942/39556475-bff79466-4e3d-11e8-8702-2ac4b45248a6.png)

"Better... much better"

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
