### PR TITLE
Do not set binmode on output temp files

### DIFF
--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -79,8 +79,10 @@ module Aruba
         @stdout_file.sync = true
         @stderr_file.sync = true
 
-        @stdout_file.binmode
-        @stderr_file.binmode
+        if RUBY_VERSION >= '1.9'
+          @stdout_file.set_encoding('ASCII-8BIT')
+          @stderr_file.set_encoding('ASCII-8BIT')
+        end
 
         @exit_status = nil
         @duplex      = true


### PR DESCRIPTION
## Summary

Do not set binmode on output temp files.

## Details

This removes binmode so Ruby can do its automatic line ending conversion like it used to. To avoid encoding compatibilities, the encoding on the temp files is set to 8 bit ascii.

## Motivation and Context

This fixes #614 in master.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
