### PR TITLE
Init: Conditionally prefix the `gem aruba` line with a carriage return.

### DIFF
--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -23,7 +23,7 @@ module Aruba
                   end
 
         content = if File.exist? file
-                    file_ends_with_carriage_return = File.open('Gemfile', 'r').readlines.last.match(/.*\n$/)
+                    file_ends_with_carriage_return = File.open(file, 'r').readlines.last.match(/.*\n$/)
 
                     prefix = file_ends_with_carriage_return ? '' : "\n"
 

--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -23,7 +23,11 @@ module Aruba
                   end
 
         content = if File.exist? file
-                    %(gem 'aruba', '~> #{Aruba::VERSION}')
+                    file_ends_with_carriage_return = File.open('Gemfile', 'r').readlines.last.match(/.*\n$/)
+
+                    prefix = file_ends_with_carriage_return ? '' : "\n"
+
+                    %(#{prefix}gem 'aruba', '~> #{Aruba::VERSION}')
                   else
                     %(source 'https://rubygems.org'\ngem 'aruba', '~> #{Aruba::VERSION}'\n)
                   end


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary
When you run `aruba init --test-framework cucumber` in the root of a project with a Gemfile that does _not_ end with a carriage return, it appends `gem 'aruba' ...` to the end of the previous line.

In this PR, if the Gemfile ends with a carriage return it appends it to the final line. If the Gemfile doesn't end with a carriage return, it prepends a carriage return to ensure that `gem 'aruba' ...` is always on a new line.

This resolves #430.
<!--- Provide a general summary description of your changes -->

## Details
I've added a simple check and conditionally prefixed a carriage return.
<!--- Describe your changes in detail -->

## Motivation and Context
This solves https://github.com/cucumber/aruba/issues/430
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
This uses the existing tests, but I can add additional tests. :+1: 
<!--- Please add tests for changes to the code, otherwise we probably won't merge it -->

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
