### PR TITLE
Restore previously removed behaviors

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -58,9 +58,7 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should not all pass with:
     """
-          expected `aruba-test-cli` to have output string includes: "goodbye world"
-          but was:
-             hello world (RSpec::Expectations::ExpectationNotMetError)
+    expected "hello world" to string includes: "goodbye world"
     """
 
   Scenario: Detect subset of multiline output
@@ -222,10 +220,13 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should not all pass with:
     """
-          expected `aruba-test-cli` to have output output string is eq: "hello\nworld"
-          but was:
-             goodbye
-             world (RSpec::Expectations::ExpectationNotMetError)
+          expected "goodbye\nworld" to output string is eq: "hello\nworld"
+          Diff:
+          @@ -1,3 +1,3 @@
+          -hello
+          +goodbye
+           world
+           (RSpec::Expectations::ExpectationNotMetError)
     """
 
   Scenario: Detect subset of one-line output with regex
@@ -439,9 +440,6 @@ Feature: All output of commands which were executed
         Then the stdout should contain exactly:
         \"\"\"
         This is cli1
-        \"\"\"
-        And the stdout should contain exactly:
-        \"\"\"
         This is cli2
         \"\"\"
     """
@@ -545,9 +543,6 @@ Feature: All output of commands which were executed
         Then the stdout should contain exactly:
         \"\"\"
         This is cli1
-        \"\"\"
-        And the stdout should contain exactly:
-        \"\"\"
         This is cli2
         \"\"\"
     """

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -92,6 +92,30 @@ module Aruba
         self
       end
 
+      # Get stdout of all processes
+      #
+      # @return [String]
+      #   The stdout of all processes which have run before
+      def all_stdout
+        aruba.command_monitor.all_stdout
+      end
+
+      # Get stderr of all processes
+      #
+      # @return [String]
+      #   The stderr of all processes which have run before
+      def all_stderr
+        aruba.command_monitor.all_stderr
+      end
+
+      # Get stderr and stdout of all processes
+      #
+      # @return [String]
+      #   The stderr and stdout of all processes which have run before
+      def all_output
+        aruba.command_monitor.all_output
+      end
+
       # Find a started command
       #
       # @param [String, Command] commandline

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -29,6 +29,15 @@ module Aruba
         self
       end
 
+      # Execute block in Aruba's current directory
+      #
+      # @yield
+      #   The block which should be run in current directory
+      def in_current_directory(&block)
+        create_directory '.' unless directory?('.')
+        cd('.', &block)
+      end
+
       # Switch to directory
       #
       # @param [String] dir

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -119,21 +119,16 @@ Then(/^the output should be (\d+) bytes long$/) do |size|
   expect(last_command_started.output).to have_output_size size.to_i
 end
 
-Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain( exactly)? "([^"]*)"$/) do |channel, cmd, negated, exactly, expected|
-  matcher = case channel.to_sym
-            when :output
-              :have_output
-            when :stderr
-              :have_output_on_stderr
-            when :stdout
-              :have_output_on_stdout
-            end
-
-  commands = if cmd
-               [aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))]
-             else
-               all_commands
-             end
+## the stderr should contain "hello"
+Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)? "([^"]*)"$/) do |channel, negated, exactly, expected|
+  combined_output = case channel.to_sym
+                    when :output
+                      all_output
+                    when :stderr
+                      all_stderr
+                    when :stdout
+                      all_stdout
+                    end
 
   output_string_matcher = if exactly
                             :an_output_string_being_eq
@@ -142,17 +137,14 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
                           end
 
   if negated
-    expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
+    expect(combined_output).not_to send(output_string_matcher, expected)
   else
-    expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
+    expect(combined_output).to send(output_string_matcher, expected)
   end
 end
 
-## the stderr should contain "hello"
 ## the stderr from "echo -n 'Hello'" should contain "hello"
-## the stderr should contain exactly:
-## the stderr from "echo -n 'Hello'" should contain exactly:
-Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain( exactly)?:$/) do |channel, cmd, negated, exactly, expected|
+Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exactly)? "([^"]*)"$/) do |channel, cmd, negated, exactly, expected|
   matcher = case channel.to_sym
             when :output
               :have_output
@@ -160,15 +152,9 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
               :have_output_on_stderr
             when :stdout
               :have_output_on_stdout
-            else
-              fail ArgumentError, %(Invalid channel "#{channel}" chosen. Only "output", "stderr" or "stdout" are allowed.)
             end
 
-  commands = if cmd
-               [aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))]
-             else
-               all_commands
-             end
+  command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
 
   output_string_matcher = if exactly
                             :an_output_string_being_eq
@@ -177,9 +163,59 @@ Then(/^(?:the )?(output|stderr|stdout)(?: from "([^"]*)")? should( not)? contain
                           end
 
   if negated
-    expect(commands).not_to include_an_object send(matcher, send(output_string_matcher, expected))
+    expect(command).not_to send(matcher, send(output_string_matcher, expected))
   else
-    expect(commands).to include_an_object send(matcher, send(output_string_matcher, expected))
+    expect(command).to send(matcher, send(output_string_matcher, expected))
+  end
+end
+
+## the stderr should contain exactly:
+Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)?:$/) do |channel, negated, exactly, expected|
+  combined_output = case channel.to_sym
+                    when :output
+                      all_output
+                    when :stderr
+                      all_stderr
+                    when :stdout
+                      all_stdout
+                    end
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  if negated
+    expect(combined_output).not_to send(output_string_matcher, expected)
+  else
+    expect(combined_output).to send(output_string_matcher, expected)
+  end
+end
+
+## the stderr from "echo -n 'Hello'" should contain exactly:
+Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exactly)?:$/) do |channel, cmd, negated, exactly, expected|
+  matcher = case channel.to_sym
+            when :output
+              :have_output
+            when :stderr
+              :have_output_on_stderr
+            when :stdout
+              :have_output_on_stdout
+            end
+
+  command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  if negated
+    expect(command).not_to send(matcher, send(output_string_matcher, expected))
+  else
+    expect(command).to send(matcher, send(output_string_matcher, expected))
   end
 end
 

--- a/lib/aruba/matchers/command/have_exit_status.rb
+++ b/lib/aruba/matchers/command/have_exit_status.rb
@@ -23,7 +23,7 @@ RSpec::Matchers.define :have_exit_status do |expected|
     @old_actual.stop
     @actual = actual.exit_status
 
-    next false unless @old_actual.respond_to? :exit_status
+    raise "Expected #{@old_actual} to respond to #exit_status" unless @old_actual.respond_to? :exit_status
 
     values_match? expected, @actual
   end

--- a/lib/aruba/matchers/command/have_finished_in_time.rb
+++ b/lib/aruba/matchers/command/have_finished_in_time.rb
@@ -24,7 +24,7 @@ RSpec::Matchers.define :have_finished_in_time do
     @old_actual = actual
     @actual     = @old_actual.commandline
 
-    next false unless @old_actual.respond_to? :timed_out?
+    raise "Expected #{@old_actual} to respond to #timed_out?" unless @old_actual.respond_to? :timed_out?
 
     @old_actual.stop
 

--- a/lib/aruba/matchers/command/have_output.rb
+++ b/lib/aruba/matchers/command/have_output.rb
@@ -19,7 +19,7 @@ RSpec::Matchers.define :have_output do |expected|
   match do |actual|
     @old_actual = actual
 
-    next false unless @old_actual.respond_to? :output
+    raise "Expected #{@old_actual} to respond to #output" unless @old_actual.respond_to? :output
 
     @old_actual.stop
 

--- a/lib/aruba/matchers/command/have_output_on_stderr.rb
+++ b/lib/aruba/matchers/command/have_output_on_stderr.rb
@@ -17,7 +17,7 @@ RSpec::Matchers.define :have_output_on_stderr do |expected|
   match do |actual|
     @old_actual = actual
 
-    next false unless @old_actual.respond_to? :stderr
+    raise "Expected #{@old_actual} to respond to #stderr" unless @old_actual.respond_to? :stderr
 
     @old_actual.stop
 

--- a/lib/aruba/matchers/command/have_output_on_stdout.rb
+++ b/lib/aruba/matchers/command/have_output_on_stdout.rb
@@ -17,7 +17,7 @@ RSpec::Matchers.define :have_output_on_stdout do |expected|
   match do |actual|
     @old_actual = actual
 
-    next false unless @old_actual.respond_to? :stdout
+    raise "Expected #{@old_actual} to respond to #stdout" unless @old_actual.respond_to? :stdout
 
     @old_actual.stop
 

--- a/lib/aruba/matchers/command/have_output_size.rb
+++ b/lib/aruba/matchers/command/have_output_size.rb
@@ -18,7 +18,7 @@
 #     end
 RSpec::Matchers.define :have_output_size do |expected|
   match do |actual|
-    next false unless actual.respond_to? :size
+    raise "Expected #{actual} to respond to #size" unless actual.respond_to? :size
 
     @actual = actual.size
     values_match? expected, @actual

--- a/lib/aruba/matchers/directory/be_an_existing_directory.rb
+++ b/lib/aruba/matchers/directory/be_an_existing_directory.rb
@@ -19,7 +19,7 @@ RSpec::Matchers.define :be_an_existing_directory do |_|
   match do |actual|
     stop_all_commands
 
-    next false unless actual.is_a? String
+    raise 'String expected' unless actual.is_a? String
 
     directory?(actual)
   end

--- a/lib/aruba/matchers/file/be_an_existing_file.rb
+++ b/lib/aruba/matchers/file/be_an_existing_file.rb
@@ -19,7 +19,7 @@ RSpec::Matchers.define :be_an_existing_file do |_|
   match do |actual|
     stop_all_commands
 
-    next false unless actual.is_a? String
+    raise 'String expected' unless actual.is_a? String
 
     file?(actual)
   end

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -83,6 +83,34 @@ module Aruba
       self
     end
 
+    # Get stdout of all commands
+    #
+    # @return [String]
+    #   The stdout of all command which have run before
+    def all_stdout
+      registered_commands.each(&:stop)
+
+      registered_commands.each_with_object('') { |e, a| a << e.stdout }
+    end
+
+    # Get stderr of all commands
+    #
+    # @return [String]
+    #   The stderr of all command which have run before
+    def all_stderr
+      registered_commands.each(&:stop)
+
+      registered_commands.each_with_object('') { |e, a| a << e.stderr }
+    end
+
+    # Get stderr and stdout of all commands
+    #
+    # @return [String]
+    #   The stderr and stdout of all command which have run before
+    def all_output
+      all_stdout << all_stderr
+    end
+
     # Register command to monitor
     def register_command(cmd)
       registered_commands << cmd

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Aruba::Api::Core do
 
       it 'sets directory environment in the passed block' do
         @aruba.create_directory @directory_name
-        old_pwd = ENV['PWD']
+        old_pwd = Dir.pwd
         full_path = File.expand_path(@directory_path)
         @aruba.cd @directory_name do
           expect(ENV['PWD']).to eq full_path
@@ -120,7 +120,7 @@ RSpec.describe Aruba::Api::Core do
       end
 
       it 'sets directory environment in the passed block' do
-        old_pwd = ENV['PWD']
+        old_pwd = Dir.pwd
         @aruba.in_current_directory do
           expect(ENV['PWD']).to eq full_path
           expect(ENV['OLDPWD']).to eq old_pwd

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 require 'aruba/api'
 require 'fileutils'
 
-describe Aruba::Api::Core do
+RSpec.describe Aruba::Api::Core do
   include_context 'uses aruba API'
 
   describe '#cd' do
-    before(:each) do
+    before do
       @directory_name = 'test_dir'
       @directory_path = File.join(@aruba.aruba.current_directory, @directory_name)
     end
@@ -21,10 +21,30 @@ describe Aruba::Api::Core do
         expect(Dir.pwd).not_to eq full_path
       end
 
-      it 'does not touch non-directory environment of the passed block' do
+      it 'sets directory environment in the passed block' do
+        @aruba.create_directory @directory_name
+        old_pwd = ENV['PWD']
+        full_path = File.expand_path(@directory_path)
+        @aruba.cd @directory_name do
+          expect(ENV['PWD']).to eq full_path
+          expect(ENV['OLDPWD']).to eq old_pwd
+        end
+      end
+
+      it 'sets aruba environment in the passed block' do
+        @aruba.create_directory @directory_name
+        @aruba.set_environment_variable('FOO', 'bar')
+        @aruba.cd @directory_name do
+          expect(ENV['FOO']).to eq 'bar'
+        end
+      end
+
+      it 'does not touch other environment variables in the passed block' do
+        keys = ENV.keys - %w(PWD OLDPWD)
+        old_values = ENV.values_at(*keys)
         @aruba.create_directory @directory_name
         @aruba.cd @directory_name do
-          expect(ENV['HOME']).not_to be_nil
+          expect(ENV.values_at(*keys)).to eq old_values
         end
       end
     end
@@ -72,53 +92,18 @@ describe Aruba::Api::Core do
       it { expect { @aruba.expand_path('') }.to raise_error ArgumentError }
     end
 
-    context 'when dir_path is given similar to File.expand_path ' do
-      it { expect(@aruba.expand_path(@file_name, 'path')).to eq File.expand_path(File.join(aruba.current_directory, 'path', @file_name)) }
+    context 'when second argument is given' do
+      it 'behaves similar to File.expand_path' do
+        expect(@aruba.expand_path(@file_name, 'path'))
+          .to eq File.expand_path(File.join(aruba.current_directory, 'path', @file_name))
+      end
     end
 
     context 'when file_name contains fixtures "%" string' do
-      let(:runtime) { instance_double('Aruba::Runtime') }
-      let(:config) { double('Aruba::Config') }
-      let(:environment) { instance_double('Aruba::Environment') }
-
-      let(:klass) do
-        Class.new do
-          include Aruba::Api
-
-          attr_reader :aruba
-
-          def initialize(aruba)
-            @aruba = aruba
-          end
-        end
+      it 'finds files in the fixtures directory' do
+        expect(@aruba.expand_path('%/cli-app'))
+          .to eq File.expand_path('cli-app', File.join(aruba.fixtures_directory))
       end
-
-      before :each do
-        allow(config).to receive(:fixtures_path_prefix).and_return('%')
-        allow(config).to receive(:root_directory).and_return aruba.config.root_directory
-        allow(config).to receive(:working_directory).and_return aruba.config.working_directory
-      end
-
-      before :each do
-        allow(environment).to receive(:clear)
-        allow(environment).to receive(:update).and_return(environment)
-        allow(environment).to receive(:to_h).and_return('PATH' => aruba.current_directory.to_s)
-      end
-
-      before :each do
-        allow(runtime).to receive(:config).and_return config
-        allow(runtime).to receive(:environment).and_return environment
-        allow(runtime).to receive(:current_directory).and_return aruba.current_directory
-        allow(runtime).to receive(:root_directory).and_return aruba.root_directory
-        allow(runtime).to receive(:fixtures_directory).and_return File.join(aruba.root_directory, aruba.current_directory, 'spec', 'fixtures')
-      end
-
-      before :each do
-        @aruba = klass.new(runtime)
-        @aruba.touch 'spec/fixtures/file1'
-      end
-
-      it { expect(@aruba.expand_path('%/file1')).to eq File.expand_path(File.join(aruba.current_directory, 'spec', 'fixtures', 'file1')) }
     end
   end
 


### PR DESCRIPTION
## Summary

Restore behaviors in master whose deprecation in 0.1.4.x was reverted.

## Details

* Restore the API methods `#in_current_directory`, `#all_stdout`, `#all_stderr`, `#all_output`.
* Raise an error in output matchers when actual object does not respond to required methods. Previously, the matcher would just fail.
* Restore old behavior for output-matching cucumber steps, splitting them up a bit as well.

## Motivation and Context

Fixes #641.

## How Has This Been Tested?

Tests in 0.14.x for `#in_current_directory` were copied as well. The other methods are only tested throught the cucumber scenarios at the momen.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Update documentation

## Checklist:

- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
