### PR TITLE
Handle announcing with DebugProcess

### DIFF
--- a/features/03_testing_frameworks/cucumber/announce_information_for_troubleshooting.feature
+++ b/features/03_testing_frameworks/cucumber/announce_information_for_troubleshooting.feature
@@ -261,3 +261,46 @@ Feature: Announce output during test run
 
     echo 'Hello World'
     """
+
+  Scenario: Announce everything
+    Given an executable named "bin/aruba-test-cli" with:
+    """bash
+    #!/usr/bin/env bash
+
+    echo 'Hello World'
+    """
+    And a file named "features/exit_status.feature" with:
+    """cucumber
+    Feature: Announce
+      @announce
+      Scenario: Run command
+        When I run `aruba-test-cli`
+        Then the exit status should be 0
+    """
+    When I run `cucumber`
+    Then the features should all pass
+    And the output should contain:
+    """
+    <<-STDOUT
+    Hello World
+
+    STDOUT
+    """
+    And the output should contain:
+    """
+    <<-STDERR
+
+    STDERR
+    """
+    And the output should contain:
+    """
+    <<-COMMAND
+    #!/usr/bin/env bash
+
+    echo 'Hello World'
+    COMMAND
+    """
+    And the output should contain:
+    """
+    <<-COMMAND FILESYSTEM STATUS
+    """

--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -58,3 +58,29 @@ Feature: Debug your command in cucumber-test-run
     => "hello"
     [2] pry(main)> exit
     """
+
+  Scenario: Can handle announcers
+    Given an executable named "bin/aruba-test-cli" with:
+    """bash
+    #!/usr/bin/env bash
+
+    exit 0
+    """
+    And a file named "features/debug.feature" with:
+    """cucumber
+    Feature: Exit status in debug environment
+
+      @debug
+      @announce
+      Scenario: Run program with debug code
+        When I run `aruba-test-cli`
+        Then the exit status should be 0
+    """
+    When I successfully run `cucumber`
+    Then the features should all pass
+    And the output should contain:
+    """
+    <<-STDOUT
+    This is the debug launcher on STDOUT. If this output is unexpected, please check your setup.
+    STDOUT
+    """

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -92,9 +92,9 @@ module Aruba
         output_format :stop_signal, proc { |p, s| format('Command will be stopped with `kill -%s %s`', s, p) }
         output_format :timeout, '# %s-timeout: %s seconds'
         output_format :wait_time, '# %s: %s seconds'
-        # rubocop:disable Metrics/LineLength
-        output_format :command_filesystem_status, proc { |status| format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS", Aruba.platform.simple_table(status.to_h, sort: false)) }
-        # rubocop:enable Metrics/LineLength
+        output_format :command_filesystem_status, proc { |status|
+          format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS",
+                 Aruba.platform.simple_table(status.to_h, sort: false)) }
       end
 
       def output_format(channel, string = '%s', &block)

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -171,13 +171,18 @@ module Aruba
 
         return unless activated?(channel)
 
-        message = if block_given?
-                    the_output_format.call(yield)
-                  else
-                    the_output_format.call(*args)
-                  end
-        message += "\n"
-        message = colorizer.cyan(message)
+        begin
+          if block_given?
+            value = yield
+            args << value
+          end
+
+          message = the_output_format.call(*args)
+          message += "\n"
+          message = colorizer.cyan(message)
+        rescue NotImplementedError => e
+          message = "Error fetching announced value for #{channel}: #{e.message}"
+        end
 
         announcer.announce(message)
 

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -39,7 +39,7 @@ module Aruba
 
       # Output pid of process
       def pid
-        'No implemented'
+        raise NotImplementedError
       end
 
       # Output stderr and stdout
@@ -48,39 +48,39 @@ module Aruba
       end
 
       def write(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def stdin(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def stdout(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def stderr(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def close_io(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def send_signal(*)
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def filesystem_status
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def content
-        NotImplementedError
+        raise NotImplementedError
       end
 
       def wait
-        NotImplementedError
+        raise NotImplementedError
       end
 
       # Restart a command

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -36,11 +36,11 @@ module Aruba
       runtime.event_bus.register(
         :command_started,
         proc do |event|
-          runtime.announcer.announce :command, event.entity.commandline
-          runtime.announcer.announce :timeout, 'exit', event.entity.exit_timeout
-          runtime.announcer.announce :timeout, 'io wait', event.entity.io_wait_timeout
-          runtime.announcer.announce :wait_time, 'startup wait time', event.entity.startup_wait_time
-          runtime.announcer.announce :full_environment, event.entity.environment
+          runtime.announcer.announce(:command) { event.entity.commandline }
+          runtime.announcer.announce(:timeout, 'exit') { event.entity.exit_timeout }
+          runtime.announcer.announce(:timeout, 'io wait') { event.entity.io_wait_timeout }
+          runtime.announcer.announce(:wait_time, 'startup wait time') { event.entity.startup_wait_time }
+          runtime.announcer.announce(:full_environment) { event.entity.environment }
         end
       )
 


### PR DESCRIPTION
## Summary

Handle announcing with the DebugProcess runner.

## Details

The DebugProcess runner does not implement all methods used by the announcer (and the same goes for the InProcess runner). Catch the resulting NotImplementedError exceptions and print an appropriate message.

## Motivation and Context

Fixes issue #563. 

## How Has This Been Tested?

A cucumber scenario was added.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
