### PR TITLE
Fix up JRuby build

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -7,7 +7,7 @@ Feature: Debug your command in cucumber-test-run
     Given I use a fixture named "cli-app"
     And the default aruba exit timeout is 60 seconds
 
-  @requires-readline
+  @unsupported-on-platform-java
   Scenario: You can use a debug repl in your cli program
 
     If you want to debug an error, which only occurs in one of your

--- a/features/06_use_aruba_cli/open_console.feature
+++ b/features/06_use_aruba_cli/open_console.feature
@@ -11,7 +11,6 @@ Feature: Aruba Console
     aruba:001:0>
     """
 
-  @unsupported-on-platform-java
   Scenario: Show help
     Given I run `aruba console` interactively
     And I type "aruba_help"
@@ -29,7 +28,6 @@ Feature: Aruba Console
     Documentation:
     """
 
-  @unsupported-on-platform-java
   Scenario: Show methods
     Given I run `aruba console` interactively
     And I type "aruba_methods"
@@ -43,7 +41,6 @@ Feature: Aruba Console
     * setup_aruba
     """
 
-  @unsupported-on-platform-java
   Scenario: Has history
     Given I run `aruba console` interactively
     And I type "aruba_methods"

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -23,8 +23,7 @@ When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) do
 end
 
 When(/^I run `([^`]*)` interactively$/) do |cmd|
-  cmd = sanitize_text(cmd)
-  @interactive = run_command(cmd)
+  run_command(sanitize_text(cmd))
 end
 
 # Merge interactive and background after refactoring with event queue


### PR DESCRIPTION
## Summary

The build was broken in #656. This PR fixes that.

## Details

* Changes the annotation for the debug feature to not run it on JRuby. Running a debugger in the DebugProcess runner doesn't actually allow interacting with in on JRuby.
* Changes the annotation for some other scenarios that actually run fine on JRuby.
* Cleans up a useless assignment to `@interactive`.

## Motivation and Context

The build is currently broken in master.

## How Has This Been Tested?

The relevant scenarios were run on JRuby and MRI.

## Types of changes

- [x] Refactoring (cleanup of codebase without changing any existing functionality)
- [x] Update documentation

## Checklist:

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
