### PR TITLE
Loosen childprocess dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,8 +86,10 @@ group :development, :test do
 
   if RUBY_VERSION < '1.9.2'
     gem 'childprocess', '~> 0.6.3'
-  else
+  elsif RUBY_VERSION < '2.3.0'
     gem 'childprocess', '~> 1.0.1'
+  else
+    gem 'childprocess', '~> 2.0'
   end
 
   if RUBY_VERSION < '1.9.2'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'http://github.com/cucumber/aruba'
 
   s.add_runtime_dependency 'cucumber', '>= 1.3.19'
-  s.add_runtime_dependency 'childprocess', ['>= 0.6.3', '< 1.1.0']
+  s.add_runtime_dependency 'childprocess', ['>= 0.6.3', '< 3.0.0']
   s.add_runtime_dependency 'ffi', '~> 1.9'
   s.add_runtime_dependency 'rspec-expectations', '>= 2.99'
   s.add_runtime_dependency 'contracts', '~> 0.9'


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Allow end-users to use childproces 2.0.0 on recent Rubies

## Details

* Loosen dependency on childprocess.
* Adjust Gemfile to allow childprocess 2.0.0 on recent Rubies.

## Motivation and Context

Allows users to stay up-to-date.

## How Has This Been Tested?

Tests are run with new version 2.0.0 of childprocess on Travis CI for compatible Ruby versions.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
