### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,7 +82,7 @@ group :development, :test do
     gem 'contracts', '~> 0.16.0'
   end
 
-  if RUBY_VERSION >= '1.9.3'
+  if RUBY_VERSION >= '2.0.0'
     # Make aruba compliant to ruby community guide
     gem 'rubocop', '~> 0.32', '< 0.41.1'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -21,14 +21,14 @@ group :debug do
   if RUBY_VERSION < '2'
     gem 'pry-doc', '~> 0.8.0'
   else
-    gem 'pry-doc', '~> 0.13.1'
+    gem 'pry-doc', '~> 1.0.0'
   end
 end
 
 group :development, :test do
   # we use this to demonstrate interactive debugging within our feature tests
   if RUBY_VERSION >= '2'
-    gem 'pry', '~> 0.11.2'
+    gem 'pry', '~> 0.12.2'
   else
     gem 'pry', '~> 0.9.12'
   end
@@ -77,7 +77,7 @@ group :development, :test do
 
   # License compliance
   if RUBY_VERSION >= '2.3'
-    gem 'license_finder', '~> 5.0.3'
+    gem 'license_finder', '~> 5.0'
   elsif RUBY_VERSION >= '1.9.3'
     gem 'license_finder', '~> 2.0.4'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,16 @@ group :debug do
   end
 end
 
+# Tools to run during development
+group :development do
+  # License compliance
+  if RUBY_VERSION >= '2.3'
+    gem 'license_finder', '~> 5.0'
+  elsif RUBY_VERSION >= '2.0.0'
+    gem 'license_finder', '~> 2.0.4'
+  end
+end
+
 group :development, :test do
   # we use this to demonstrate interactive debugging within our feature tests
   if RUBY_VERSION >= '2'
@@ -79,13 +89,6 @@ group :development, :test do
 
   if RUBY_VERSION >= '1.9.3'
     gem 'cucumber-pro', '~> 0.0'
-  end
-
-  # License compliance
-  if RUBY_VERSION >= '2.3'
-    gem 'license_finder', '~> 5.0'
-  elsif RUBY_VERSION >= '2.0.0'
-    gem 'license_finder', '~> 2.0.4'
   end
 
   gem 'minitest', '~> 5.8'

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,14 @@ group :development, :test do
     gem 'pry', '~> 0.9.12'
   end
 
-  # Run development tasks
-  gem 'rake', '>= 10.0', '< 13.0'
+  # Run development and test tasks
+  if RUBY_VERSION >= '2.0.0'
+    gem 'rake', '~> 12.3'
+  elsif RUBY_VERSION >= '1.9.3'
+    gem 'rake', '~> 12.2.0'
+  else
+    gem 'rake', '~> 10.5.0'
+  end
 
   if RUBY_VERSION >= '2.0.0'
     # Lint travis yaml

--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ group :development, :test do
   # License compliance
   if RUBY_VERSION >= '2.3'
     gem 'license_finder', '~> 5.0'
-  elsif RUBY_VERSION >= '1.9.3'
+  elsif RUBY_VERSION >= '2.0.0'
     gem 'license_finder', '~> 2.0.4'
   end
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'cucumber', '>= 1.3.19'
   s.add_runtime_dependency 'childprocess', ['>= 0.6.3', '< 0.10.0']
-  s.add_runtime_dependency 'ffi', '~> 1.9.10'
+  s.add_runtime_dependency 'ffi', '~> 1.9'
   s.add_runtime_dependency 'rspec-expectations', '>= 2.99'
   s.add_runtime_dependency 'contracts', '~> 0.9'
   s.add_runtime_dependency 'thor', '~> 0.19'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'contracts', '~> 0.9'
   s.add_runtime_dependency 'thor', '~> 0.19'
 
-  s.add_development_dependency 'bundler', '~> 1.11'
+  s.add_development_dependency 'bundler', ['>= 1.7', '< 3.0']
 
   s.rubygems_version = ">= 1.6.1"
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -22,7 +22,7 @@ which 'zsh' >/dev/null 2>error.log || ( echo -e "$error_msg\n\nCould not find \`
 echo OK
 
 echo -e "$info_msg rubygem \"bundler\" "
-gem install bundler
+which bundle > /dev/null || gem install bundler
 
 echo -e "$info_msg \"bundle install\" "
 bundle install $*

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -22,7 +22,7 @@ which 'zsh' >/dev/null 2>error.log || ( echo -e "$error_msg\n\nCould not find \`
 echo OK
 
 echo -e "$info_msg rubygem \"bundler\" "
-which bundle > /dev/null || gem install bundler
+which bundle > /dev/null || gem install bundler --version '~> 1.17.3'
 
 echo -e "$info_msg \"bundle install\" "
 bundle install $*


### PR DESCRIPTION
## Summary

Update dependencies

## Details

Update dependency on FFI and several development dependencies.

## Motivation and Context

FFI 1.10 is out and Aruba should allow users to use it. For development dependencies, simply ensures keeping up to date.