### PR TITLE
Remove checks for now-unsupported Cucumber version

### DIFF
--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -3,11 +3,7 @@ require 'cucumber/platform'
 Before '@requires-python' do |scenario|
   next unless Aruba.platform.which('python').nil?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@requires-zsh' do |scenario|
@@ -23,85 +19,53 @@ end
 Before '@requires-java' do |scenario|
   next unless Aruba.platform.which('javac').nil?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@requires-perl' do |scenario|
   next unless Aruba.platform.which('perl').nil?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@requires-ruby' do |scenario|
   next unless Aruba.platform.which('ruby').nil?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@requires-posix-standard-tools' do |scenario|
   next unless Aruba.platform.which('printf').nil?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@requires-ruby-platform-java' do |scenario|
   # leave if java
   next if RUBY_PLATFORM.include? 'java'
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@unsupported-on-platform-java' do |scenario|
   # leave if not java
   next unless RUBY_PLATFORM.include? 'java'
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@unsupported-on-platform-windows' do |scenario|
   # leave if not windows
   next unless FFI::Platform.windows?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@requires-readline' do
   begin
     require 'readline'
   rescue LoadError
-    if Cucumber::VERSION < '2'
-      skip_invoke!
-    else
-      skip_this_scenario
-    end
+    skip_this_scenario
   end
 end
 
@@ -109,20 +73,12 @@ Before '@unsupported-on-platform-unix' do |scenario|
   # leave if not windows
   next unless FFI::Platform.unix?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end
 
 Before '@unsupported-on-platform-mac' do |scenario|
   # leave if not windows
   next unless FFI::Platform.mac?
 
-  if Cucumber::VERSION < '2'
-    scenario.skip_invoke!
-  else
-    skip_this_scenario
-  end
+  skip_this_scenario
 end


### PR DESCRIPTION
## Summary

Stop checking for Cucumber::VERSION below 2.

## Details

Removes some outdated checks for the cucumber version from Aruba's hooks. Cucumber below 2.4 is no longer supported per the gemspec.

## Motivation and Context

Cleaning up.

## Types of changes

- [x] Refactoring (cleanup of codebase without changing any existing functionality)