### PR TITLE
Undeprecate some stuff

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -375,7 +375,7 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
-  Scenario: Detect output from all processes normal and interactive ones
+  Scenario: Detect combined output from normal and interactive processes
     Given an executable named "bin/aruba-test-cli1" with:
     """
     #!/usr/bin/env bash

--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -347,7 +347,6 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
-  @requires-aruba-version-1
   Scenario: Detect output from all processes
     Given an executable named "bin/aruba-test-cli1" with:
     """bash
@@ -370,34 +369,35 @@ Feature: All output of commands which were executed
         Then the stdout should contain exactly:
         \"\"\"
         This is cli1
-        \"\"\"
-        And the stdout should contain exactly:
-        \"\"\"
         This is cli2
         \"\"\"
     """
     When I run `cucumber`
     Then the features should all pass
 
-  Scenario: Detect output from all processes (deprecated)
+  Scenario: Detect output from all processes normal and interactive ones
     Given an executable named "bin/aruba-test-cli1" with:
-    """bash
+    """
     #!/usr/bin/env bash
-
     echo 'This is cli1'
     """
     And an executable named "bin/aruba-test-cli2" with:
-    """bash
-    #!/usr/bin/env bash
+    """
+    #!/usr/bin/env ruby
 
-    echo 'This is cli2'
+    while input = gets do
+      break if "" == input
+      puts input
+    end
     """
     And a file named "features/output.feature" with:
-    """cucumber
+    """
     Feature: Run command
       Scenario: Run command
         When I run `aruba-test-cli1`
-        When I run `aruba-test-cli2`
+        When I run `aruba-test-cli2` interactively
+        And I type "This is cli2"
+        And I type ""
         Then the stdout should contain exactly:
         \"\"\"
         This is cli1
@@ -474,42 +474,6 @@ Feature: All output of commands which were executed
         Then the output should contain "a"
         And the output should be 65536 bytes long
         And the exit status should be 0
-    """
-    When I run `cucumber`
-    Then the features should all pass
-
-  @requires-aruba-version-1
-  Scenario: Detect output from all processes normal and interactive ones
-    Given an executable named "bin/aruba-test-cli1" with:
-    """
-    #!/usr/bin/env bash
-    echo 'This is cli1'
-    """
-    And an executable named "bin/aruba-test-cli2" with:
-    """
-    #!/usr/bin/env ruby
-
-    while input = gets do
-      break if "" == input
-      puts input
-    end
-    """
-    And a file named "features/output.feature" with:
-    """
-    Feature: Run command
-      Scenario: Run command
-        When I run `aruba-test-cli1`
-        When I run `aruba-test-cli2` interactively
-        And I type "This is cli2"
-        And I type ""
-        Then the stdout should contain exactly:
-        \"\"\"
-        This is cli1
-        \"\"\"
-        And the stdout should contain exactly:
-        \"\"\"
-        This is cli2
-        \"\"\"
     """
     When I run `cucumber`
     Then the features should all pass

--- a/features/03_testing_frameworks/cucumber/steps/command/check_stderr_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_stderr_of_command.feature
@@ -29,7 +29,7 @@ Feature: STDERR of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
-  Scenario: Detect stderr from all processes (deprecated)
+  Scenario: Detect stderr from all processes
     Given a file named "features/output.feature" with:
     """
     Feature: Run command

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -106,7 +106,7 @@ module Aruba
       # Get stdout of all processes
       #
       # @return [String]
-      #   The stdout of all process which have run before
+      #   The stdout of all processes which have run before
       def all_stdout
         aruba.command_monitor.all_stdout
       end
@@ -114,7 +114,7 @@ module Aruba
       # Get stderr of all processes
       #
       # @return [String]
-      #   The stderr of all process which have run before
+      #   The stderr of all processes which have run before
       def all_stderr
         aruba.command_monitor.all_stderr
       end
@@ -122,7 +122,7 @@ module Aruba
       # Get stderr and stdout of all processes
       #
       # @return [String]
-      #   The stderr and stdout of all process which have run before
+      #   The stderr and stdout of all processes which have run before
       def all_output
         aruba.command_monitor.all_output
       end

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -103,6 +103,30 @@ module Aruba
         self
       end
 
+      # Get stdout of all processes
+      #
+      # @return [String]
+      #   The stdout of all process which have run before
+      def all_stdout
+        aruba.command_monitor.all_stdout
+      end
+
+      # Get stderr of all processes
+      #
+      # @return [String]
+      #   The stderr of all process which have run before
+      def all_stderr
+        aruba.command_monitor.all_stderr
+      end
+
+      # Get stderr and stdout of all processes
+      #
+      # @return [String]
+      #   The stderr and stdout of all process which have run before
+      def all_output
+        aruba.command_monitor.all_output
+      end
+
       # Find a started command
       #
       # @param [String, Command] commandline

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -29,6 +29,15 @@ module Aruba
         self
       end
 
+      # Execute block in Aruba's current directory
+      #
+      # @yield
+      #   The block which should be run in current directory
+      def in_current_directory(&block)
+        create_directory '.' unless directory?('.')
+        cd('.', &block)
+      end
+
       # Switch to directory
       #
       # @param [String] dir

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -1019,60 +1019,6 @@ module Aruba
 
       # @deprecated
       #
-      # Get stdout of all processes
-      #
-      # @return [String]
-      #   The stdout of all process which have run before
-      def all_stdout
-        Aruba.platform.deprecated(
-          'The use of "#all_stdout" is deprecated.' \
-          ' Use `all_commands.map { |c| c.stdout }.join("\n") instead.' \
-          ' If you need to check for some output, use' \
-          ' "expect(all_commands).to included_an_object have_output_on_stdout(/output/)"' \
-          ' instead'
-        )
-
-        process_monitor.all_stdout
-      end
-
-      # @deprecated
-      #
-      # Get stderr of all processes
-      #
-      # @return [String]
-      #   The stderr of all process which have run before
-      def all_stderr
-        Aruba.platform.deprecated(
-          'The use of "#all_stderr" is deprecated.' \
-          ' Use `all_commands.map { |c| c.stderr }.join("\n") instead.' \
-          ' If you need to check for some output use' \
-          ' "expect(all_commands).to included_an_object have_output_on_stderr /output/"' \
-          ' instead'
-        )
-
-        process_monitor.all_stderr
-      end
-
-      # @deprecated
-      #
-      # Get stderr and stdout of all processes
-      #
-      # @return [String]
-      #   The stderr and stdout of all process which have run before
-      def all_output
-        Aruba.platform.deprecated(
-          'The use of "#all_output" is deprecated.' \
-          ' Use `all_commands.map { |c| c.output }.join("\n") instead.' \
-          ' If you need to check for some output use' \
-          ' "expect(all_commands).to included_an_object have_output /output/"' \
-          ' instead'
-        )
-
-        process_monitor.all_output
-      end
-
-      # @deprecated
-      #
       # Default exit timeout for running commands with aruba
       #
       # Overwrite this method if you want a different timeout or set

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -52,22 +52,6 @@ module Aruba
       end
 
       # @deprecated
-      # Execute block in current directory
-      #
-      # @yield
-      #   The block which should be run in current directory
-      def in_current_directory(&block)
-        Aruba.platform.deprecated(
-          'The use of "in_current_directory" is deprecated.' \
-          ' Use "#cd(\'.\') { # your code }" instead. But be aware,' \
-          ' "cd" requires a previously created directory'
-        )
-
-        create_directory '.' unless directory?('.')
-        cd('.', &block)
-      end
-
-      # @deprecated
       def detect_ruby(cmd)
         Aruba.platform.deprecated('The use of "#detect_ruby" is deprecated')
 
@@ -525,11 +509,10 @@ module Aruba
       def in_current_dir(&block)
         Aruba.platform.deprecated(
           'The use of "in_current_dir" is deprecated.' \
-          ' Use "#cd(\'.\') { }" instead'
+          ' Use "#in_current_directory { }" instead'
         )
 
-        create_directory '.' unless directory?('.')
-        cd('.', &block)
+        in_current_directory(&block)
       end
 
       # @deprecated

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -136,21 +136,15 @@ Then(/^the output should be (\d+) bytes long$/) do |size|
   expect(last_command_started.output).to have_output_size size.to_i
 end
 
-Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain( exactly)? "([^"]*)"$/) do |channel, cmd, negated, exactly, expected|
-  matcher = case channel.to_sym
-            when :output
-              :have_output
-            when :stderr
-              :have_output_on_stderr
-            when :stdout
-              :have_output_on_stdout
-            end
-
-  commands = if cmd
-               [aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))]
-             else
-               all_commands
-             end
+Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)? "([^"]*)"$/) do |channel, negated, exactly, expected|
+  combined_output = case channel.to_sym
+                    when :output
+                      all_output
+                    when :stderr
+                      all_stderr
+                    when :stdout
+                      all_stdout
+                    end
 
   output_string_matcher = if exactly
                             :an_output_string_being_eq
@@ -158,31 +152,14 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
                             :an_output_string_including
                           end
 
-  if Aruba::VERSION < '1.0'
-    combined_output = commands.map do |c|
-      c.stop
-      c.send(channel.to_sym).chomp
-    end.join("\n")
-
-    if negated
-      expect(combined_output).not_to send(output_string_matcher, expected)
-    else
-      expect(combined_output).to send(output_string_matcher, expected)
-    end
+  if negated
+    expect(combined_output).not_to send(output_string_matcher, expected)
   else
-    if negated
-      expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
-    else
-      expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
-    end
+    expect(combined_output).to send(output_string_matcher, expected)
   end
 end
 
-## the stderr should contain "hello"
-## the stderr from "echo -n 'Hello'" should contain "hello"
-## the stderr should contain exactly:
-## the stderr from "echo -n 'Hello'" should contain exactly:
-Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain( exactly)?:$/) do |channel, cmd, negated, exactly, expected|
+Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exactly)? "([^"]*)"$/) do |channel, cmd, negated, exactly, expected|
   matcher = case channel.to_sym
             when :output
               :have_output
@@ -190,15 +167,9 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
               :have_output_on_stderr
             when :stdout
               :have_output_on_stdout
-            else
-              fail ArgumentError, %(Invalid channel "#{channel}" chosen. Only "output", "stderr" or "stdout" are allowed.)
             end
 
-  commands = if cmd
-               [aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))]
-             else
-               all_commands
-             end
+  command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
 
   output_string_matcher = if exactly
                             :an_output_string_being_eq
@@ -206,23 +177,58 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
                             :an_output_string_including
                           end
 
-  if Aruba::VERSION < '1.0'
-    combined_output = commands.map do |c|
-      c.stop
-      c.send(channel.to_sym).chomp
-    end.join("\n")
-
-    if negated
-      expect(combined_output).not_to send(output_string_matcher, expected)
-    else
-      expect(combined_output).to send(output_string_matcher, expected)
-    end
+  if negated
+    expect(command).not_to send(matcher, send(output_string_matcher, expected))
   else
-    if negated
-      expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
-    else
-      expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
-    end
+    expect(command).to send(matcher, send(output_string_matcher, expected))
+  end
+end
+
+Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)?:$/) do |channel, negated, exactly, expected|
+  combined_output = case channel.to_sym
+                    when :output
+                      all_output
+                    when :stderr
+                      all_stderr
+                    when :stdout
+                      all_stdout
+                    end
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  if negated
+    expect(combined_output).not_to send(output_string_matcher, expected)
+  else
+    expect(combined_output).to send(output_string_matcher, expected)
+  end
+end
+
+Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exactly)?:$/) do |channel, cmd, negated, exactly, expected|
+  matcher = case channel.to_sym
+            when :output
+              :have_output
+            when :stderr
+              :have_output_on_stderr
+            when :stdout
+              :have_output_on_stdout
+            end
+
+  command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  if negated
+    expect(command).not_to send(matcher, send(output_string_matcher, expected))
+  else
+    expect(command).to send(matcher, send(output_string_matcher, expected))
   end
 end
 

--- a/lib/aruba/matchers/string/output_string_eq.rb
+++ b/lib/aruba/matchers/string/output_string_eq.rb
@@ -15,7 +15,7 @@
 #
 #     RSpec.describe do
 #       it { expect(last_command_started).to have_output output_string_eq string) }
-#       it { expect(last_command_started).to have_output an_output_string_begin_eq string) }
+#       it { expect(last_command_started).to have_output an_output_string_being_eq string) }
 #     end
 RSpec::Matchers.define :output_string_eq do |expected|
   match do |actual|

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -125,7 +125,6 @@ module Aruba
       find(cmd).stderr
     end
 
-    # @deprecated
     # Get stdout of all commands
     #
     # @return [String]
@@ -140,7 +139,6 @@ module Aruba
       end
     end
 
-    # @deprecated
     # Get stderr of all commands
     #
     # @return [String]
@@ -155,7 +153,6 @@ module Aruba
       end
     end
 
-    # @deprecated
     # Get stderr and stdout of all commands
     #
     # @return [String]

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -45,6 +45,43 @@ RSpec.describe Aruba::Api::Core do
     end
   end
 
+  describe '#in_current_directory' do
+    let(:directory_path) { @aruba.aruba.current_directory }
+    let!(:full_path) { File.expand_path(directory_path) }
+
+    context 'with a block given' do
+      it 'runs the passed block in the given directory' do
+        @aruba.in_current_directory do
+          expect(Dir.pwd).to eq full_path
+        end
+        expect(Dir.pwd).not_to eq full_path
+      end
+
+      it 'sets directory environment in the passed block' do
+        old_pwd = ENV['PWD']
+        @aruba.in_current_directory do
+          expect(ENV['PWD']).to eq full_path
+          expect(ENV['OLDPWD']).to eq old_pwd
+        end
+      end
+
+      it 'sets aruba environment in the passed block' do
+        @aruba.set_environment_variable('FOO', 'bar')
+        @aruba.in_current_directory do
+          expect(ENV['FOO']).to eq 'bar'
+        end
+      end
+
+      it 'does not touch other environment variables in the passed block' do
+        keys = ENV.keys - ['PWD', 'OLDPWD']
+        old_values = ENV.values_at(*keys)
+        @aruba.in_current_directory do
+          expect(ENV.values_at(*keys)).to eq old_values
+        end
+      end
+    end
+  end
+
   describe '#cd' do
     before do
       @directory_name = 'test_dir'


### PR DESCRIPTION
## Summary

Restores `#all_output`, `#all_stdout`, `#all_stderr` and `#in_current_directory` API methods to non-deprecated status. Also un-deprecates the current behavior of output-checking cucumber steps.

## Motivation and Context

* These API methods seem to be the deprecated methods most used by downstream projects, and their replacements are more complex.
* The output-checking cucumber steps are currently set to have a breaking change in 1.0.0 and we should instead have a smooth upgrade path that will allow moving from latest 0.14.x to 1.0.0 when the latter is released.
* The replacement cucumber steps in master currently have less useful output, and the current behavior is more intuitive.

## How Has This Been Tested?

Some tests were added but mostly code was just moved.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [x] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added (some) tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
