### PR TITLE
CI: Use 2.4.6, 2.5.5, 2.6.3, jruby-9.2.7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ jobs:
       os: linux
     - rvm: ruby-head
       os: osx
-    - rvm: 2.6.1
+    - rvm: 2.6.3
       os: linux
-    - rvm: 2.6.1
+    - rvm: 2.6.3
       os: osx
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       os: linux
-    - rvm: 2.5.3
+    - rvm: 2.5.5
       os: osx
-    - rvm: 2.4.5
+    - rvm: 2.4.6
       os: linux
-    - rvm: 2.4.4
+    - rvm: 2.4.6
       os: osx
     - rvm: 2.3.8
       os: linux
@@ -47,18 +47,18 @@ jobs:
       osx_image: xcode8
     - rvm: jruby
       os: linux
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       os: linux
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
       os: osx
     - stage: lint
       script: bundle exec rake lint
-      rvm: 2.6.1
+      rvm: 2.6.3
       os: linux
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.7.0
   fast_finish: true
 
 branches:


### PR DESCRIPTION
## Summary

This updates the CI matrix to use latest releases of Rubies.

