### PR TITLE
Fix deprecation edge case

### DIFF
--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -149,7 +149,7 @@ module Aruba
           stop_signal       = opts[:stop_signal].nil? ? aruba.config.stop_signal : opts[:stop_signal]
           startup_wait_time = opts[:startup_wait_time].nil? ? aruba.config.startup_wait_time : opts[:startup_wait_time]
         else
-          if args.size > 1
+          if args.size > 0
             Aruba.platform.deprecated(
               "Please pass options to `#run_command` as named parameters/hash and don\'t use the old style, e.g. `#run_command('cmd', :exit_timeout => 5)`.")
           end
@@ -253,7 +253,7 @@ module Aruba
           opts = args.pop
           fail_on_error = opts.delete(:fail_on_error) == true ? true : false
         else
-          if args.size > 1
+          if args.size > 0
             # rubocop:disable Metrics/LineLength
             Aruba.platform.deprecated("Please pass options to `#run_command_and_stop` as named parameters/hash and don\'t use the old style with positional parameters, NEW: e.g. `#run_command_and_stop('cmd', :exit_timeout => 5)`.")
             # rubocop:enable Metrics/LineLength

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -864,7 +864,7 @@ describe Aruba::Api do
         end
 
         it "should announce to stdout exactly once" do
-          @aruba.run_command_and_stop('echo "hello world"', false)
+          @aruba.run_command_and_stop('echo "hello world"')
           expect(@aruba.last_command_started.output).to include('hello world')
         end
       end
@@ -872,7 +872,7 @@ describe Aruba::Api do
       context 'disabled' do
         it "should not announce to stdout" do
           result = capture(:stdout) do
-            @aruba.run_command_and_stop('echo "hello world"', false)
+            @aruba.run_command_and_stop('echo "hello world"')
           end
 
           expect(result).not_to include('hello world')


### PR DESCRIPTION
## Summary

Properly warn about deprecation when passing one positional option to run methods.

## Details

Passing positional options to `#run_command` and `#run_command_and_stop` is deprecated, but this was not properly caught by the deprecation logic for the case where one options was passed.

## Motivation and Context

Users should be able to fix their code before support for this is removed.

## How Has This Been Tested?

Specs where run and new deprecation warnings taken care of.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
