### PR TITLE
README seen in Jam: Drop Gemnasium badge

### DIFF
--- a/features/README.md
+++ b/features/README.md
@@ -1,7 +1,6 @@
 [![GitHub stars](https://img.shields.io/github/stars/cucumber/aruba.svg)](https://github.com/cucumber/aruba/stargazers)
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/master/LICENSE)
 [![Gem Version](https://badge.fury.io/rb/aruba.svg)](http://badge.fury.io/rb/aruba)
-[![Dependency Status](https://gemnasium.com/cucumber/aruba.svg)](https://gemnasium.com/cucumber/aruba)
 [![Code Climate](https://codeclimate.com/github/cucumber/aruba.svg)](https://codeclimate.com/github/cucumber/aruba)
 [![Support](https://img.shields.io/badge/cucumber-support-orange.svg)](https://cucumber.io/support)
 


### PR DESCRIPTION
## Summary

This PR updates the README seen by people browsing Jam: https://jam.cucumber.io/projects/aruba/documents/branch/master

## Details

This README has not been updated in a while.

One of the badges' service has been closed since then.

## Motivation and Context

We want the information shown to be relevant and current.

## Types of changes

- [x] Update documentation

