### PR TITLE
Refactor: Uncouple some of aruba's step definition code

### DIFF
--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -120,14 +120,7 @@ end
 
 ## the stderr should contain "hello"
 Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)? "([^"]*)"$/) do |channel, negated, exactly, expected|
-  combined_output = case channel.to_sym
-                    when :output
-                      all_output
-                    when :stderr
-                      all_stderr
-                    when :stdout
-                      all_stdout
-                    end
+  combined_output = send("all_#{channel}")
 
   output_string_matcher = if exactly
                             :an_output_string_being_eq
@@ -170,14 +163,7 @@ end
 
 ## the stderr should contain exactly:
 Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)?:$/) do |channel, negated, exactly, expected|
-  combined_output = case channel.to_sym
-                    when :output
-                      all_output
-                    when :stderr
-                      all_stderr
-                    when :stdout
-                      all_stdout
-                    end
+  combined_output = send("all_#{channel}")
 
   output_string_matcher = if exactly
                             :an_output_string_being_eq
@@ -330,8 +316,6 @@ Then(/^(?:the )?(output|stderr|stdout) should not contain anything$/) do |channe
               :have_output_on_stderr
             when :stdout
               :have_output_on_stdout
-            else
-              fail ArgumentError, %(Invalid channel "#{channel}" chosen. Only "output", "stdout" and "stderr" are supported.)
             end
 
   expect(all_commands).to include_an_object send(matcher, be_nil.or(be_empty))
@@ -346,9 +330,9 @@ Then(/^(?:the )?(output|stdout|stderr) should( not)? contain all of these lines:
       :have_output_on_stderr
     when :stdout
       :have_output_on_stdout
-    else
-      fail ArgumentError, %(Invalid channel "#{channel}" chosen. Only "output", "stdout" and "stderr" are supported.)
     end
+
+    # TODO: This isn't actually using the above. It's hardcoded to use have_output only
 
     if negated
       expect(all_commands).not_to include_an_object have_output an_output_string_including(expected)

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -161,8 +161,8 @@ Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exa
   end
 end
 
-## the stderr should contain exactly:
-Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)?:$/) do |channel, negated, exactly, expected|
+## the stderr should not contain exactly:
+Then(/^(?:the )?(output|stderr|stdout) should not contain( exactly)?:$/) do |channel, exactly, expected|
   combined_output = send("all_#{channel}")
 
   output_string_matcher = if exactly
@@ -171,15 +171,24 @@ Then(/^(?:the )?(output|stderr|stdout) should( not)? contain( exactly)?:$/) do |
                             :an_output_string_including
                           end
 
-  if negated
-    expect(combined_output).not_to send(output_string_matcher, expected)
-  else
-    expect(combined_output).to send(output_string_matcher, expected)
-  end
+  expect(combined_output).not_to send(output_string_matcher, expected)
 end
 
-## the stderr from "echo -n 'Hello'" should contain exactly:
-Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exactly)?:$/) do |channel, cmd, negated, exactly, expected|
+## the stderr should contain exactly:
+Then(/^(?:the )?(output|stderr|stdout) should contain( exactly)?:$/) do |channel, exactly, expected|
+  combined_output = send("all_#{channel}")
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  expect(combined_output).to send(output_string_matcher, expected)
+end
+
+## the stderr from "echo -n 'Hello'" should not contain exactly:
+Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should not contain( exactly)?:$/) do |channel, cmd, exactly, expected|
   matcher = case channel.to_sym
             when :output
               :have_output
@@ -197,11 +206,29 @@ Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should( not)? contain( exa
                             :an_output_string_including
                           end
 
-  if negated
-    expect(command).not_to send(matcher, send(output_string_matcher, expected))
-  else
-    expect(command).to send(matcher, send(output_string_matcher, expected))
-  end
+  expect(command).not_to send(matcher, send(output_string_matcher, expected))
+end
+
+## the stderr from "echo -n 'Hello'" should contain exactly:
+Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should contain( exactly)?:$/) do |channel, cmd, exactly, expected|
+  matcher = case channel.to_sym
+            when :output
+              :have_output
+            when :stderr
+              :have_output_on_stderr
+            when :stdout
+              :have_output_on_stdout
+            end
+
+  command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
+
+  output_string_matcher = if exactly
+                            :an_output_string_being_eq
+                          else
+                            :an_output_string_including
+                          end
+
+  expect(command).to send(matcher, send(output_string_matcher, expected))
 end
 
 # "the output should match" allows regex in the partial_output, if
@@ -244,7 +271,7 @@ Then(/^the exit status should( not)? be (\d+)$/) do |negated, exit_status|
   end
 end
 
-Then(/^it should( not)? (pass|fail) with "(.*?)"$/) do |negated, pass_fail, expected|
+Then(/^it should not (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
   last_command_started.stop
 
   if pass_fail == 'pass'
@@ -253,14 +280,10 @@ Then(/^it should( not)? (pass|fail) with "(.*?)"$/) do |negated, pass_fail, expe
     expect(last_command_stopped).not_to be_successfully_executed
   end
 
-  if negated
-    expect(last_command_stopped).not_to have_output an_output_string_including(expected)
-  else
-    expect(last_command_stopped).to have_output an_output_string_including(expected)
-  end
+  expect(last_command_stopped).not_to have_output an_output_string_including(expected)
 end
 
-Then(/^it should( not)? (pass|fail) with:$/) do |negated, pass_fail, expected|
+Then(/^it should (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
   last_command_started.stop
 
   if pass_fail == 'pass'
@@ -269,14 +292,10 @@ Then(/^it should( not)? (pass|fail) with:$/) do |negated, pass_fail, expected|
     expect(last_command_stopped).not_to be_successfully_executed
   end
 
-  if negated
-    expect(last_command_stopped).not_to have_output an_output_string_including(expected)
-  else
-    expect(last_command_stopped).to have_output an_output_string_including(expected)
-  end
+  expect(last_command_stopped).to have_output an_output_string_including(expected)
 end
 
-Then(/^it should( not)? (pass|fail) with exactly:$/) do |negated, pass_fail, expected|
+Then(/^it should not (pass|fail) with:$/) do |pass_fail, expected|
   last_command_started.stop
 
   if pass_fail == 'pass'
@@ -285,14 +304,10 @@ Then(/^it should( not)? (pass|fail) with exactly:$/) do |negated, pass_fail, exp
     expect(last_command_stopped).not_to be_successfully_executed
   end
 
-  if negated
-    expect(last_command_stopped).not_to have_output an_output_string_eq(expected)
-  else
-    expect(last_command_stopped).to have_output an_output_string_being_eq(expected)
-  end
+  expect(last_command_stopped).not_to have_output an_output_string_including(expected)
 end
 
-Then(/^it should( not)? (pass|fail) (?:with regexp?|matching):$/) do |negated, pass_fail, expected|
+Then(/^it should (pass|fail) with:$/) do |pass_fail, expected|
   last_command_started.stop
 
   if pass_fail == 'pass'
@@ -301,11 +316,55 @@ Then(/^it should( not)? (pass|fail) (?:with regexp?|matching):$/) do |negated, p
     expect(last_command_stopped).not_to be_successfully_executed
   end
 
-  if negated
-    expect(last_command_stopped).not_to have_output an_output_string_matching(expected)
+  expect(last_command_stopped).to have_output an_output_string_including(expected)
+end
+
+Then(/^it should not (pass|fail) with exactly:$/) do |pass_fail, expected|
+  last_command_started.stop
+
+  if pass_fail == 'pass'
+    expect(last_command_stopped).to be_successfully_executed
   else
-    expect(last_command_stopped).to have_output an_output_string_matching(expected)
+    expect(last_command_stopped).not_to be_successfully_executed
   end
+
+  expect(last_command_stopped).not_to have_output an_output_string_eq(expected)
+end
+
+Then(/^it should (pass|fail) with exactly:$/) do |pass_fail, expected|
+  last_command_started.stop
+
+  if pass_fail == 'pass'
+    expect(last_command_stopped).to be_successfully_executed
+  else
+    expect(last_command_stopped).not_to be_successfully_executed
+  end
+
+  expect(last_command_stopped).to have_output an_output_string_being_eq(expected)
+end
+
+Then(/^it should not (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|
+  last_command_started.stop
+
+  if pass_fail == 'pass'
+    expect(last_command_stopped).to be_successfully_executed
+  else
+    expect(last_command_stopped).not_to be_successfully_executed
+  end
+
+  expect(last_command_stopped).not_to have_output an_output_string_matching(expected)
+end
+
+Then(/^it should (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|
+  last_command_started.stop
+
+  if pass_fail == 'pass'
+    expect(last_command_stopped).to be_successfully_executed
+  else
+    expect(last_command_stopped).not_to be_successfully_executed
+  end
+
+  expect(last_command_stopped).to have_output an_output_string_matching(expected)
 end
 
 Then(/^(?:the )?(output|stderr|stdout) should not contain anything$/) do |channel|

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -88,21 +88,19 @@ Then(/^the following files should (not )?exist:$/) do |negated, files|
   end
 end
 
-Then(/^(?:a|the) (file|directory)(?: named)? "([^"]*)" should (not )?exist(?: anymore)?$/) do |directory_or_file, path, expect_match|
-  if directory_or_file == 'file'
-    if expect_match
-      expect(path).not_to be_an_existing_file
-    else
-      expect(path).to be_an_existing_file
-    end
-  elsif directory_or_file == 'directory'
-    if expect_match
-      expect(path).not_to be_an_existing_directory
-    else
-      expect(path).to be_an_existing_directory
-    end
+Then(/^(?:a|the) file(?: named)? "([^"]*)" should (not )?exist(?: anymore)?$/) do |path, expect_match|
+  if expect_match
+    expect(path).not_to be_an_existing_file
   else
-    fail ArgumentError, %("#{directory_or_file}" can only be "directory" or "file".)
+    expect(path).to be_an_existing_file
+  end
+end
+
+Then(/^(?:a|the) directory(?: named)? "([^"]*)" should (not )?exist(?: anymore)?$/) do |path, expect_match|
+  if expect_match
+    expect(path).not_to be_an_existing_directory
+  else
+    expect(path).to be_an_existing_directory
   end
 end
 

--- a/lib/aruba/cucumber/testing_frameworks.rb
+++ b/lib/aruba/cucumber/testing_frameworks.rb
@@ -48,7 +48,7 @@ Then /^the spec(?:s)? should not(?: all)? pass(?: with (\d+) failures?)?$/ do |c
 end
 
 # RSpec
-Then /^the spec(?:s)? should(?: all)? pass(?: with (\d+) failures?)?$/ do |_count_failures|
+Then /^the spec(?:s)? should all pass$/ do
   step 'the output should contain "0 failures"'
   step 'the exit status should be 0'
 end
@@ -89,7 +89,7 @@ Then /^the tests(?:s)? should not(?: all)? pass(?: with (\d+) failures?)?$/ do |
 end
 
 # Minitest
-Then /^the tests(?:s)? should(?: all)? pass(?: with (\d+) failures?)?$/ do |_count_failures|
+Then /^the tests(?:s)? should all pass$/ do
   step 'the output should contain "0 errors"'
   step 'the exit status should be 0'
 end

--- a/lib/aruba/cucumber/testing_frameworks.rb
+++ b/lib/aruba/cucumber/testing_frameworks.rb
@@ -1,25 +1,33 @@
 # Cucumber
-Then /^the feature(?:s)? should( not)?(?: all)? pass$/ do |negated|
-  if negated
-    step 'the output should contain " failed)"'
-    step 'the exit status should be 1'
+Then /^the feature(?:s)? should not(?: all)? pass$/ do
+  step 'the output should contain " failed)"'
+  step 'the exit status should be 1'
+end
+
+# Cucumber
+Then /^the feature(?:s)? should(?: all)? pass$/ do
+  step 'the output should not contain " failed)"'
+  step 'the output should not contain " undefined)"'
+  step 'the exit status should be 0'
+end
+
+# Cucumber
+Then /^the feature(?:s)? should not(?: all)? pass with( regex)?:$/ do |regex, string|
+  step 'the output should contain " failed)"'
+  step 'the exit status should be 1'
+
+  if regex
+    step "the output should match %r<#{string}>"
   else
-    step 'the output should not contain " failed)"'
-    step 'the output should not contain " undefined)"'
-    step 'the exit status should be 0'
+    step 'the output should contain:', string
   end
 end
 
 # Cucumber
-Then /^the feature(?:s)? should( not)?(?: all)? pass with( regex)?:$/ do |negated, regex, string|
-  if negated
-    step 'the output should contain " failed)"'
-    step 'the exit status should be 1'
-  else
-    step 'the output should not contain " failed)"'
-    step 'the output should not contain " undefined)"'
-    step 'the exit status should be 0'
-  end
+Then /^the feature(?:s)? should(?: all)? pass with( regex)?:$/ do |regex, string|
+  step 'the output should not contain " failed)"'
+  step 'the output should not contain " undefined)"'
+  step 'the exit status should be 0'
 
   if regex
     step "the output should match %r<#{string}>"
@@ -29,30 +37,38 @@ Then /^the feature(?:s)? should( not)?(?: all)? pass with( regex)?:$/ do |negate
 end
 
 # RSpec
-Then /^the spec(?:s)? should( not)?(?: all)? pass(?: with (\d+) failures?)?$/ do |negated, count_failures|
-  if negated
-    if count_failures.nil?
-      step 'the output should not contain "0 failures"'
-    else
-      step %(the output should contain "#{count_failures} failures")
-    end
-
-    step 'the exit status should be 1'
-  else
-    step 'the output should contain "0 failures"'
-    step 'the exit status should be 0'
-  end
-end
-
-# RSpec
-Then /^the spec(?:s)? should( not)?(?: all)? pass with( regex)?:$/ do |negated, regex, string|
-  if negated
+Then /^the spec(?:s)? should not(?: all)? pass(?: with (\d+) failures?)?$/ do |count_failures|
+  if count_failures.nil?
     step 'the output should not contain "0 failures"'
-    step 'the exit status should be 1'
   else
-    step 'the output should contain "0 failures"'
-    step 'the exit status should be 0'
+    step %(the output should contain "#{count_failures} failures")
   end
+
+  step 'the exit status should be 1'
+end
+
+# RSpec
+Then /^the spec(?:s)? should(?: all)? pass(?: with (\d+) failures?)?$/ do |_count_failures|
+  step 'the output should contain "0 failures"'
+  step 'the exit status should be 0'
+end
+
+# RSpec
+Then /^the spec(?:s)? should not(?: all)? pass with( regex)?:$/ do |regex, string|
+  step 'the output should not contain "0 failures"'
+  step 'the exit status should be 1'
+
+  if regex
+    step "the output should match %r<#{string}>"
+  else
+    step 'the output should contain:', string
+  end
+end
+
+# RSpec
+Then /^the spec(?:s)? should(?: all)? pass with( regex)?:$/ do |regex, string|
+  step 'the output should contain "0 failures"'
+  step 'the exit status should be 0'
 
   if regex
     step "the output should match %r<#{string}>"
@@ -62,30 +78,38 @@ Then /^the spec(?:s)? should( not)?(?: all)? pass with( regex)?:$/ do |negated, 
 end
 
 # Minitest
-Then /^the tests(?:s)? should( not)?(?: all)? pass(?: with (\d+) failures?)?$/ do |negated, count_failures|
-  if negated
-    if count_failures.nil?
-      step 'the output should not contain "0 errors"'
-    else
-      step %(the output should contain "#{count_failures} errors")
-    end
-
-    step 'the exit status should be 1'
+Then /^the tests(?:s)? should not(?: all)? pass(?: with (\d+) failures?)?$/ do |count_failures|
+  if count_failures.nil?
+    step 'the output should not contain "0 errors"'
   else
-    step 'the output should contain "0 errors"'
-    step 'the exit status should be 0'
+    step %(the output should contain "#{count_failures} errors")
+  end
+
+  step 'the exit status should be 1'
+end
+
+# Minitest
+Then /^the tests(?:s)? should(?: all)? pass(?: with (\d+) failures?)?$/ do |_count_failures|
+  step 'the output should contain "0 errors"'
+  step 'the exit status should be 0'
+end
+
+# Minitest
+Then /^the test(?:s)? should not(?: all)? pass with( regex)?:$/ do |regex, string|
+  step 'the output should contain "0 errors"'
+  step 'the exit status should be 1'
+
+  if regex
+    step "the output should match %r<#{string}>"
+  else
+    step 'the output should contain:', string
   end
 end
 
 # Minitest
-Then /^the test(?:s)? should( not)?(?: all)? pass with( regex)?:$/ do |negated, regex, string|
-  if negated
-    step 'the output should contain "0 errors"'
-    step 'the exit status should be 1'
-  else
-    step 'the output should not contain "0 errors"'
-    step 'the exit status should be 0'
-  end
+Then /^the test(?:s)? should(?: all)? pass with( regex)?:$/ do |regex, string|
+  step 'the output should not contain "0 errors"'
+  step 'the exit status should be 0'
 
   if regex
     step "the output should match %r<#{string}>"


### PR DESCRIPTION
## Summary

Partially fix up the highly coupled / split steps in aruba

## Details

Where a step had 4/5/6 block params, I've opted to duplicate the cukes but reduce complexity. I've not done them all, but done sufficiently enough to improve the codebase

## Motivation and Context

Partially fixes https://github.com/cucumber/aruba/issues/640

## How Has This Been Tested?

CI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
