### PR TITLE
define_method + yield would not work. Use Proc#call instead

### DIFF
--- a/lib/aruba/colorizer.rb
+++ b/lib/aruba/colorizer.rb
@@ -52,11 +52,11 @@ module Aruba
     self.coloring = true
 
     ATTRIBUTES.each do |c, v|
-      define_method(c) do |string|
+      define_method(c) do |string, &block|
         result = ''
         result << "\e[#{v}m" if Aruba::AnsiColor.coloring?
-        if block_given?
-          result << yield
+        if block
+          result << block.call
         elsif string
           result << string
         elsif respond_to?(:to_str)


### PR DESCRIPTION
The prervious code tries to call the given block via `yield`, but ruby won't actually run this as expected.

Basically, you can't call `yield` in a method defined by `define_method`. This would cause a SyntaxError.

```
$ ruby -e "define_method(:a) { yield }; a { p :hello }"
Traceback (most recent call last):
	1: from -e:1:in `<main>'
-e:1:in `block in <main>': no block given (yield) (LocalJumpError)
```

But in this case here in colorizer.rb, we're not seeing a SyntaxError because the `yield` tries to call a block from an outer scope, i.e., the Module scope.
So, this code will cause another error, LocalJumpError.

```
$ ruby -e "
  module M
    define_method(:a) { yield }
  end

  extend M

  a { p :hello }"
Traceback (most recent call last):
	1: from -e:8:in `<main>'
-e:3:in `block in <module:M>': no block given (yield) (LocalJumpError)
```

In order to properly give a block via define_method, we need to explicitly pass a Proc as a parameter.

```
$ ruby -e "
module M
  define_method(:b) do |&block|
    block.call
  end
end

extend M

b { p :hello }"
:hello
```