### PR TITLE
add require time to avoid test failure

### DIFF
--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'aruba/api'
 require 'fileutils'
+require 'time'
 
 describe Aruba::Api do
   include_context 'uses aruba API'


### PR DESCRIPTION

## Summary

fix below test error (on Debian unstable)

## Details

> │ Run tests for ruby2.5 from debian/ruby-tests.rake                            │
>
> All examples were filtered out; ignoring {:focus=>true}
>      # ./spec/aruba/api_spec.rb:333:in `block (5 levels) in <top (required)>'
>
>      NoMethodError:
>        undefined method `parse' for Time:Class
>      Shared Example Group: "an existing directory" called from ./spec/aruba/api_spec.rb:388
>      # ./spec/aruba/api_spec.rb:386:in `block (7 levels) in <top (required)>'
>      # ./spec/aruba/api_spec.rb:381:in `block (6 levels) in <top (required)>'
>      # ./lib/aruba/rspec.rb:22:in `block (2 levels) in <top (required)>'

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->



<!--- Provide a general summary description of your changes -->


<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

 create debian package

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
