### PR TITLE
Allow use with Cucumber 3.x

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'childprocess', '~> 1.0'
   spec.add_runtime_dependency 'contracts', '~> 0.13'
-  spec.add_runtime_dependency 'cucumber', '~> 2.4'
+  spec.add_runtime_dependency 'cucumber', ['>= 2.4', '< 4.0']
   spec.add_runtime_dependency 'ffi', '~> 1.9'
   spec.add_runtime_dependency 'rspec-expectations', '~> 3.4'
   spec.add_runtime_dependency 'thor', '~> 0.19'


### PR DESCRIPTION
## Summary

Loosen dependency on Cucumber to allow use of Aruba with Cucumber 3.x.

## Motivation and Context

Fixes #625.

## How Has This Been Tested?

Tests were run with updated bundle.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)