### PR TITLE
Fix Cucumber steps to use `have_same_file_content_as` matcher

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+* Fix Cucumber steps to use `have_same_file_content_as` matcher (#572)
+
 #  RELEASED
 
 ## [v0.14.6](https://github.com/cucumber/aruba/compare/v0.14.5...v0.14.6)

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -174,9 +174,9 @@ end
 
 Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?be equal to file "([^"]*)"/) do |file, negated, reference_file|
   if negated
-    expect(file).not_to have_same_file_content_like(reference_file)
+    expect(file).not_to have_same_file_content_as(reference_file)
   else
-    expect(file).to have_same_file_content_like(reference_file)
+    expect(file).to have_same_file_content_as(reference_file)
   end
 end
 


### PR DESCRIPTION
※ Pointing to `still` branch

## Summary

Follow up on https://github.com/cucumber/aruba/pull/557: update the cucumber step to use the new matcher `have_same_file_content_as`.

## Details

Confirmed in https://github.com/cucumber/aruba/pull/557#issuecomment-416453305 that we missed to update the cucumber part to use the newly updated matcher.

## How Has This Been Tested?

Don't think there's any existing tests that I can work on...? 🤔 

And I know this is not scientific at all, I happen to update the gem for a project, and was able to use my patch to correctly compare the file content.

Also did a grep and confirmed all references of the now-deprecated matcher `have_same_file_content_like` are updated.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

I updated the `History.md` file to jot down the change, feel free to modify it to your needs. 🙂

cc @mvz @xtrasimplicity 