### PR TITLE
Fix JRuby before :command helper hook 

### DIFF
--- a/features/08_other/improve_performance_if_using_jruby.feature
+++ b/features/08_other/improve_performance_if_using_jruby.feature
@@ -4,7 +4,7 @@ Feature: Support for JRuby
   be accomplished by adding
 
   ```ruby
-  require 'aruba/jruby'
+  require 'aruba/config/jruby'
   ```
 
   *Note* - no conflict resolution on the JAVA/JRuby environment options is
@@ -12,3 +12,26 @@ Feature: Support for JRuby
   environment variables in the hook or externally.
 
   Refer to http://blog.headius.com/2010/03/jruby-startup-time-tips.html for other tips on startup time.
+
+  Background:
+    Given I use a fixture named "cli-app"
+
+  @requires-ruby-platform-java
+  Scenario:
+    Given a file named "spec/jruby_env_spec.rb" with:
+      """
+      require 'spec_helper'
+      require 'aruba/config/jruby'
+
+      RSpec.describe 'running commands with before :command hook', :type => :aruba do
+        it 'sets up for efficient JRuby startup' do
+          with_environment 'JRUBY_OPTS' => '-d' do
+            run_command_and_stop('env')
+
+            expect(last_command_started.output).to include 'JRUBY_OPTS=--dev -X-C -d'
+          end
+        end
+      end
+      """
+    When I run `rspec`
+    Then the specs should all pass

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -3,8 +3,6 @@ require 'aruba/runtime'
 require 'aruba/errors'
 require 'aruba/setup'
 
-require 'aruba/config/jruby'
-
 # Aruba
 module Aruba
   # Api

--- a/lib/aruba/config/jruby.rb
+++ b/lib/aruba/config/jruby.rb
@@ -2,10 +2,12 @@ require 'rbconfig'
 
 # ideas taken from: http://blog.headius.com/2010/03/jruby-startup-time-tips.html
 Aruba.configure do |config|
-  config.before :command do
+  config.before :command do |command|
     next unless RUBY_PLATFORM == 'java'
 
-    jruby_opts = aruba.environment['JRUBY_OPTS'] || ''
+    env = command.environment
+
+    jruby_opts = env['JRUBY_OPTS'] || ''
 
     # disable JIT since these processes are so short lived
     jruby_opts = "-X-C #{jruby_opts}" unless jruby_opts.include? '-X-C'
@@ -13,13 +15,13 @@ Aruba.configure do |config|
     # Faster startup for jruby
     jruby_opts = "--dev #{jruby_opts}" unless jruby_opts.include? '--dev'
 
-    set_environment_variable('JRUBY_OPTS', jruby_opts)
+    env['JRUBY_OPTS'] = jruby_opts
 
     if RbConfig::CONFIG['host_os'] =~ /solaris|sunos/i
-      java_opts = aruba.environment['JAVA_OPTS'] || ''
+      java_opts = env['JAVA_OPTS'] || ''
 
       # force jRuby to use client JVM for faster startup times
-      set_environment_variable('JAVA_OPTS', "-d32 #{java_opts}") unless java_opts.include?('-d32')
+      env['JAVA_OPTS'] = "-d32 #{java_opts}" unless java_opts.include?('-d32')
     end
   end
 end


### PR DESCRIPTION
## Summary

Add full integration test for JRuby helper and make it work.

## Details

The before :command hooks are run after the command's environment has already been set up, so instead of modifying Aruba's environment, of the actual environment, we need to modify the command's environment. This change adds a scenario for this feature, and updates the implementation
to make it work.

We also no longer require the helper by default, so requiring by the user will have the desired effect.

## Motivation and Context

An attempt was made to fix this feature in #610, but it lacked an integration test so it failed.

## How Has This Been Tested?

A scenario was added and the specs were updated.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I've added tests for my code