### PR TITLE
Do not replace entire environment inside cd block

### DIFF
--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -61,7 +61,7 @@ module Aruba
 
             Aruba.platform.chdir File.join(aruba.root_directory, aruba.current_directory)
 
-            result = Aruba.platform.with_environment(
+            result = with_environment(
               'OLDPWD' => old_dir,
               'PWD' => File.expand_path(File.join(aruba.root_directory, aruba.current_directory)),
               &block

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -113,7 +113,25 @@ describe Aruba::Api do
           expect(Dir.pwd).not_to eq full_path
         end
 
-        it 'does not touch non-directory environment the passed block' do
+        it 'sets directory environment in the passed block' do
+          @aruba.create_directory @directory_name
+          old_pwd = ENV['PWD']
+          full_path = File.expand_path(@directory_path)
+          @aruba.cd @directory_name do
+            expect(ENV['PWD']).to eq full_path
+            expect(ENV['OLDPWD']).to eq old_pwd
+          end
+        end
+
+        it 'sets aruba environment in the passed block' do
+          @aruba.create_directory @directory_name
+          @aruba.set_environment_variable('FOO', 'bar')
+          @aruba.cd @directory_name do
+            expect(ENV['FOO']).to eq 'bar'
+          end
+        end
+
+        it 'does not touch other environment variables in the passed block' do
           @aruba.create_directory @directory_name
           @aruba.cd @directory_name do
             expect(ENV['HOME']).not_to be_nil

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -101,6 +101,26 @@ describe Aruba::Api do
         expect(File.exist?(File.expand_path(@directory_path))).to be_truthy
       end
     end
+
+    describe '#cd' do
+      context 'with a block given' do
+        it 'runs the passed block in the given directory' do
+          @aruba.create_directory @directory_name
+          full_path = File.expand_path(@directory_path)
+          @aruba.cd @directory_name do
+            expect(Dir.pwd).to eq full_path
+          end
+          expect(Dir.pwd).not_to eq full_path
+        end
+
+        it 'does not touch non-directory environment the passed block' do
+          @aruba.create_directory @directory_name
+          @aruba.cd @directory_name do
+            expect(ENV['HOME']).not_to be_nil
+          end
+        end
+      end
+    end
   end
 
   describe '#read' do


### PR DESCRIPTION
## Summary

Backport fix for `cd` behavior.

## Details

Test and fix the the setting of environment variables inside the block passed to `cd`. Backport of cbbefda22343ee8a858cc6e0ce85446b107b5609, which was part of #442.

## Motivation and Context

The `#cd` method would clear the entire environment within the block, instead of just updating it. This is clearly not the intended behavior, since even variables set with `set_environment_variable` are ignored. This also makes `#cd` a bad substitute for the deprecated `#in_current_directory` method.

## How Has This Been Tested?

Specs were added.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I've added tests for my code
