### PR TITLE
Build on recent Rubies in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,9 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: '19'
-    - ruby_version: '20'
-    - ruby_version: '21'
     - ruby_version: '22'
+    - ruby_version: '23'
+    - ruby_version: '24'
+    - ruby_version: '25'
+    - ruby_version: '26'
 


### PR DESCRIPTION
## Summary

Update AppVeyor Ruby version list to currently supported set.

## Details

Build on 2.2, 2.3, 2.4, 2.5 and 2.6.

## Motivation and Context

It's useless to build on unsupported Ruby versions