### PR TITLE
Fix JRuby before :command helper hook

### DIFF
--- a/features/08_other/improve_performance_if_using_jruby.feature
+++ b/features/08_other/improve_performance_if_using_jruby.feature
@@ -4,7 +4,7 @@ Feature: Support for JRuby
   be accomplished by adding
 
   ```ruby
-  require 'aruba/jruby'
+  require 'aruba/config/jruby'
   ```
 
   *Note* - no conflict resolution on the JAVA/JRuby environment options is
@@ -12,3 +12,26 @@ Feature: Support for JRuby
   environment variables in the hook or externally.
 
   Refer to http://blog.headius.com/2010/03/jruby-startup-time-tips.html for other tips on startup time.
+
+  Background:
+    Given I use a fixture named "cli-app"
+
+  @requires-ruby-platform-java
+  Scenario:
+    Given a file named "spec/jruby_env_spec.rb" with:
+      """
+      require 'spec_helper'
+      require 'aruba/config/jruby'
+
+      RSpec.describe 'running commands with before :command hook', :type => :aruba do
+        it 'sets up for efficient JRuby startup' do
+          with_environment 'JRUBY_OPTS' => '-d' do
+            run_command_and_stop('env')
+
+            expect(last_command_started.output).to include 'JRUBY_OPTS=--dev -X-C -d'
+          end
+        end
+      end
+      """
+    When I run `rspec`
+    Then the specs should all pass

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -3,8 +3,6 @@ require 'aruba/runtime'
 require 'aruba/errors'
 require 'aruba/setup'
 
-require 'aruba/config/jruby'
-
 # Aruba
 module Aruba
   # Api

--- a/spec/aruba/jruby_spec.rb
+++ b/spec/aruba/jruby_spec.rb
@@ -2,54 +2,72 @@ require 'spec_helper'
 require 'aruba/api'
 
 describe 'Aruba JRuby Startup Helper' do
-  before(:all) do
-    @fake_env = ENV.clone
-  end
+  include Aruba::Api
 
-  before :each do
+  let(:rb_config) { double('RbConfig::CONFIG') }
+  let(:command) do
+    instance_double(Aruba::Processes::BasicProcess, environment: command_environment)
+  end
+  let(:command_environment) { { 'JRUBY_OPTS' => '--1.9', 'JAVA_OPTS' => '-Xdebug' } }
+
+  before do
     Aruba.config.reset
 
-    # Define before_cmd-hook
+    # Define before :command hook
     load 'aruba/config/jruby.rb'
   end
 
-  before(:each) do
-    @fake_env['JRUBY_OPTS'] = '--1.9'
-    @fake_env['JAVA_OPTS'] = '-Xdebug'
-
-    stub_const('ENV', @fake_env)
-  end
-
-  context 'when some mri ruby' do
-    before :each do
+  context 'when running under some MRI Ruby' do
+    before do
       stub_const('RUBY_PLATFORM', 'x86_64-chocolate')
     end
 
-    before :each do
-      Aruba.config.before :command, self
-    end
+    it 'keeps the existing JRUBY_OPTS and JAVA_OPTS environment values' do
+      # Run defined before :command hook
+      Aruba.config.before :command, self, command
 
-    it { expect(ENV['JRUBY_OPTS']).to eq '--1.9' }
-    it { expect(ENV['JAVA_OPTS']).to eq '-Xdebug' }
+      aggregate_failures do
+        expect(command_environment['JRUBY_OPTS']).to eq '--1.9'
+        expect(command_environment['JAVA_OPTS']).to eq '-Xdebug'
+      end
+    end
   end
 
-  context 'when jruby ruby' do
-    before :each do
-      stub_const('RUBY_PLATFORM', 'java')
-    end
-
-    before :each do
-      rb_config = double('rb_config')
-      allow(rb_config).to receive(:[]).and_return('solaris')
-
+  context 'when running under JRuby but not on Solaris' do
+    before do
+      stub_const 'RUBY_PLATFORM', 'java'
       stub_const 'RbConfig::CONFIG', rb_config
+
+      allow(rb_config).to receive(:[]).with('host_os').and_return('foo-os')
     end
 
+    it 'updates the existing JRuby but not Java option values' do
+      # Run defined before :command hook
+      Aruba.config.before :command, self, command
+
+      aggregate_failures do
+        expect(command_environment['JRUBY_OPTS']).to eq '--dev -X-C --1.9'
+        expect(command_environment['JAVA_OPTS']).to eq '-Xdebug'
+      end
+    end
+  end
+
+  context 'when running under JRuby on Solaris' do
     before :each do
-      Aruba.config.before :command, self
+      stub_const 'RUBY_PLATFORM', 'java'
+      stub_const 'RbConfig::CONFIG', rb_config
+
+      allow(rb_config).to receive(:[]).with('host_os').and_return('solaris')
     end
 
-    it { expect(ENV['JRUBY_OPTS']).to eq '--dev -X-C --1.9' }
-    it { expect(ENV['JAVA_OPTS']).to eq '-d32 -Xdebug' }
+    it 'keeps the existing JRuby and Java option values' do
+      # Run defined before :command hook
+      Aruba.config.before :command, self, command
+
+      aggregate_failures do
+        expect(command_environment['JRUBY_OPTS']).to eq '--dev -X-C --1.9'
+        expect(command_environment['JAVA_OPTS']).to eq '-d32 -Xdebug'
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Add full integration test for JRuby helper and make it work.

## Details

The before :command hooks are run after the command's environment has already been set up, so instead of modifying Aruba's environment, or the actual environment, we need to modify the command's environment. This change adds a scenario for this feature, and updates the implementation to make it work.

We also no longer require the helper by default, so requiring by the user will have the desired effect.

## Motivation and Context

This is a forward-port of #612.

## How Has This Been Tested?

Cucumber scenario and RSpec specs were added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
