### PR TITLE
[WIP] Add support for common Windows commands

### DIFF
--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -236,6 +236,10 @@ module Aruba
       def which(program, path = ENV['PATH'])
         UnixWhich.new.call(program, path)
       end
+
+      def internal_shell_commands
+        []
+      end
     end
   end
 end

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -237,7 +237,7 @@ module Aruba
         UnixWhich.new.call(program, path)
       end
 
-      def internal_shell_commands
+      def builtin_shell_commands
         []
       end
     end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -37,6 +37,10 @@ module Aruba
       def which(program, path = ENV['PATH'])
         WindowsWhich.new.call(program, path)
       end
+
+      def internal_shell_commands
+        ['echo']
+      end
     end
   end
 end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -38,7 +38,7 @@ module Aruba
         WindowsWhich.new.call(program, path)
       end
 
-      def internal_shell_commands
+      def builtin_shell_commands
         ['echo']
       end
     end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -259,7 +259,7 @@ module Aruba
         # gather fully qualified path
         cmd = Aruba.platform.which(command, environment['PATH'])
 
-        if cmd.nil? and Aruba.platform.internal_shell_commands.include?(command)
+        if cmd.nil? and Aruba.platform.builtin_shell_commands.include?(command)
           cmd = command
         end
 

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -201,7 +201,7 @@ module Aruba
         end
 
         @exit_status  = @process.exit_code
-
+  
         @stdout_cache = read_temporary_output_file @stdout_file
         @stderr_cache = read_temporary_output_file @stderr_file
 
@@ -258,6 +258,10 @@ module Aruba
       def command_string
         # gather fully qualified path
         cmd = Aruba.platform.which(command, environment['PATH'])
+
+        if cmd.nil? and Aruba.platform.internal_shell_commands.include?(command)
+          cmd = command
+        end
 
         fail LaunchError, %(Command "#{command}" not found in PATH-variable "#{environment['PATH']}".) if cmd.nil?
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
On Windows, as on Linux, Aruba knows how to handle running applications that are in the user's PATH environment variable. Unlike on Linux, however, some windows commands (such as `echo`) are built-in to the command prompt and are not standalone executables.

Currently, running `echo` from Aruba on a Windows computer will fail the scenario with `Command "echo" not found in PATH-variable` errors. This PR aims to resolve this.
<!--- Provide a general summary description of your changes -->

## Details
I've added the ability to define commands that should _always_ be prefixed with `cmd.exe /c`, in `internal_shell_commands` under each platform's class.

I then check whether the command that couldn't be found in PATH is an internal shell command, and if so, bypass the call to `fail`.  `Aruba.platform.command_string` then kicks in and prepends `cmd.exe /c` as usual.

<!--- Describe your changes in detail -->

## Motivation and Context
The AppVeyor CI builds are failing on Windows as many of the scenarios are incompatible due to their use of `echo` and other commands. Rather than tag the failing scenarios with `@not-supported-on-platform-windows`, which will reduce the test coverage for Windows, I figured we should look at fixing the issue and only use that tag when we really need to.

Please see #568 for further information.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
No additional tests have been added. Instead, these changes fix some of the previously failing tests (e.g. `features/02_configure_aruba/working_directory.feature`)
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
