### PR TITLE
Warn when deprecated files are required

### DIFF
--- a/lib/aruba/in_process.rb
+++ b/lib/aruba/in_process.rb
@@ -1,6 +1,8 @@
 require 'aruba/processes/in_process'
 require 'aruba/platform'
 
+Aruba.platform.deprecated('The use of "Aruba::InProcess" is deprecated. Use "Aruba::Processes::InProcess" instead.')
+
 # Aruba
 module Aruba
   # @deprecated

--- a/lib/aruba/spawn_process.rb
+++ b/lib/aruba/spawn_process.rb
@@ -1,9 +1,12 @@
 require 'aruba/processes/spawn_process'
+require 'aruba/platform'
+
+Aruba.platform.deprecated('The use of "Aruba::SpawnProcess" is deprecated. Use "Aruba::Processes::SpawnProcess" instead.')
 
 module Aruba
   class SpawnProcess < Aruba::Processes::SpawnProcess
     def initialize(*args)
-      warn('The use of "Aruba::SpawnProcess" is deprecated. Use "Aruba::Processes::SpawnProcess" instead.')
+      Aruba.platform.deprecated('The use of "Aruba::SpawnProcess" is deprecated. Use "Aruba::Processes::SpawnProcess" instead.')
 
       super
     end


### PR DESCRIPTION
## Summary

Warn when deprecated files `aruba/in_process` and `aruba/spawn_process` are required.

## Motivation and Context

Fixes #630.

## How Has This Been Tested?

```bash
bundle exec ruby -e "require 'aruba/in_process'"
```

## Types of changes

I'm confused. We may need a new category for this :confused: 
