### PR TITLE
Use trusty distribution on Travis CI (still branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+# In order to install old Rubies, we need to use old Ubuntu distribution.
+dist: trusty
 sudo: false
 language: ruby
 script: script/test


### PR DESCRIPTION
## Summary

Use Ubuntu trusty so old Rubies can be installed. May help with the JRuby failures, too.

## Details

Travis configuration update taken from https://github.com/rspec/rspec-core/blob/8e3ce245a78c8c55eeda0bc5928f68731a2fa206/.travis.yml#L5

## Motivation and Context

Failing builds

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
