### PR TITLE
Test on lowest supported Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ jobs:
       os: linux
     - rvm: 2.3.8
       os: osx
+    - rvm: 2.3.0
+      os: linux
     - rvm: jruby
       os: linux
     - rvm: jruby-9.2.7.0


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Test on CRuby 2.3.0.

## Details

Adds target CRuby 2.3.0 on Linux to Travis CI

## Motivation and Context

We officially support Ruby 2.3 and up, so we need to make sure Aruba actually works there. There are some dependency versions that support, e.g., 2.3.3 and up, so this is not an academic exercise.

## How Has This Been Tested?

Travis CI will do its thing.