### PR TITLE
Allow multiple arguments to xProcess#write

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-bundle exec rake rubygem:release

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -186,7 +186,7 @@ module Aruba
       def type(input)
         return close_input if input == "\u0004"
 
-        last_command_started.write(input << "\n")
+        last_command_started.write(input, "\n")
       end
 
       # Close stdin

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -52,15 +52,15 @@ module Aruba
       end
 
       def stdin(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def stdout(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def stderr(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def close_io(*)

--- a/lib/aruba/processes/in_process.rb
+++ b/lib/aruba/processes/in_process.rb
@@ -103,7 +103,7 @@ module Aruba
       #
       # @param *input [Array of String]
       def write(*input)
-        @stdin.write *input
+        @stdin.write(*input)
       end
 
       # Close io

--- a/lib/aruba/processes/in_process.rb
+++ b/lib/aruba/processes/in_process.rb
@@ -99,12 +99,11 @@ module Aruba
         @stderr.string
       end
 
-      # Write strint to stdin
+      # Write strings to stdin
       #
-      # @param [String] input
-      #   Write string to stdin in
-      def write(input)
-        @stdin.write input
+      # @param *input [Array of String]
+      def write(*input)
+        @stdin.write *input
       end
 
       # Close io

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -154,10 +154,10 @@ module Aruba
         end
       end
 
-      def write(input)
+      def write(*input)
         return if stopped?
 
-        @process.io.stdin.write(input)
+        @process.io.stdin.write(*input)
         @process.io.stdin.flush
 
         self

--- a/spec/aruba/processes/basic_process_spec.rb
+++ b/spec/aruba/processes/basic_process_spec.rb
@@ -5,31 +5,33 @@ RSpec.describe Aruba::Processes::BasicProcess do
   let(:exit_timeout) { 0 }
   let(:io_wait_timeout) { 0 }
   let(:working_directory) { Dir.pwd }
-  let(:stdout) { 'foo output' }
-  let(:stderr) { 'foo error output' }
-
-  subject do
-    Class.new(described_class) do
-      def initialize(*args)
-        @stdout = args.shift
-        @stderr = args.shift
-        super(*args)
-      end
-
-      def stdout(*_args)
-        @stdout
-      end
-
-      def stderr(*_args)
-        @stderr
-      end
-    end.new(stdout, stderr, cmd, exit_timeout, io_wait_timeout, working_directory)
-  end
+  let(:process) { described_class.new(cmd, exit_timeout, io_wait_timeout, working_directory) }
 
   describe '#inspect' do
+    let(:stdout) { 'foo output' }
+    let(:stderr) { 'foo error output' }
+
+    let(:derived_process) do
+      Class.new(described_class) do
+        def initialize(*args)
+          @stdout = args.shift
+          @stderr = args.shift
+          super(*args)
+        end
+
+        def stdout(*_args)
+          @stdout
+        end
+
+        def stderr(*_args)
+          @stderr
+        end
+      end.new(stdout, stderr, cmd, exit_timeout, io_wait_timeout, working_directory)
+    end
+
     it 'it shows useful info' do
       expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout="foo output" stderr="foo error output"/
-      expect(subject.inspect).to match(expected)
+      expect(derived_process.inspect).to match(expected)
     end
 
     context 'with no stdout' do
@@ -37,7 +39,7 @@ RSpec.describe Aruba::Processes::BasicProcess do
 
       it 'it shows useful info' do
         expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout=nil stderr="foo error output"/
-        expect(subject.inspect).to match(expected)
+        expect(derived_process.inspect).to match(expected)
       end
     end
 
@@ -46,7 +48,7 @@ RSpec.describe Aruba::Processes::BasicProcess do
 
       it 'it shows useful info' do
         expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout="foo output" stderr=nil/
-        expect(subject.inspect).to match(expected)
+        expect(derived_process.inspect).to match(expected)
       end
     end
 
@@ -56,8 +58,26 @@ RSpec.describe Aruba::Processes::BasicProcess do
 
       it 'it shows useful info' do
         expected = /#<#<Class:0x[0-9A-Fa-f]+>:\d+ commandline="foobar": stdout=nil stderr=nil/
-        expect(subject.inspect).to match(expected)
+        expect(derived_process.inspect).to match(expected)
       end
+    end
+  end
+
+  describe '#stdin' do
+    it 'raises NotImplementedError' do
+      expect { process.stdin }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#stdout' do
+    it 'raises NotImplementedError' do
+      expect { process.stdout }.to raise_error NotImplementedError
+    end
+  end
+
+  describe '#stderr' do
+    it 'raises NotImplementedError' do
+      expect { process.stderr }.to raise_error NotImplementedError
     end
   end
 end

--- a/spec/aruba/processes/in_process_spec.rb
+++ b/spec/aruba/processes/in_process_spec.rb
@@ -147,14 +147,14 @@ RSpec.describe Aruba::Processes::InProcess do
     let(:main_class) { StdinRunner }
 
     it 'writes single strings to the process' do
-      process.write "World"
+      process.write 'World'
       process.start
       process.stop
       expect(process.stdout).to eq "Hello, World!\n"
     end
 
     it 'writes multiple strings to the process' do
-      process.write "Wor", "ld"
+      process.write 'Wor', 'ld'
       process.start
       process.stop
       expect(process.stdout).to eq "Hello, World!\n"

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe Aruba::Processes::SpawnProcess do
     end
   end
 
+  describe '#write' do
+    let(:command_line) { "ruby -e 'puts gets'" }
+
+    it 'writes single strings to the process' do
+      process.start
+      process.write "hello\n"
+      process.stop
+
+      expect(process.stdout).to eq "hello\n"
+    end
+
+    it 'writes multiple strings to the process' do
+      process.start
+      process.write "hel", "lo\n"
+      process.stop
+
+      expect(process.stdout).to eq "hello\n"
+    end
+  end
+
   describe '#stop' do
     before(:each) { process.start }
 

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Aruba::Processes::SpawnProcess do
 
     it 'writes multiple strings to the process' do
       process.start
-      process.write "hel", "lo\n"
+      process.write 'hel', "lo\n"
       process.stop
 
       expect(process.stdout).to eq "hello\n"


### PR DESCRIPTION
## Summary

Allow passing more than one string to `InProcess#write` and `SpawnProcess#write`

## Details

Changes the arity of these two methods to match that of the base class' method. This makes these methods match the behavior of `IO#write`.

## Motivation and Context

This avoids the need to do a string append in `Api::Commands#type`, which in turn will help avoid issues when frozen strings are passed to that method. As a next step, all strings in Aruba can be made frozen by default.

## How Has This Been Tested?

Specs have been added

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
