### PR TITLE
Move deprecated cucumber steps into a separate file

### DIFF
--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -6,6 +6,7 @@ World(Aruba::Api)
 require 'aruba/cucumber/hooks'
 require 'aruba/cucumber/command'
 require 'aruba/cucumber/core'
+require 'aruba/cucumber/deprecated'
 require 'aruba/cucumber/environment'
 require 'aruba/cucumber/file'
 require 'aruba/cucumber/testing_frameworks'

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -3,23 +3,9 @@ if Aruba::VERSION < '1.0.0'
 end
 require 'aruba/generators/script_file'
 
-When(/^I run "(.*)"$/)do |cmd|
-  warn(%{\e[35m    The /^I run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-
-  cmd = sanitize_text(cmd)
-  run_command_and_stop(cmd, false)
-end
-
 When(/^I run `([^`]*)`$/)do |cmd|
   cmd = sanitize_text(cmd)
   run_command_and_stop(cmd, :fail_on_error => false)
-end
-
-When(/^I successfully run "(.*)"$/)do |cmd|
-  warn(%{\e[35m    The  /^I successfully run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-
-  cmd = sanitize_text(cmd)
-  run_command_and_stop(cmd)
 end
 
 ## I successfully run `echo -n "Hello"`
@@ -38,12 +24,6 @@ When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do
   Aruba::ScriptFile.new(:interpreter => shell, :content => commands,
                         :path => expand_path('bin/myscript')).call
   step 'I run `myscript`'
-end
-
-When(/^I run "([^"]*)" interactively$/) do |cmd|
-  Aruba.platform.deprecated(%{\e[35m    The /^I run "([^"]*)" interactively$/ step definition is deprecated. Please use the `backticks` version\e[0m})
-
-  step %(I run `#{cmd}` interactively)
 end
 
 When(/^I run `([^`]*)` interactively$/)do |cmd|
@@ -372,22 +352,6 @@ Then(/^(?:the )?(output|stdout|stderr) should( not)? contain all of these lines:
       expect(all_commands).to include_an_object have_output an_output_string_including(expected)
     end
   end
-end
-
-Given(/the default aruba timeout is (\d+) seconds/) do |seconds|
-  # rubocop:disable Metrics/LineLength
-  Aruba.platform.deprecated(%{The /^the default aruba timeout is (\d+) seconds/ step definition is deprecated. Please use /^the default aruba exit timeout is (\d+) seconds/ step definition is deprecated.})
-  # rubocop:enable Metrics/LineLength
-
-  aruba.config.exit_timeout = seconds.to_i
-end
-
-Given(/The default aruba timeout is (\d+) seconds/) do |seconds|
-  # rubocop:disable Metrics/LineLength
-  Aruba.platform.deprecated(%{The /^The default aruba timeout is (\d+) seconds/ step definition is deprecated. Please use /^the default aruba exit timeout is (\d+) seconds/ step definition is deprecated.})
-  # rubocop:enable Metrics/LineLength
-
-  aruba.config.exit_timeout = seconds.to_i
 end
 
 Given(/^the (?:default )?aruba io wait timeout is ([\d.]+) seconds?$/) do |seconds|

--- a/lib/aruba/cucumber/deprecated.rb
+++ b/lib/aruba/cucumber/deprecated.rb
@@ -1,0 +1,93 @@
+Before('@announce-cmd') do
+  Aruba.platform.deprecated 'The use of "@announce-cmd"-hook is deprecated. Please use "@announce-command"'
+
+  aruba.announcer.activate :command
+end
+
+Before('@announce-dir') do
+  Aruba.platform.deprecated 'The use of "@announce-dir"-hook is deprecated. Please use "@announce-directory"'
+
+  aruba.announcer.activate :directory
+end
+
+Before('@announce-env') do
+  Aruba.platform.deprecated 'The use of "@announce-env"-hook is deprecated. Please use "@announce-changed-environment"'
+
+  aruba.announcer.activate :environment
+end
+
+Before('@announce-environment') do
+  Aruba.platform.deprecated '@announce-environment is deprecated. Use @announce-changed-environment instead'
+
+  aruba.announcer.activate :changed_environment
+end
+
+Before('@announce-modified-environment') do
+  Aruba.platform.deprecated '@announce-modified-environment is deprecated. Use @announce-changed-environment instead'
+
+  aruba.announcer.activate :changed_environment
+end
+
+Before('@ansi') do
+  # rubocop:disable Metrics/LineLength
+  Aruba::Platform.deprecated('The use of "@ansi" is deprecated. Use "@keep-ansi-escape-sequences" instead. But be aware, that this hook uses the aruba configuration and not an instance variable')
+  # rubocop:enable Metrics/LineLength
+
+  aruba.config.remove_ansi_escape_sequences = false
+end
+
+
+Before '@mocked_home_directory' do
+  Aruba.platform.deprecated('The use of "@mocked_home_directory" is deprecated. Use "@mocked-home-directory" instead')
+
+  set_environment_variable 'HOME', expand_path('.')
+end
+
+When(/^I run "(.*)"$/)do |cmd|
+  warn(%{\e[35m    The /^I run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
+
+  cmd = sanitize_text(cmd)
+  run_command_and_stop(cmd, false)
+end
+
+When(/^I successfully run "(.*)"$/)do |cmd|
+  warn(%{\e[35m    The  /^I successfully run "(.*)"$/ step definition is deprecated. Please use the `backticks` version\e[0m})
+
+  cmd = sanitize_text(cmd)
+  run_command_and_stop(cmd)
+end
+
+When(/^I run "([^"]*)" interactively$/) do |cmd|
+  Aruba.platform.deprecated(%{\e[35m    The /^I run "([^"]*)" interactively$/ step definition is deprecated. Please use the `backticks` version\e[0m})
+
+  step %(I run `#{cmd}` interactively)
+end
+
+Given(/the default aruba timeout is (\d+) seconds/) do |seconds|
+  # rubocop:disable Metrics/LineLength
+  Aruba.platform.deprecated(%{The /^the default aruba timeout is (\d+) seconds/ step definition is deprecated. Please use /^the default aruba exit timeout is (\d+) seconds/ step definition is deprecated.})
+  # rubocop:enable Metrics/LineLength
+
+  aruba.config.exit_timeout = seconds.to_i
+end
+
+Given(/The default aruba timeout is (\d+) seconds/) do |seconds|
+  # rubocop:disable Metrics/LineLength
+  Aruba.platform.deprecated(%{The /^The default aruba timeout is (\d+) seconds/ step definition is deprecated. Please use /^the default aruba exit timeout is (\d+) seconds/ step definition is deprecated.})
+  # rubocop:enable Metrics/LineLength
+
+  aruba.config.exit_timeout = seconds.to_i
+end
+
+Then(/^the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)"$/) do |file, negated, permissions|
+  # rubocop:disable Metrics/LineLength
+  Aruba.platform.deprecated('The use of step "the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)" is deprecated. Use "^the (?:file|directory)(?: named)? "([^"]*)" should have permissions "([^"]*)"$" instead')
+  # rubocop:enable Metrics/LineLength
+
+  if negated
+    expect(file).not_to have_permissions(permissions)
+  else
+    expect(file).to have_permissions(permissions)
+  end
+end
+

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -180,18 +180,6 @@ Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?be equal to file "([^"]
   end
 end
 
-Then(/^the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)"$/) do |file, negated, permissions|
-  # rubocop:disable Metrics/LineLength
-  Aruba.platform.deprecated('The use of step "the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)" is deprecated. Use "^the (?:file|directory)(?: named)? "([^"]*)" should have permissions "([^"]*)"$" instead')
-  # rubocop:enable Metrics/LineLength
-
-  if negated
-    expect(file).not_to have_permissions(permissions)
-  else
-    expect(file).to have_permissions(permissions)
-  end
-end
-
 Then(/^the (?:file|directory)(?: named)? "([^"]*)" should( not)? have permissions "([^"]*)"$/) do |path, negated, permissions|
   if negated
     expect(path).not_to have_permissions(permissions)

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -44,12 +44,6 @@ Before('@announce-command-filesystem-status') do
   aruba.announcer.activate :command_filesystem_status
 end
 
-Before('@announce-cmd') do
-  Aruba.platform.deprecated 'The use of "@announce-cmd"-hook is deprecated. Please use "@announce-command"'
-
-  aruba.announcer.activate :command
-end
-
 Before('@announce-output') do
   aruba.announcer.activate :stdout
   aruba.announcer.activate :stderr
@@ -63,12 +57,6 @@ Before('@announce-stderr') do
   aruba.announcer.activate :stderr
 end
 
-Before('@announce-dir') do
-  Aruba.platform.deprecated 'The use of "@announce-dir"-hook is deprecated. Please use "@announce-directory"'
-
-  aruba.announcer.activate :directory
-end
-
 Before('@announce-directory') do
   aruba.announcer.activate :directory
 end
@@ -77,26 +65,8 @@ Before('@announce-stop-signal') do
   aruba.announcer.activate :stop_signal
 end
 
-Before('@announce-env') do
-  Aruba.platform.deprecated 'The use of "@announce-env"-hook is deprecated. Please use "@announce-changed-environment"'
-
-  aruba.announcer.activate :environment
-end
-
-Before('@announce-environment') do
-  Aruba.platform.deprecated '@announce-environment is deprecated. Use @announce-changed-environment instead'
-
-  aruba.announcer.activate :changed_environment
-end
-
 Before('@announce-full-environment') do
   aruba.announcer.activate :full_environment
-end
-
-Before('@announce-modified-environment') do
-  Aruba.platform.deprecated '@announce-modified-environment is deprecated. Use @announce-changed-environment instead'
-
-  aruba.announcer.activate :changed_environment
 end
 
 Before('@announce-changed-environment') do
@@ -135,23 +105,9 @@ end
 #   aruba.config.command_launcher = :spawn
 # end
 
-Before('@ansi') do
-  # rubocop:disable Metrics/LineLength
-  Aruba::Platform.deprecated('The use of "@ansi" is deprecated. Use "@keep-ansi-escape-sequences" instead. But be aware, that this hook uses the aruba configuration and not an instance variable')
-  # rubocop:enable Metrics/LineLength
-
-  aruba.config.remove_ansi_escape_sequences = false
-end
-
 Before('@keep-ansi-escape-sequences') do
   aruba.config.remove_ansi_escape_sequences = false
   aruba.config.keep_ansi = true
-end
-
-Before '@mocked_home_directory' do
-  Aruba.platform.deprecated('The use of "@mocked_home_directory" is deprecated. Use "@mocked-home-directory" instead')
-
-  set_environment_variable 'HOME', expand_path('.')
 end
 
 Before '@mocked-home-directory' do


### PR DESCRIPTION
## Summary

Move deprecated cucumber steps into a separate file

## Details

Move deprecated cucumber steps into `lib/aruba/cucumber/deprecated.rb`.

## Motivation and Context

Part of #598. This will make merging easier.

## How Has This Been Tested?

Travis.

## Types of changes

- [x] Refactoring (cleanup of codebase without changing any existing functionality)