### PR TITLE
TimeoutError is deprecated in favor of Timeout::Error

### DIFF
--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -80,7 +80,7 @@ When(/^I stop the command(?: started last)? if (output|stdout|stderr) contains:$
         sleep 0.1
       end
     end
-  rescue ChildProcess::TimeoutError, TimeoutError
+  rescue ChildProcess::TimeoutError, Timeout::Error
     last_command_started.terminate
   end
 end


### PR DESCRIPTION
Ruby stdlib Timeout's TimeoutError is deprecated in favor of Timeout::Error.

https://github.com/ruby/ruby/blob/34d7ec4e9b0a24b3ce89009927738f1dac38e6d3/lib/timeout.rb#L125-L130