### PR TITLE
Support windows internal commands

### DIFF
--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -236,6 +236,10 @@ module Aruba
       def which(program, path = ENV['PATH'])
         UnixWhich.new.call(program, path)
       end
+
+      def internal_shell_commands
+        []
+      end
     end
   end
 end

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -237,7 +237,7 @@ module Aruba
         UnixWhich.new.call(program, path)
       end
 
-      def internal_shell_commands
+      def builtin_shell_commands
         []
       end
     end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -37,6 +37,10 @@ module Aruba
       def which(program, path = ENV['PATH'])
         WindowsWhich.new.call(program, path)
       end
+
+      def internal_shell_commands
+        ['echo']
+      end
     end
   end
 end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -39,7 +39,7 @@ module Aruba
       end
 
       def builtin_shell_commands
-        ['echo']
+        ['cd', 'echo']
       end
     end
   end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -38,7 +38,7 @@ module Aruba
         WindowsWhich.new.call(program, path)
       end
 
-      def internal_shell_commands
+      def builtin_shell_commands
         ['echo']
       end
     end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -39,7 +39,7 @@ module Aruba
       end
 
       def builtin_shell_commands
-        ['cd', 'echo']
+        ['cd', 'dir', 'echo', 'exit', 'set', 'type']
       end
     end
   end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -266,7 +266,7 @@ module Aruba
       end
 
       def command_path
-        @command_path ||= (Aruba.platform.internal_shell_commands.include?(command) ? command : Aruba.platform.which(command, environment['PATH']))
+        @command_path ||= (Aruba.platform.builtin_shell_commands.include?(command) ? command : Aruba.platform.which(command, environment['PATH']))
       end
 
       def wait_for_io(time_to_wait)

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -206,7 +206,7 @@ module Aruba
         end
 
         @exit_status  = @process.exit_code
-
+  
         @stdout_cache = read_temporary_output_file @stdout_file
         @stderr_cache = read_temporary_output_file @stderr_file
 
@@ -262,12 +262,11 @@ module Aruba
 
       def command_string
         fail LaunchError, %(Command "#{command}" not found in PATH-variable "#{environment['PATH']}".) if command_path.nil?
-
         Aruba.platform.command_string.new(command_path, *arguments)
       end
 
       def command_path
-        @command_path ||= Aruba.platform.which(command, environment['PATH'])
+        @command_path ||= (Aruba.platform.internal_shell_commands.include?(command) ? command : Aruba.platform.which(command, environment['PATH']))
       end
 
       def wait_for_io(time_to_wait)


### PR DESCRIPTION
## Summary

Support windows internal commands by accepting them as existing commands.

## Details

Allow SpawnProcess to find built-in shell commands in addition to real executable files. Provide list of such built-in commands for Windows.

## Motivation and Context

* This was implemented as part of #505
* Fixes #568

## How Has This Been Tested?

TBA

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
