### PR TITLE
Travis: update to jruby-9.2.6.0, and to 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ jobs:
       os: linux
     - rvm: ruby-head
       os: osx
-    - rvm: 2.6.0
+    - rvm: 2.6.1
       os: linux
-    - rvm: 2.6.0
+    - rvm: 2.6.1
       os: osx
     - rvm: 2.5.3
       os: linux
@@ -53,7 +53,7 @@ jobs:
       os: osx
     - stage: lint
       script: bundle exec rake lint
-      rvm: 2.6.0
+      rvm: 2.6.1
       os: linux
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 script: bundle exec rake test
 before_install:
@@ -48,9 +47,9 @@ jobs:
       osx_image: xcode8
     - rvm: jruby
       os: linux
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       os: linux
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
       os: osx
     - stage: lint
       script: bundle exec rake lint
@@ -59,7 +58,7 @@ jobs:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby
-    - rvm: jruby-9.2.5.0
+    - rvm: jruby-9.2.6.0
   fast_finish: true
 
 branches:


### PR DESCRIPTION
## Summary

CI matrix updated with latest GA JRuby version.

## Details

   - and sudo: false is no longer a setting

## Motivation and Context

We want to keep abreast of recent developments in JRuby that our users might be using.

## How Has This Been Tested?

This is a CI change, so it is tested on CI.

