### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,23 +9,11 @@ load File.expand_path('../Gemfile.local', __FILE__) if File.file? File.expand_pa
 # Debug aruba
 group :debug do
   unless RUBY_PLATFORM.include?('java')
-    if RUBY_VERSION >= '2.2'
-      gem 'byebug', '~> 10.0'
-      gem 'pry-byebug', '~> 3.4'
-    elsif RUBY_VERSION >= '2'
-      gem 'byebug', '~> 9.0'
-      gem 'pry-byebug', '~> 3.4'
-    else
-      gem 'debugger', '~> 1.6.8'
-      gem 'pry-debugger', '~> 0.2.3'
-    end
+    gem 'byebug', '~> 10.0'
+    gem 'pry-byebug', '~> 3.4'
   end
 
-  if RUBY_VERSION < '2'
-    gem 'pry-doc', '~> 0.8.0'
-  else
-    gem 'pry-doc', '~> 1.0.0'
-  end
+  gem 'pry-doc', '~> 1.0.0'
 end
 
 # Tools to run during development
@@ -38,26 +26,16 @@ end
 
 group :development, :test do
   # we use this to demonstrate interactive debugging within our feature tests
-  if RUBY_VERSION >= '2'
-    gem 'pry', '~> 0.12.2'
-  else
-    gem 'pry', '~> 0.9.12'
-  end
+  gem 'pry', '~> 0.12.2'
 
   # Run development and test tasks
-  if RUBY_VERSION >= '2.0.0'
-    gem 'rake', '~> 12.3'
-  else
-    gem 'rake', '~> 12.2.0'
-  end
+  gem 'rake', '~> 12.3'
 
-  if RUBY_VERSION >= '2.0.0'
-    # Lint travis yaml
-    gem 'travis-yaml'
+  # Lint travis yaml
+  gem 'travis-yaml'
 
-    # Reporting
-    gem 'kramdown', '~> 1.14'
-  end
+  # Reporting
+  gem 'kramdown', '~> 1.14'
 
   # Code Coverage
   gem 'simplecov', '~> 0.10'
@@ -69,22 +47,15 @@ group :development, :test do
   gem 'fuubar', '~> 2.2'
   gem 'rspec', '~> 3.4'
 
-  if RUBY_VERSION >= '2.0.0'
-    # Make aruba compliant to ruby community guide
-    gem 'rubocop', '~> 0.50.0'
-  end
-
-  # gem 'cucumber-pro', '~> 0.0'
+  # Make aruba compliant to ruby community guide
+  gem 'rubocop', '~> 0.50.0'
 
   # License compliance
   if RUBY_VERSION >= '2.3'
     gem 'license_finder', '~> 5.0'
   end
 
-  # Upload documentation
-  # gem 'relish', '~> 0.7.1'
-
   gem 'minitest', '~> 5.8'
 
-  gem 'json', '~>2.1'
+  gem 'json', '~> 2.1'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
   gem 'rspec', '~> 3.4'
 
   # Make aruba compliant to ruby community guide
-  gem 'rubocop', '~> 0.50.0'
+  gem 'rubocop', '~> 0.64.0'
 
   # License compliance
   if RUBY_VERSION >= '2.3'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,12 @@ load File.expand_path('../Gemfile.local', __FILE__) if File.file? File.expand_pa
 # Debug aruba
 group :debug do
   unless RUBY_PLATFORM.include?('java')
-    gem 'byebug', '~> 10.0'
+    if RUBY_VERSION >= '2.3.0'
+      gem 'byebug', '~> 11.0'
+    else
+      gem 'byebug', '~> 10.0'
+    end
+
     gem 'pry-byebug', '~> 3.4'
   end
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,6 @@ group :development, :test do
   # Lint travis yaml
   gem 'travis-yaml'
 
-  # Reporting
-  gem 'kramdown', '~> 1.14'
-
   # Code Coverage
   gem 'simplecov', '~> 0.10'
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'childprocess', ['>= 0.6.3', '< 0.10.0']
   spec.add_runtime_dependency 'contracts', '~> 0.13'
-  spec.add_runtime_dependency 'cucumber', '~> 2.4', '>= 2.4.0'
-  spec.add_runtime_dependency 'ffi', '~> 1.9', '>= 1.9.10'
-  spec.add_runtime_dependency 'rspec-expectations', '~> 3.4', '>= 3.4.0'
+  spec.add_runtime_dependency 'cucumber', '~> 2.4'
+  spec.add_runtime_dependency 'ffi', '~> 1.9'
+  spec.add_runtime_dependency 'rspec-expectations', '~> 3.4'
   spec.add_runtime_dependency 'thor', '~> 0.19'
 
   spec.add_development_dependency 'bundler', ['>= 1.7.0', '< 3.0']

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.email       = 'cukes@googlegroups.com'
   spec.homepage    = 'http://github.com/cucumber/aruba'
 
-  spec.add_runtime_dependency 'childprocess', ['>= 0.6.3', '< 0.10.0']
+  spec.add_runtime_dependency 'childprocess', '~> 1.0'
   spec.add_runtime_dependency 'contracts', '~> 0.13'
   spec.add_runtime_dependency 'cucumber', '~> 2.4'
   spec.add_runtime_dependency 'ffi', '~> 1.9'


### PR DESCRIPTION
## Summary

Update Aruba's runtime and development dependencies

## Details

Update most dependencies to the latest version. Still to do is Cucumber itself.

## Motivation and Context

Allow users of Aruba to use more up-to-date additional dependencies. This is made possible by the recent drop of support for older Rubies from master.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
