### PR TITLE
Allow both 'a' and 'the' in step, as documented

### DIFF
--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -180,7 +180,7 @@ Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?be equal to file "([^"]
   end
 end
 
-Then(/^the (?:file|directory)(?: named)? "([^"]*)" should( not)? have permissions "([^"]*)"$/) do |path, negated, permissions|
+Then(/^(?:a|the) (?:file|directory)(?: named)? "([^"]*)" should( not)? have permissions "([^"]*)"$/) do |path, negated, permissions|
   if negated
     expect(path).not_to have_permissions(permissions)
   else


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Allow both 'a' and 'the' in file mode checking step, as documented in the corresponding feature file.

## Details

Updates the step regexp to allow both 'a' and 'the' at the start. So, now 'a file named ...' is properly matched.

## Motivation and Context

Oddly, on JRuby 9.2.7.0, cucumber fails on undefined steps. This made the feature for this step fail and surfaced the problem.

## How Has This Been Tested?

Nothing yet. We need to have some way to detect undefined steps better.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
