### PR TITLE
Make JRuby before command hook work on Aruba environment

### DIFF
--- a/lib/aruba/config/jruby.rb
+++ b/lib/aruba/config/jruby.rb
@@ -5,13 +5,21 @@ Aruba.configure do |config|
   config.before :command do
     next unless RUBY_PLATFORM == 'java'
 
+    jruby_opts = aruba.environment['JRUBY_OPTS'] || ''
+
     # disable JIT since these processes are so short lived
-    ENV['JRUBY_OPTS'] = "-X-C #{ENV['JRUBY_OPTS']}" unless (ENV['JRUBY_OPTS'] || '') .include? '-X-C'
+    jruby_opts = "-X-C #{jruby_opts}" unless jruby_opts.include? '-X-C'
 
     # Faster startup for jruby
-    ENV['JRUBY_OPTS'] = "--dev #{ENV['JRUBY_OPTS']}" unless (ENV['JRUBY_OPTS'] || '').include? '--dev'
+    jruby_opts = "--dev #{jruby_opts}" unless jruby_opts.include? '--dev'
 
-    # force jRuby to use client JVM for faster startup times
-    ENV['JAVA_OPTS'] = "-d32 #{ENV['JAVA_OPTS']}" if RbConfig::CONFIG['host_os'] =~ /solaris|sunos/i && !(ENV['JAVA_OPTS'] || '').include?('-d32')
+    set_environment_variable('JRUBY_OPTS', jruby_opts)
+
+    if RbConfig::CONFIG['host_os'] =~ /solaris|sunos/i
+      java_opts = aruba.environment['JAVA_OPTS'] || ''
+
+      # force jRuby to use client JVM for faster startup times
+      set_environment_variable('JAVA_OPTS', "-d32 #{java_opts}") unless java_opts.include?('-d32')
+    end
   end
 end


### PR DESCRIPTION
## Summary

Make the JRuby before command helper modify the Aruba environment, rather than the real one.

## Details

The JRuby helper sets up a `before :command` hook to set helpful environment variables for JRuby. This changes makes the helper use `set_environment_variable` to set Aruba's environment rather than directly modifying the real one.

## Motivation and Context

When the environment is modified directly, this causes unexpected behavior when using `with_environment`, since that methods will base the changed environment on the environment at startup, rather than the current one. Therefore, `with_environment` will unexpectedly undo such modifiections.

All this came to light while working on #603.

## How Has This Been Tested?

Tests for the JRuby helper were updated to check the result inside a `with_environment` block, thus mimicing the behavior when the hook is used before running a command.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I've added tests for my code