### PR TITLE
Backport allowing decimal timeout values to still

### DIFF
--- a/features/01_getting_started_with_aruba/cleanup_working_directory.feature
+++ b/features/01_getting_started_with_aruba/cleanup_working_directory.feature
@@ -1,10 +1,9 @@
 Feature: Cleanup Aruba Working Directory
 
-  By default Aruba removes its scratch directory before
-  every scenario. This isn't always the right thing
-  to do, especially when the path to the default directory
-  has been changed. Use @no-clobber to stop Aruba from
-  cleaning up after itself.
+  By default Aruba removes its scratch directory *before* every scenario. This
+  isn't always the right thing to do, especially when the path to the default
+  directory has been changed. Use the `@no-clobber`-tag on your scenarios to
+  stop Aruba from cleaning up *before* it runs.
 
   Background:
     Given I use a fixture named "cli-app"

--- a/features/01_getting_started_with_aruba/run_commands.feature
+++ b/features/01_getting_started_with_aruba/run_commands.feature
@@ -12,6 +12,15 @@ Feature: Run commands with Aruba
 
   Background:
     Given I use a fixture named "getting-started-app"
+
+  @requires-bash
+  Scenario: Bash Program
+    Given an executable named "bin/aruba-test-cli" with:
+    """bash
+    #!/usr/bin/env bash
+
+    echo "Hello, Aruba!"
+    """
     And a file named "features/hello_aruba.feature" with:
     """
     Feature: Getting Started With Aruba
@@ -21,15 +30,6 @@ Feature: Run commands with Aruba
         \"\"\"
         Hello, Aruba!
         \"\"\"
-    """
-
-  @requires-bash
-  Scenario: Bash Program
-    Given an executable named "bin/aruba-test-cli" with:
-    """bash
-    #!/usr/bin/env bash
-
-    echo "Hello, Aruba!"
     """
     When I successfully run `cucumber`
     Then the features should all pass
@@ -61,6 +61,16 @@ Feature: Run commands with Aruba
 
     puts "Hello, Aruba!"
     """
+    And a file named "features/hello_aruba.feature" with:
+    """
+    Feature: Getting Started With Aruba
+      Scenario: First Run of Command
+        Given I successfully run `aruba-test-cli`
+        Then the output should contain:
+        \"\"\"
+        Hello, Aruba!
+        \"\"\"
+    """
     When I successfully run `cucumber`
     Then the features should all pass
 
@@ -91,6 +101,16 @@ Feature: Run commands with Aruba
 
     print("Hello, Aruba!")
     """
+    And a file named "features/hello_aruba.feature" with:
+    """
+    Feature: Getting Started With Aruba
+      Scenario: First Run of Command
+        Given I successfully run `aruba-test-cli`
+        Then the output should contain:
+        \"\"\"
+        Hello, Aruba!
+        \"\"\"
+    """
     When I successfully run `cucumber`
     Then the features should all pass
 
@@ -120,6 +140,16 @@ Feature: Run commands with Aruba
     #!/usr/bin/env perl
 
     print "Hello, Aruba!\n";
+    """
+    And a file named "features/hello_aruba.feature" with:
+    """
+    Feature: Getting Started With Aruba
+      Scenario: First Run of Command
+        Given I successfully run `aruba-test-cli`
+        Then the output should contain:
+        \"\"\"
+        Hello, Aruba!
+        \"\"\"
     """
     When I successfully run `cucumber`
     Then the features should all pass
@@ -160,7 +190,7 @@ Feature: Run commands with Aruba
           }
         }
         \"\"\"
-        And I successfully run `javac tmp/HelloArubaApp.java`
+        And I successfully run `javac tmp/HelloArubaApp.java` for up to 20 seconds
         And I cd to "tmp/"
         And I successfully run `java HelloArubaApp`
         Then the output should contain:
@@ -168,7 +198,7 @@ Feature: Run commands with Aruba
         Hello, Aruba!
         \"\"\"
     """
-    When I successfully run `cucumber`
+    When I successfully run `cucumber` for up to 21 seconds
     Then the features should all pass
 
   @requires-posix-standard-tools

--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -31,19 +31,11 @@ Feature: Supported Testing Frameworks
     Then the features should all pass
 
   Scenario: Use "aruba" with "RSpec"
-    Given a file named "spec/support/aruba.rb" with:
-    """
-    require 'aruba/rspec'
-    """
-    And a file named "spec/spec_helper.rb" with:
+    Given a file named "spec/spec_helper.rb" with:
     """
     $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-    if RUBY_VERSION < '1.9.3'
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-    else
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-    end
+    require 'aruba/rspec'
     """
     And a file named "spec/use_aruba_with_rspec_spec.rb" with:
     """
@@ -63,19 +55,11 @@ Feature: Supported Testing Frameworks
 
 
   Scenario: Use "aruba" with "Minitest"
-    Given a file named "test/support/aruba.rb" with:
-    """
-    require 'aruba/api'
-    """
-    And a file named "test/test_helper.rb" with:
+    Given a file named "test/test_helper.rb" with:
     """
     $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-    if RUBY_VERSION < '1.9.3'
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-    else
-      ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require_relative f }
-    end
+    require 'aruba/api'
     """
     And a file named "test/use_aruba_with_minitest.rb" with:
     """
@@ -93,7 +77,7 @@ Feature: Supported Testing Frameworks
 
       def getting_started_with_aruba
         file = 'file.txt'
-        content = 'Hello World' 
+        content = 'Hello World'
 
         write_file file, content
         read(file).must_equal [content]

--- a/features/02_configure_aruba/activate_announcer_on_command_failure.feature
+++ b/features/02_configure_aruba/activate_announcer_on_command_failure.feature
@@ -8,7 +8,7 @@ Feature: Configure announcer activation on command failure
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.activate_announcer_on_command_failure.inspect}")
@@ -21,7 +21,7 @@ Feature: Configure announcer activation on command failure
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       config.activate_announcer_on_command_failure = [:foo, :bar]

--- a/features/02_configure_aruba/basics.feature
+++ b/features/02_configure_aruba/basics.feature
@@ -21,12 +21,10 @@ Feature: Usage of configuration
     """
 
   Scenario: Setting default values for option for RSpec
-    Given a file named "spec/support/aruba.rb" with:
+    Given a file named "spec/support/aruba_config.rb" with:
     """ruby
-    require 'aruba/rspec'
-
     Aruba.configure do |config|
-      config.exit_timeout = 1
+      config.exit_timeout = 0.1
     end
     """
     And a file named "spec/usage_configuration_spec.rb" with:
@@ -40,7 +38,7 @@ Feature: Usage of configuration
       end
 
       context 'when slow command' do
-        before(:each) { run_command('aruba-test-cli 2') }
+        before(:each) { run_command('aruba-test-cli 0.2') }
         it { expect(last_command_started).not_to be_successfully_executed }
       end
     end
@@ -54,12 +52,10 @@ Feature: Usage of configuration
     want to set the default timeout for all commands to the maximum value only
     to prevent those commands from failing.
 
-    Given a file named "spec/support/aruba.rb" with:
+    Given a file named "spec/support/aruba_config.rb" with:
     """ruby
-    require 'aruba/rspec'
-
     Aruba.configure do |config|
-      config.exit_timeout = 1
+      config.exit_timeout = 0.1
     end
     """
     And a file named "spec/support/hooks.rb" with:
@@ -68,7 +64,7 @@ Feature: Usage of configuration
       config.before :each do |example|
         next unless example.metadata.key? :slow_command
 
-        aruba.config.exit_timeout = 5
+        aruba.config.exit_timeout = 0.3
       end
     end
     """
@@ -83,12 +79,12 @@ Feature: Usage of configuration
       end
 
       context 'when slow command and this is known by the developer', :slow_command => true do
-        before(:each) { run_command('aruba-test-cli 2') }
+        before(:each) { run_command('aruba-test-cli 0.2') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command, but this might be a failure' do
-        before(:each) { run_command('aruba-test-cli 2') }
+        before(:each) { run_command('aruba-test-cli 0.2') }
         it { expect(last_command_started).not_to be_successfully_executed }
       end
     end
@@ -97,12 +93,10 @@ Feature: Usage of configuration
     Then the specs should all pass
 
   Scenario: Setting default values for option for Cucumber
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
-    require 'aruba/cucumber'
-
     Aruba.configure do |config|
-      config.exit_timeout = 1
+      config.exit_timeout = 0.1
     end
     """
     And a file named "features/run.feature" with:
@@ -113,7 +107,7 @@ Feature: Usage of configuration
         Then the exit status should be 0
 
       Scenario: Slow command
-        When I run `aruba-test-cli 2`
+        When I run `aruba-test-cli 0.2`
         Then the exit status should be 128
     """
     When I run `cucumber`
@@ -125,18 +119,16 @@ Feature: Usage of configuration
     want to set the default timeout for all commands to the maximum value only
     to prevent those commands from failing.
 
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
-    require 'aruba/cucumber'
-
     Aruba.configure do |config|
-      config.exit_timeout = 1
+      config.exit_timeout = 0.1
     end
     """
     And a file named "features/support/hooks.rb" with:
     """ruby
     Before '@slow-command' do
-      aruba.config.exit_timeout = 5
+      aruba.config.exit_timeout = 0.3
     end
     """
     And a file named "features/usage_configuration.feature" with:
@@ -148,11 +140,11 @@ Feature: Usage of configuration
 
       @slow-command
       Scenario: Slow command known by the developer
-        When I run `aruba-test-cli 2`
+        When I run `aruba-test-cli 0.2`
         Then the exit status should be 0
 
       Scenario: Slow command which might be a failure
-        When I run `aruba-test-cli 3`
+        When I run `aruba-test-cli 0.2`
         Then the exit status should be 128
     """
     When I run `cucumber`

--- a/features/02_configure_aruba/console_history_file.feature
+++ b/features/02_configure_aruba/console_history_file.feature
@@ -8,7 +8,7 @@ Feature: Configure the aruba console history file
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       puts %(The default value is "#{config.console_history_file}")
@@ -21,7 +21,7 @@ Feature: Configure the aruba console history file
     """
 
   Scenario: Set some value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       config.console_history_file = '~/.config/aruba/history.txt'

--- a/features/02_configure_aruba/exit_timeout.feature
+++ b/features/02_configure_aruba/exit_timeout.feature
@@ -6,9 +6,15 @@ Feature: Configure timeout for command execution
 
   Background:
     Given I use the fixture "cli-app"
+    And an executable named "bin/aruba-test-cli" with:
+    """bash
+    #!/bin/bash
+    trap "exit 128" SIGTERM SIGINT
+    sleep $*
+    """
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.exit_timeout}")
@@ -21,43 +27,33 @@ Feature: Configure timeout for command execution
     """
 
   Scenario: Modify value
-    Given an executable named "bin/aruba-test-cli" with:
-    """bash
-    #!/bin/bash
-    sleep 1
-    """
-    And a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
-      config.exit_timeout = 2
+      config.exit_timeout = 0.2
     end
     """
     And a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Fast command
-        When I run `aruba-test-cli`
+        When I run `aruba-test-cli 0.1`
         Then the exit status should be 0
     """
     Then I successfully run `cucumber`
 
   Scenario: Fails if takes longer
-    Given an executable named "bin/aruba-test-cli" with:
-    """ruby
-    #!/bin/bash
-    sleep 2
-    """
-    And a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
-      config.exit_timeout = 1
+      config.exit_timeout = 0.1
     end
     """
     And a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Fast command
-        When I run `aruba-test-cli`
+        When I run `aruba-test-cli 0.2`
         Then the exit status should be 0
     """
     Then I run `cucumber`

--- a/features/02_configure_aruba/fixtures_directories.feature
+++ b/features/02_configure_aruba/fixtures_directories.feature
@@ -8,7 +8,7 @@ Feature: Configure directory where to look for fixtures
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "%w(#{config.fixtures_directories.join(" ")})")
@@ -21,7 +21,7 @@ Feature: Configure directory where to look for fixtures
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       config.fixtures_directories = %w(spec/fixtures)

--- a/features/02_configure_aruba/fixtures_path_prefix.feature
+++ b/features/02_configure_aruba/fixtures_path_prefix.feature
@@ -8,7 +8,7 @@ Feature: Use fixtures path prefix of aruba
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts "The prefix is \"#{config.fixtures_path_prefix}\"."

--- a/features/02_configure_aruba/home_directory.feature
+++ b/features/02_configure_aruba/home_directory.feature
@@ -13,7 +13,7 @@ Feature: Configure the home directory to be used with aruba
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.home_directory}")
@@ -26,7 +26,7 @@ Feature: Configure the home directory to be used with aruba
     """
 
   Scenario: Set to current working directory
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       # use current working directory
@@ -44,7 +44,7 @@ Feature: Configure the home directory to be used with aruba
     """
 
   Scenario: Set to aruba's working directory
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       # Use aruba working directory
@@ -56,13 +56,13 @@ Feature: Configure the home directory to be used with aruba
     end
     """
     Then I successfully run `cucumber`
-    Then the output should contain:
+    Then the output should match:
     """
-    The default value is "/home/
+    The default value is "/.*/tmp/aruba"
     """
 
   Scenario: Set to some other path (deprecated)
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       # use current working directory

--- a/features/02_configure_aruba/io_timeout.feature
+++ b/features/02_configure_aruba/io_timeout.feature
@@ -8,7 +8,7 @@ Feature: Configure timeout for io of commands
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.io_wait_timeout}")
@@ -21,7 +21,7 @@ Feature: Configure timeout for io of commands
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       config.io_wait_timeout = 2

--- a/features/02_configure_aruba/log_level.feature
+++ b/features/02_configure_aruba/log_level.feature
@@ -8,7 +8,7 @@ Feature: Configure Log level of aruba logger
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.log_level}")
@@ -21,7 +21,7 @@ Feature: Configure Log level of aruba logger
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       config.log_level = :warn

--- a/features/02_configure_aruba/physical_block_size.feature
+++ b/features/02_configure_aruba/physical_block_size.feature
@@ -8,7 +8,7 @@ Feature: Configure the phsical block size of disk
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.physical_block_size}")
@@ -21,7 +21,7 @@ Feature: Configure the phsical block size of disk
     """
 
   Scenario: Set the block size to something else which is a power of two
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       # use current working directory
@@ -39,7 +39,7 @@ Feature: Configure the phsical block size of disk
     """
 
   Scenario: The value needs to be a power of two, otherwise it will fail
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       config.physical_block_size = 3

--- a/features/02_configure_aruba/remove_ansi_escape_sequences.feature
+++ b/features/02_configure_aruba/remove_ansi_escape_sequences.feature
@@ -8,7 +8,7 @@ Feature: Configure if ansi color codes should be stripped off from command outpu
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       puts %(The default value is "#{config.remove_ansi_escape_sequences}")
@@ -21,7 +21,7 @@ Feature: Configure if ansi color codes should be stripped off from command outpu
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       config.remove_ansi_escape_sequences = false

--- a/features/02_configure_aruba/root_directory.feature
+++ b/features/02_configure_aruba/root_directory.feature
@@ -8,7 +8,7 @@ Feature: Use root directory of aruba
     Given I use the fixture "cli-app"
 
   Scenario: Default configuration
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       puts config.root_directory

--- a/features/02_configure_aruba/startup_wait_time.feature
+++ b/features/02_configure_aruba/startup_wait_time.feature
@@ -18,7 +18,7 @@ Feature: Set time to wait after spawning command
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       puts %(The default value is "#{config.startup_wait_time}")
@@ -31,7 +31,7 @@ Feature: Set time to wait after spawning command
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
       config.startup_wait_time = 2

--- a/features/02_configure_aruba/working_directory.feature
+++ b/features/02_configure_aruba/working_directory.feature
@@ -8,7 +8,7 @@ Feature: Configure working directory of aruba
     Given I use the fixture "cli-app"
 
   Scenario: Default value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       puts %(The default value is "#{config.working_directory}")
@@ -21,7 +21,7 @@ Feature: Configure working directory of aruba
     """
 
   Scenario: Modify value
-    Given a file named "features/support/aruba.rb" with:
+    Given a file named "features/support/aruba_config.rb" with:
     """
     Aruba.configure do |config|
       config.working_directory = 'tmp/cucumber'

--- a/features/03_testing_frameworks/cucumber/announce_information_for_troubleshooting.feature
+++ b/features/03_testing_frameworks/cucumber/announce_information_for_troubleshooting.feature
@@ -7,26 +7,6 @@ Feature: Announce output during test run
   Background:
     Given I use a fixture named "cli-app"
 
-  Scenario: Announce change of directory (deprecated)
-    Given a file named "features/exit_status.feature" with:
-    """cucumber
-    Feature: Announce
-      @announce-dir
-      Scenario: Run command
-        Given a directory named "dir.d"
-        When I cd to "dir.d"
-    """
-    When I run `cucumber`
-    Then the features should all pass
-    And the output should contain:
-    """
-    $ cd /
-    """
-    And the output should contain:
-    """
-    tmp/aruba/dir.d
-    """
-
   Scenario: Announce change of directory
     Given a file named "features/exit_status.feature" with:
     """cucumber
@@ -140,7 +120,7 @@ Feature: Announce output during test run
     And a file named "features/exit_status.feature" with:
     """cucumber
     Feature: Announce
-      @announce-cmd
+      @announce-command
       Scenario: Run command
         When I run `aruba-test-cli`
         Then the exit status should be 0
@@ -162,7 +142,7 @@ Feature: Announce output during test run
     And a file named "features/exit_status.feature" with:
     """cucumber
     Feature: Announce
-      @announce-env
+      @announce-changed-environment
       Scenario: Run command
         When I set the environment variables to:
           | variable | value    |
@@ -187,7 +167,7 @@ Feature: Announce output during test run
     And a file named "features/exit_status.feature" with:
     """cucumber
     Feature: Announce
-      @announce-env
+      @announce-changed-environment
       Scenario: Run command
         When I set the environment variables to:
           | variable | value      |

--- a/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
@@ -88,13 +88,13 @@ Feature: Check exit status of commands
     Given an executable named "bin/aruba-test-cli" with:
     """
     #!/bin/bash
-    sleep 1
+    sleep 0.1
     """
     And a file named "features/exit_status.feature" with:
     """
     Feature: Failing program
       Scenario: Run command
-        Given the default aruba exit timeout is 2 seconds
+        Given the default aruba exit timeout is 0.2 seconds
         When I successfully run `aruba-test-cli`
     """
     When I run `cucumber`
@@ -104,14 +104,14 @@ Feature: Check exit status of commands
     Given an executable named "bin/aruba-test-cli" with:
     """
     #!/bin/bash
-    sleep 1
+    sleep 0.1
     """
     And a file named "features/exit_status.feature" with:
     """
     Feature: Failing program
       Scenario: Run command
         Given the default aruba exit timeout is 0 seconds
-        When I successfully run `aruba-test-cli` for up to 2 seconds
+        When I successfully run `aruba-test-cli` for up to 0.2 seconds
     """
     When I run `cucumber`
     Then the features should all pass

--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -158,23 +158,6 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
-  Scenario: Detect subset of one-line output
-    Given an executable named "bin/aruba-test-cli" with:
-    """bash
-    #!/usr/bin/env bash
-
-    echo 'hello world'
-    """
-    And a file named "features/output.feature" with:
-    """cucumber
-    Feature: Run command
-      Scenario: Run command
-        When I run `aruba-test-cli`
-        Then the output should contain "hello world"
-    """
-    When I run `cucumber`
-    Then the features should all pass
-
   Scenario: Detect subset of one-line output with regex
     Given an executable named "bin/aruba-test-cli" with:
     """bash

--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -429,7 +429,7 @@ Feature: All output of commands which were executed
     """bash
     #!/usr/bin/env bash
 
-    for ((c=0; c<256; c = c+1)); do 
+    for ((c=0; c<256; c = c+1)); do
       echo -n "a"
     done
     """

--- a/features/03_testing_frameworks/cucumber/steps/command/send_signal_to_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/send_signal_to_command.feature
@@ -9,9 +9,7 @@ Feature: Send a signal to command
 
   Background:
     Given I use a fixture named "cli-app"
-
-  Scenario: Sending signal to the command started last
-    Given an executable named "bin/aruba-test-cli" with:
+    And an executable named "bin/aruba-test-cli" with:
     """bash
     #!/usr/bin/env bash
     function hup {
@@ -20,14 +18,21 @@ Feature: Send a signal to command
     }
 
     trap hup HUP
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
-    And a file named "features/run.feature" with:
+    And a file named "features/support/aruba_config.rb" with:
+    """ruby
+    Aruba.configure do |config|
+      config.startup_wait_time = 0.1
+      config.exit_timeout = 0.2
+    end
+    """
+
+  Scenario: Sending signal to the command started last
+    Given a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Run command
-        Given the default aruba exit timeout is 5 seconds
-        And I wait 5 seconds for a command to start up
         When I run `aruba-test-cli` in background
         And I send the signal "HUP" to the command started last
         Then the exit status should be 0
@@ -40,23 +45,10 @@ Feature: Send a signal to command
     Then the features should all pass
 
   Scenario: Sending signal to a command given by command line
-    Given an executable named "bin/aruba-test-cli" with:
-    """bash
-    #!/usr/bin/env bash
-    function hup {
-      echo "Got signal HUP."
-      exit 0
-    }
-
-    trap hup HUP
-    while [ true ]; do sleep 1; done
-    """
-    And a file named "features/run.feature" with:
+    Given a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Run command
-        Given the default aruba exit timeout is 5 seconds
-        And I wait 5 seconds for a command to start up
         When I run `aruba-test-cli` in background
         And I send the signal "HUP" to the command "aruba-test-cli"
         Then the exit status should be 0
@@ -76,23 +68,10 @@ Feature: Send a signal to command
     PID of the last command started. Please note, this feature is experimental.
     The name of the variable may change without further notice.
 
-    Given an executable named "bin/aruba-test-cli" with:
-    """bash
-    #!/usr/bin/env bash
-    function hup {
-      echo "Got signal HUP."
-      exit 0
-    }
-
-    trap hup HUP
-    while [ true ]; do sleep 1; done
-    """
-    And a file named "features/run.feature" with:
+    Given a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Run command
-        Given the default aruba exit timeout is 5 seconds
-        And I wait 5 seconds for a command to start up
         When I run `aruba-test-cli` in background
         And I run `kill -HUP <pid-last-command-started>`
         Then the output should contain:

--- a/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
@@ -246,41 +246,13 @@ Feature: Stop commands
     When I run `cucumber`
     Then the features should all pass
 
-  @requires-ruby-platform-java
-  Scenario: STDERR/STDOUT is empty on JRUBY if output was written in "signal"-handler
-    Given an executable named "bin/aruba-test-cli1" with:
-    """bash
-    #!/bin/bash
-
-    function term {
-      echo 'Hello, TERM'
-      exit 100
-    }
-
-    trap term TERM
-    echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
-    exit 1
-    """
-    And a file named "features/stop.feature" with:
-    """
-    Feature: Run it
-      Scenario: Run command
-        Given the default aruba exit timeout is 1 second
-        And I wait 2 seconds for a command to start up
-        When I run `aruba-test-cli1` in background
-        And I terminate the command started last
-        Then the exit status should be 100
-        And the output should not contain:
-        \"\"\"
-        Hello, TERM
-        \"\"\"
-    """
-    When I run `cucumber`
-    Then the features should all pass
-
   @requires-ruby-platform-mri
-  Scenario: STDERR/STDOUT is written normally with MRI-Ruby if output was written in "signal"-handler
+  Scenario: STDERR/STDOUT is captured from signal handlers
+
+     STDERR/STDOUT is written normally on MRI if output was written in "signal"-handler
+
+     This is currently broken on JRuby.
+
     Given an executable named "bin/aruba-test-cli1" with:
     """bash
     #!/bin/bash

--- a/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
@@ -25,7 +25,7 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And an executable named "bin/aruba-test-cli2" with:
@@ -38,15 +38,15 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And a file named "features/stop.feature" with:
     """
     Feature: Run it
       Scenario: Run command
-        Given the default aruba exit timeout is 1 second
-        And I wait 2 seconds for a command to start up
+        Given the default aruba exit timeout is 0.2 seconds
+        And I wait 0.1 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I run `aruba-test-cli2` in background
         And I terminate the command started last
@@ -75,7 +75,7 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And an executable named "bin/aruba-test-cli2" with:
@@ -88,7 +88,7 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And a file named "features/stop.feature" with:
@@ -97,8 +97,8 @@ Feature: Stop commands
       Background:
 
       Scenario: Run command
-        Given the default aruba exit timeout is 5 seconds
-        And I wait 2 seconds for a command to start up
+        Given the default aruba exit timeout is 0.2 seconds
+        And I wait 0.1 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I run `aruba-test-cli2` in background
         And I stop the command started last
@@ -126,7 +126,7 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
     And an executable named "bin/aruba-test-cli2" with:
     """bash
@@ -138,17 +138,17 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 2
     """
     And a file named "features/stop.feature" with:
     """
     Feature: Run it
       Background:
-        Given the default aruba exit timeout is 5 seconds
+        Given the default aruba exit timeout is 0.2 seconds
 
       Scenario: Run command
-        Given I wait 2 seconds for a command to start up
+        Given I wait 0.1 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         When I run `aruba-test-cli2` in background
         And I terminate the command "aruba-test-cli1"
@@ -177,7 +177,7 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And an executable named "bin/aruba-test-cli2" with:
@@ -190,17 +190,17 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And a file named "features/stop.feature" with:
     """
     Feature: Run it
       Background:
-        Given the default aruba exit timeout is 5 seconds
+        Given the default aruba exit timeout is 0.2 seconds
 
       Scenario: Run command
-        Given I wait 2 seconds for a command to start up
+        Given I wait 0.1 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I run `aruba-test-cli2` in background
         When I stop the command "aruba-test-cli1"
@@ -231,7 +231,7 @@ Feature: Stop commands
     trap hup HUP
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And a file named "features/run.feature" with:
@@ -239,7 +239,7 @@ Feature: Stop commands
     Feature: Run it
       Scenario: Run command
         Given the default aruba stop signal is "HUP"
-        And the default aruba exit timeout is 5 seconds
+        And the default aruba exit timeout is 0.2 seconds
         When I run `aruba-test-cli`
         Then the exit status should be 155
     """
@@ -264,15 +264,15 @@ Feature: Stop commands
 
     trap term TERM
     echo "Hello, Aruba!"
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     exit 1
     """
     And a file named "features/stop.feature" with:
     """
     Feature: Run it
       Scenario: Run command
-        Given the default aruba exit timeout is 1 second
-        And I wait 2 seconds for a command to start up
+        Given the default aruba exit timeout is 0.2 seconds
+        And I wait 0.1 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I terminate the command started last
         Then the exit status should be 100

--- a/features/03_testing_frameworks/rspec/hooks/define_after_hook_for_commands.feature
+++ b/features/03_testing_frameworks/rspec/hooks/define_after_hook_for_commands.feature
@@ -17,10 +17,8 @@ Feature: After command hooks
     Given I use a fixture named "cli-app"
 
   Scenario: Run a simple command with an "after(:command)"-hook
-    Given a file named "spec/support/hooks.rb" with:
+    Given a file named "spec/support/aruba_config.rb" with:
     """
-    require 'aruba'
-
     Aruba.configure do |config|
       config.after :command do |cmd|
         puts "after the run of `#{cmd.commandline}`"
@@ -43,4 +41,3 @@ Feature: After command hooks
     """
     after the run of `echo running`
     """
-

--- a/features/03_testing_frameworks/rspec/hooks/define_before_hook_for_commands.feature
+++ b/features/03_testing_frameworks/rspec/hooks/define_before_hook_for_commands.feature
@@ -19,10 +19,8 @@ Feature: before_cmd hooks
     Given I use a fixture named "cli-app"
 
   Scenario: Run a simple command with a "before(:command)"-hook
-    Given a file named "spec/support/hooks.rb" with:
+    Given a file named "spec/support/aruba_config.rb" with:
     """
-    require 'aruba'
-
     Aruba.configure do |config|
       config.before :command do |cmd|
         puts "before the run of `#{cmd.commandline}`"
@@ -49,8 +47,6 @@ Feature: before_cmd hooks
   Scenario: Run a simple command with a "before(:cmd)"-hook (deprecated)
     Given a file named "spec/support/hooks.rb" with:
     """
-    require 'aruba'
-
     Aruba.configure do |config|
       config.before :cmd do |cmd|
         puts "before the run of `#{cmd}`"

--- a/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
+++ b/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
@@ -9,17 +9,17 @@ Feature: Getting started with RSpec and aruba
     `spec_helper.rb`. After that you only need to flag your tests with `type:
     :aruba` and some things are set up for.
 
-    The simple integration adds some `before(:each)`-hooks for you:
+    The simple integration adds some `before(:each)` hooks for you:
 
       \* Setup Aruba Test directory
       \* Clear environment (ENV)
-      \* Make HOME-variable configarable via `arub.config.home_directory`
-      \* Configure `aruba` via `RSpec`-metadata
-      \* Activate announcers based on `RSpec`-metadata
+      \* Make HOME variable configurable via `arub.config.home_directory`
+      \* Configure `aruba` via `RSpec` metadata
+      \* Activate announcers based on `RSpec` metadata
 
-    Be careful, if you are going to use a `before(:all)`-hook to set up
-    files/directories. Those will be deleted by the `setup_aruba`-call within
-    the `before(:each)`-hook. Look for some custom integration further down the
+    Be careful, if you are going to use a `before(:all)` hook to set up
+    files/directories. Those will be deleted by the `setup_aruba` call within
+    the `before(:each)` hook. Look for some custom integration further down the
     documentation for a solution.
 
     Given a file named "spec/spec_helper.rb" with:
@@ -82,18 +82,18 @@ Feature: Getting started with RSpec and aruba
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Custom Integration using before(:all)-hook
+  Scenario: Custom Integration using before(:all) hook
 
-    You can even use `aruba` within a `before(:all)`-hook. But again, make sure
+    You can even use `aruba` within a `before(:all)` hook. But again, make sure
     that `setup_aruba` is run before you use any method of `aruba`. Using
-    `setup_aruba` both in `before(:all)`- and `before(:each)`-hook is not
-    possible and therefor not supported:
+    `setup_aruba` both in a `before(:all)` and a `before(:each)` hook is not
+    possible and therefore not supported:
 
-    Running `setup_aruba` removes `tmp/aruba`, creates a new one `tmp/aruba`
-    and make it the working directory. Running it within a `before(:all)`-hook,
-    run some `aruba`-method and then run `setup_arub` again within a
-    `before(:each)`-hook, will remove the files/directories created within the
-    `before(:all)`-hook.
+    Running `setup_aruba` removes `tmp/aruba`, creates a new `tmp/aruba`, and
+    makes that the working directory. Running it within a `before(:all)` hook,
+    running some `aruba` method and, then running `setup_aruba` again within a
+    `before(:each)` hook, will remove the files and directories created within
+    the `before(:all)` hook.
 
     Given a file named "spec/spec_helper.rb" with:
     """

--- a/features/04_aruba_api/command/read_stderr_of_command.feature
+++ b/features/04_aruba_api/command/read_stderr_of_command.feature
@@ -5,7 +5,7 @@ Feature: Access STDERR of command
 
   Background:
     Given I use a fixture named "cli-app"
-    And the default aruba io wait timeout is 1 seconds
+    And the default aruba io wait timeout is 0.1 seconds
 
   Scenario: Existing executable
     Given an executable named "bin/aruba-test-cli" with:
@@ -26,18 +26,18 @@ Feature: Access STDERR of command
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Waiting for output to "appear" after 2 seconds
+  Scenario: Waiting for output to appear
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 1
+    sleep 0.1
     echo 'Hello, Aruba' >&2
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :io_wait_timeout => 2 do
+    RSpec.describe 'Run command', :type => :aruba, :io_wait_timeout => 0.2 do
       before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started.stderr).to start_with 'Hello' }
     end

--- a/features/04_aruba_api/command/read_stdout_of_command.feature
+++ b/features/04_aruba_api/command/read_stdout_of_command.feature
@@ -26,7 +26,7 @@ Feature: Access STDOUT of command
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Waiting for output to "appear" after 2 seconds
+  Scenario: Waiting for output to appear
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash

--- a/features/04_aruba_api/command/read_stdout_of_command.feature
+++ b/features/04_aruba_api/command/read_stdout_of_command.feature
@@ -30,14 +30,14 @@ Feature: Access STDOUT of command
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 1
+    sleep 0.1
     echo 'Hello, Aruba'
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :io_wait_timeout => 2 do
+    RSpec.describe 'Run command', :type => :aruba, :io_wait_timeout => 0.2 do
       before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started.stdout).to start_with 'Hello' }
     end

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -1,6 +1,6 @@
 Feature: Run command
 
-  To run a command use the `#run_command`-method. There are some configuration options
+  To run a command use the `#run_command` method. There are some configuration options
   which are relevant here:
 
   - `startup_wait_time`:
@@ -82,9 +82,9 @@ Feature: Run command
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/usr/bin/env bash
- 
+
     function initialize_script {
-      sleep 2
+      sleep 0.2
     }
 
     function do_some_work {
@@ -105,20 +105,25 @@ Feature: Run command
     initialize_script
     do_some_work
 
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 2 do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { last_command_started.send_signal 'HUP' }
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.1, :startup_wait_time => 0.2 do
+      before do
+        run_command('aruba-test-cli')
+        last_command_started.send_signal 'HUP'
+      end
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output /Hello, Aruba is working/ }
-      it { expect(last_command_started).to have_output /Hello, Aruba here/ }
-
+      it 'runs the command with the expected results' do
+        aggregate_failures do
+          expect(last_command_started).to be_successfully_executed
+          expect(last_command_started).to have_output /Hello, Aruba is working/
+          expect(last_command_started).to have_output /Hello, Aruba here/
+        end
+      end
     end
     """
     When I run `rspec`
@@ -134,7 +139,7 @@ Feature: Run command
     #!/usr/bin/env bash
 
     function do_some_work {
-      sleep 2
+      sleep 0.2
       echo "Hello, Aruba here"
     }
 
@@ -144,11 +149,15 @@ Feature: Run command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 3 do
-      before(:each) { run_command('aruba-test-cli') }
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.3 do
+      before { run_command('aruba-test-cli') }
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output /Hello, Aruba here/ }
+      it 'runs the command with the expected results' do
+        aggregate_failures do
+          expect(last_command_started).to be_successfully_executed
+          expect(last_command_started).to have_output /Hello, Aruba here/
+        end
+      end
     end
     """
     When I run `rspec`

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -109,7 +109,7 @@ Feature: Run command in a simpler fashion
     #!/usr/bin/env bash
 
     function initialize_script {
-      sleep 2
+      sleep 0.2
     }
 
     function do_some_work {
@@ -125,11 +125,15 @@ Feature: Run command in a simpler fashion
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 2 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.1, :startup_wait_time => 0.3 do
       before(:each) { run_command_and_stop('aruba-test-cli') }
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output /Hello, Aruba is working/ }
+      it 'runs the command with the expected results' do
+        aggregate_failures do
+          expect(last_command_started).to be_successfully_executed
+          expect(last_command_started).to have_output /Hello, Aruba is working/
+        end
+      end
     end
     """
     When I run `rspec`
@@ -145,7 +149,7 @@ Feature: Run command in a simpler fashion
     #!/usr/bin/env bash
 
     function do_some_work {
-      sleep 2
+      sleep 0.2
       echo "Hello, Aruba here"
     }
 
@@ -155,11 +159,15 @@ Feature: Run command in a simpler fashion
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 3 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.3 do
       before(:each) { run_command_and_stop('aruba-test-cli') }
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output /Hello, Aruba here/ }
+      it 'runs the command with the expected results' do
+        aggregate_failures do
+          expect(last_command_started).to be_successfully_executed
+          expect(last_command_started).to have_output /Hello, Aruba here/
+        end
+      end
     end
     """
     When I run `rspec`
@@ -176,11 +184,11 @@ Feature: Run command in a simpler fashion
     #!/usr/bin/env bash
 
     function initialize_script {
-      sleep 1
+      sleep 0.1
     }
 
     function cleanup_script {
-      sleep 1
+      sleep 0.1
     }
 
     function do_some_work {
@@ -198,7 +206,7 @@ Feature: Run command in a simpler fashion
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2, :startup_wait_time => 1 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.2, :startup_wait_time => 0.2 do
       before { run_command_and_stop('aruba-test-cli') }
 
       it 'refuses to send a signal' do

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -1,4 +1,4 @@
-Feature: Run command
+Feature: Run command in a simpler fashion
 
   To run a command use the `#run_command_and_stop`-method. There are some configuration options
   which are relevant here:
@@ -102,7 +102,7 @@ Feature: Run command
     If you have got a command with a long startup phase or use `ruby` together
     with `bundler`, you should consider using the `startup_wait_time`-option.
     Otherwise methods like `#send_signal` don't work since they require the
-    command to be running and have setup it's signal handler.
+    command to be running and have setup its signal handler.
 
     Given an executable named "bin/aruba-test-cli" with:
     """bash
@@ -135,9 +135,9 @@ Feature: Run command
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Long running command
+  Scenario: Long-running command
 
-    If you have got a "long running" command, you should consider using the
+    If you have got a long-running command, you should consider using the
     `exit_timeout`-option.
 
     Given an executable named "bin/aruba-test-cli" with:
@@ -199,8 +199,12 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2, :startup_wait_time => 1 do
-      before(:each) { run_command_and_stop('aruba-test-cli') }
-      it { expect { last_command_started.send_signal 'HUP' }.to raise_error Aruba::CommandAlreadyStoppedError }
+      before { run_command_and_stop('aruba-test-cli') }
+
+      it 'refuses to send a signal' do
+        expect { last_command_started.send_signal 'HUP' }.
+          to raise_error Aruba::CommandAlreadyStoppedError
+      end
     end
     """
     When I run `rspec`

--- a/features/04_aruba_api/command/send_signal_to_command.feature
+++ b/features/04_aruba_api/command/send_signal_to_command.feature
@@ -19,13 +19,13 @@ Feature: Send running command a signal
 
     trap hup HUP
 
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 5 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 0.1 do
       before(:each) { run_command('aruba-test-cli') }
       before(:each) { last_command_started.send_signal 'HUP' }
       it { expect(last_command_started).to have_output /Exit/ }
@@ -44,7 +44,7 @@ Feature: Send running command a signal
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 5 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1, :startup_wait_time => 0.1 do
       before(:each) { run_command('aruba-test-cli') }
       it { expect { last_command_started.send_signal 'HUP' }.to raise_error Aruba::CommandAlreadyStoppedError, /Command "aruba-test-cli" with PID/ }
     end

--- a/features/04_aruba_api/command/stop_all_commands.feature
+++ b/features/04_aruba_api/command/stop_all_commands.feature
@@ -9,13 +9,13 @@ Feature: Stop all commands
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 3
+    sleep 0.2
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 5 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.3 do
       before(:each) { run_command('aruba-test-cli') }
       before(:each) { run_command('aruba-test-cli') }
 
@@ -31,22 +31,26 @@ Feature: Stop all commands
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 1
+    sleep 0.1
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.2 do
       before(:each) { @cmd1 = run_command('aruba-test-cli') }
       before(:each) { @cmd2 = run_command('aruba-test-cli') }
       before(:each) { @cmd3 = run_command('sleep 1') }
 
       before(:each) { stop_all_commands { |c| c.commandline == 'aruba-test-cli' } }
 
-      it { expect(@cmd1).to be_stopped }
-      it { expect(@cmd2).to be_stopped }
-      it { expect(@cmd3).not_to be_stopped }
+      it 'only stops selected commands' do
+        aggregate_failures do
+          expect(@cmd1).to be_stopped
+          expect(@cmd2).to be_stopped
+          expect(@cmd3).not_to be_stopped
+        end
+      end
     end
     """
     When I run `rspec`

--- a/features/04_aruba_api/command/stop_single_command.feature
+++ b/features/04_aruba_api/command/stop_single_command.feature
@@ -6,7 +6,7 @@ Feature: Stop command
   - `find_command('command').stop`
 
   But normally there's no need to stop a command manually. All matchers
-  handling commands make sure, that they stop ALL command before check actual
+  handling commands make sure, that they stop ALL commands before checking actual
   against expected.
 
   Background:
@@ -21,13 +21,13 @@ Feature: Stop command
     }
 
     trap term TERM
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.2 do
       before(:each) { run_command('aruba-test-cli') }
       before(:each) { last_command_started.stop }
       it { expect(last_command_started).to be_successfully_executed }
@@ -45,13 +45,14 @@ Feature: Stop command
     }
 
     trap term TERM
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
+    exit 1
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 0.2 do
       before(:each) { run_command('aruba-test-cli') }
       before(:each) { find_command('aruba-test-cli').stop }
       it { expect(last_command_started).to be_successfully_executed }
@@ -76,7 +77,7 @@ Feature: Stop command
 
     trap hup HUP
     trap term TERM
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
@@ -84,7 +85,7 @@ Feature: Stop command
 
     Aruba.configure do |config|
       config.stop_signal  = 'HUP'
-      config.exit_timeout = 1
+      config.exit_timeout = 0.2
     end
 
     RSpec.describe 'Run command', :type => :aruba do
@@ -111,7 +112,7 @@ Feature: Stop command
 
     trap hup HUP
     trap term TERM
-    while [ true ]; do sleep 1; done
+    while [ true ]; do sleep 0.1; done
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
@@ -119,7 +120,7 @@ Feature: Stop command
 
     Aruba.configure do |config|
       config.stop_signal  = 'HUP'
-      config.exit_timeout = 1
+      config.exit_timeout = 0.2
     end
 
     RSpec.describe 'Run command', :type => :aruba do

--- a/features/04_aruba_api/command/terminate_all_commands.feature
+++ b/features/04_aruba_api/command/terminate_all_commands.feature
@@ -31,22 +31,26 @@ Feature: Terminate all commands
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 1
+    sleep 0.5
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 2 do
+    RSpec.describe 'Run command', :type => :aruba, :exit_timeout => 1 do
       before(:each) { @cmd1 = run_command('aruba-test-cli') }
       before(:each) { @cmd2 = run_command('aruba-test-cli') }
       before(:each) { @cmd3 = run_command('sleep 1') }
 
       before(:each) { terminate_all_commands { |c| c.commandline == 'aruba-test-cli' } }
 
-      it { expect(@cmd1).to be_stopped }
-      it { expect(@cmd2).to be_stopped }
-      it { expect(@cmd3).not_to be_stopped }
+      it 'only terminates selected commands' do
+        aggregate_failures do
+          expect(@cmd1).to be_stopped
+          expect(@cmd2).to be_stopped
+          expect(@cmd3).not_to be_stopped
+        end
+      end
     end
     """
     When I run `rspec`

--- a/features/05_use_rspec_matchers/path/have_permissions.feature
+++ b/features/05_use_rspec_matchers/path/have_permissions.feature
@@ -31,7 +31,7 @@ Feature: Check if path has permissions in filesystem
 
     RSpec.describe 'Check if path has permissions', :type => :aruba do
       let(:file) { 'file.txt' }
-      let(:permissions) { 0700 }
+      let(:permissions) { 0600 }
 
       before(:each) { touch(file) }
       before(:each) { chmod(permissions, file) }
@@ -67,7 +67,7 @@ Feature: Check if path has permissions in filesystem
 
     RSpec.describe 'Check if path has permissions', :type => :aruba do
       let(:files) { %w(file1.txt file2.txt) }
-      let(:permissions) { 0700 }
+      let(:permissions) { 0600 }
 
       before :each do
         files.each do |f|
@@ -89,7 +89,7 @@ Feature: Check if path has permissions in filesystem
 
     RSpec.describe 'Check if path has permissions', :type => :aruba do
       let(:files) { %w(file1.txt file2.txt) }
-      let(:permissions) { 0700 }
+      let(:permissions) { 0600 }
 
       before :each do
         touch(files.first)
@@ -109,7 +109,7 @@ Feature: Check if path has permissions in filesystem
 
     RSpec.describe 'Check if path has permissions', :type => :aruba do
       let(:path) { 'file.txt' }
-      let(:permissions) { 0777 }
+      let(:permissions) { 0700 }
 
       it { expect(path).to have_permissions permissions }
     end

--- a/fixtures/cli-app/spec/spec_helper.rb
+++ b/fixtures/cli-app/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'cli/app'
+require 'support/aruba'
 
 if RUBY_VERSION < '1.9.3'
   ::Dir.glob(::File.expand_path('../support/**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }

--- a/fixtures/empty-app/lib/cli/app.rb
+++ b/fixtures/empty-app/lib/cli/app.rb
@@ -1,11 +1,5 @@
 require 'cli/app/version'
 
-if RUBY_VERSION < '1.9.3'
-  ::Dir.glob(::File.expand_path('../**/*.rb', __FILE__)).each { |f| require File.join(File.dirname(f), File.basename(f, '.rb')) }
-else
-  ::Dir.glob(File.expand_path('../**/*.rb', __FILE__)).each { |f| require_relative f }
-end
-
 module Cli
   module App
     # Your code goes here...

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -24,9 +24,9 @@ end
 
 ## I successfully run `echo -n "Hello"`
 ## I successfully run `sleep 29` for up to 30 seconds
-When(/^I successfully run `(.*?)`(?: for up to (\d+) seconds)?$/)do |cmd, secs|
+When(/^I successfully run `(.*?)`(?: for up to ([\d.]+) seconds)?$/) do |cmd, secs|
   cmd = sanitize_text(cmd)
-  run_command_and_stop(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_i)
+  run_command_and_stop(cmd, :fail_on_error => true, :exit_timeout => secs && secs.to_f)
 end
 
 When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do |shell, commands|
@@ -390,20 +390,20 @@ Given(/The default aruba timeout is (\d+) seconds/) do |seconds|
   aruba.config.exit_timeout = seconds.to_i
 end
 
-Given(/^the (?:default )?aruba io wait timeout is (\d+) seconds?$/) do |seconds|
-  aruba.config.io_wait_timeout = seconds.to_i
+Given(/^the (?:default )?aruba io wait timeout is ([\d.]+) seconds?$/) do |seconds|
+  aruba.config.io_wait_timeout = seconds.to_f
 end
 
-Given(/^the (?:default )?aruba exit timeout is (\d+) seconds?$/) do |seconds|
-  aruba.config.exit_timeout = seconds.to_i
+Given(/^the (?:default )?aruba exit timeout is ([\d.]+) seconds?$/) do |seconds|
+  aruba.config.exit_timeout = seconds.to_f
 end
 
 Given(/^the (?:default )?aruba stop signal is "([^"]*)"$/) do |signal|
   aruba.config.stop_signal = signal
 end
 
-Given(/^I wait (\d+) seconds? for (?:a|the) command to start up$/) do |seconds|
-  aruba.config.startup_wait_time = seconds.to_i
+Given(/^I wait ([\d.]+) seconds? for (?:a|the) command to start up$/) do |seconds|
+  aruba.config.startup_wait_time = seconds.to_f
 end
 
 When(/^I send the signal "([^"]*)" to the command (?:"([^"]*)"|(?:started last))$/) do |signal, command|

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -25,17 +25,29 @@ module Aruba
 
       # Create process
       #
-      # @params [String] cmd
+      # @param [String] cmd
       #   Command string
       #
-      # @params [Integer] exit_timeout
+      # @param [Numeric] exit_timeout
       #   The timeout until we expect the command to be finished
       #
-      # @params [Integer] io_wait_timeout
+      # @param [Numeric] io_wait_timeout
       #   The timeout until we expect the io to be finished
       #
-      # @params [String] working_directory
+      # @param [String] working_directory
       #   The directory where the command will be executed
+      #
+      # @param [Hash] environment
+      #   Environment variables
+      #
+      # @param [Class] main_class
+      #   E.g. Cli::App::Runner
+      #
+      # @param [String] stop_signal
+      #   Name of signal to send to stop process. E.g. 'HUP'.
+      #
+      # @param [Numeric] startup_wait_time
+      #   The amount of seconds to wait after Aruba has started a command.
       def initialize(cmd, exit_timeout, io_wait_timeout, working_directory, environment = ENV.to_hash.dup, main_class = nil, stop_signal = nil, startup_wait_time = 0)
         super
 
@@ -262,7 +274,7 @@ module Aruba
       end
 
       def wait_for_io(time_to_wait, &block)
-        sleep time_to_wait.to_i
+        sleep time_to_wait
         yield
       end
 


### PR DESCRIPTION
## Summary

Allow timeout values with decimal values.

## Details

* Update several cucumber scenarios to match master, without changes to functionality
* Backport allowing decimal timeout values from #544.

## Motivation and Context

Part of #598.

## How Has This Been Tested?

Travis!

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (cleanup of codebase without changing any existing functionality)
- [x] Update documentation

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
