### PR TITLE
Mark setting of root directory as deprecated

### DIFF
--- a/features/02_configure_aruba/command_runtime_environment.feature
+++ b/features/02_configure_aruba/command_runtime_environment.feature
@@ -23,7 +23,7 @@ Feature: Define default process environment
     ENV['LONG_LONG_VARIABLE'] = 'y'
 
     Aruba.configure do |config|
-      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
@@ -44,7 +44,7 @@ Feature: Define default process environment
     ENV['LONG_LONG_VARIABLE'] = 'y'
 
     Aruba.configure do |config|
-      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
@@ -67,7 +67,7 @@ Feature: Define default process environment
     ENV['LONG_LONG_VARIABLE'] = 'y'
 
     Aruba.configure do |config|
-      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
@@ -90,7 +90,7 @@ Feature: Define default process environment
     ENV['LONG_LONG_VARIABLE'] = 'y'
 
     Aruba.configure do |config|
-      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
@@ -113,7 +113,7 @@ Feature: Define default process environment
     ENV['LONG_LONG_VARIABLE'] = 'y'
 
     Aruba.configure do |config|
-      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' } 
+      config.command_runtime_environment = { 'LONG_LONG_VARIABLE' => 'x' }
     end
 
     RSpec.describe 'Environment command', :type => :aruba do

--- a/features/02_configure_aruba/root_directory.feature
+++ b/features/02_configure_aruba/root_directory.feature
@@ -20,7 +20,7 @@ Feature: Use root directory of aruba
     tmp/aruba
     """
 
-  Scenario: Modify value
+  Scenario: Modify value (deprecated)
     Given a file named "features/support/aruba.rb" with:
     """
     Aruba.configure do |config|


### PR DESCRIPTION
## Summary

Setting root_directory will no longer be supported in 1.0.0. Mark it as deprecated in the cucumber scenario.

**This was originally the main pull request for #598. Original description follows**

## Summary

Update the `still` development branch so the change to `master` is no more than a removal of deprecations.

## Details

**This is a work in progress**. This is a combination of backporting bug fixes, moving deprecated code, moving other files. The end goal is that merging `still` into `master` will only lead to conflicts in deleted files that contain the code deprecated in the `0.14.x` line and removed in `1.0.0`.

## Motivation and Context

A lot of projects that use Aruba are not even on `0.14.x` yet. We should be able to tell them that they should do that and fix all deprecations, and then they should be able to safely move to upcoming `1.0.0`. Since there are still reasons why projects are stuck on pre-0.14 versions, these reasons should be taken away first. This means Aruba development is stuk on 0.14 for a while longer as well. To avoid duplicate effort, `still` and `master` need to be made as similar as possible.

We may have to revert some breaking behavioral changes between still and master eventually, as well as some deprecations.

## How Has This Been Tested?

CI. I'm hoping to add AppVeyor to the still branch as well.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (cleanup of codebase without changing any existing functionality)
- [x] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
