### PR TITLE
Test with Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ jobs:
       os: linux
     - rvm: ruby-head
       os: osx
+    - rvm: 2.6.0
+      os: linux
+    - rvm: 2.6.0
+      os: osx
     - rvm: 2.5.0
       os: linux
     - rvm: 2.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,11 @@ group :development, :test do
   end
 
   # Run development and test tasks
-  gem 'rake', '~> 12.0'
+  if RUBY_VERSION >= '2.0.0'
+    gem 'rake', '~> 12.3'
+  else
+    gem 'rake', '~> 12.2.0'
+  end
 
   if RUBY_VERSION >= '2.0.0'
     # Lint travis yaml

--- a/Gemfile
+++ b/Gemfile
@@ -82,6 +82,11 @@ group :development, :test do
     gem 'license_finder', '~> 5.0.3'
   end
 
+  # Force compatible version of httparty for use by license_finder
+  if RUBY_VERSION <= '2.0.0'
+    gem 'httparty', '0.14.0'
+  end
+
   # Upload documentation
   # gem 'relish', '~> 0.7.1'
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'contracts', '~> 0.13'
   spec.add_runtime_dependency 'thor', '~> 0.19'
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '~> 1.7'
   spec.rubygems_version = ">= 1.6.1"
   spec.required_ruby_version = '>= 1.9.3'
 


### PR DESCRIPTION
## Summary

Update build matrix with Ruby 2.6.

## Details

Update Travis CI configuration to run tests on Ruby 2.6.0 series.

## Motivation and Context

Ruby 2.6 has been released and we should test Aruba on it.