### PR TITLE
Update JRuby and build environment on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-# Use old Ubuntu distribution to avoid JRuby issues
-dist: trusty
 language: ruby
 script: bundle exec rake test
 before_install:
@@ -37,7 +35,6 @@ jobs:
       os: linux
     - rvm: jruby-9.2.6.0
       os: osx
-      env: JAVA_OPTS="--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/javax.crypto=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --illegal-access=warn"
       script: bundle exec rake spec
     - stage: lint
       script: bundle exec rake lint
@@ -61,3 +58,14 @@ env:
     # JRUBY_OPTS, but JRuby 9 does not support C extensions at all
     # so it issues warning that will mess up the stderr checks.
     - JRUBY_OPTS="--dev --debug"
+    - JAVA_OPTS="
+        --add-opens java.base/java.io=ALL-UNNAMED
+        --add-opens java.base/java.lang=ALL-UNNAMED
+        --add-opens java.base/java.util=ALL-UNNAMED
+        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+        --add-opens java.base/java.security.cert=ALL-UNNAMED
+        --add-opens java.base/java.security=ALL-UNNAMED
+        --add-opens java.base/javax.crypto=ALL-UNNAMED
+        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+        --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+        --illegal-access=warn"

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,7 @@ env:
   global:
     - secure: l8uznA5K4K9mZ1krmP3lTMD8WcJ32qGxFOR3jubKHcOBSLB4xSzU2aIqjyJdO+rLzebkwamhJc8pGSIWOUDQYvFiX7splK+uEkbBJ5huAhXtLF4Qgl86bCWbEXYzN7rvn0DQfpJAovyFMNRMnfo70XhwqWzFsaYa7Z0YbqYsJE4=
     - JAVA_OPTS="
+        --add-opens java.base/sun.nio.ch=org.jruby.dist
         --add-opens java.base/java.io=ALL-UNNAMED
         --add-opens java.base/java.lang=ALL-UNNAMED
         --add-opens java.base/java.util=ALL-UNNAMED

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ jobs:
       os: linux
     - rvm: jruby-9.1
       os: linux
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.8.0
       os: linux
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.8.0
       os: osx
       script: bundle exec rake spec
     - stage: lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ branches:
 env:
   global:
     - secure: l8uznA5K4K9mZ1krmP3lTMD8WcJ32qGxFOR3jubKHcOBSLB4xSzU2aIqjyJdO+rLzebkwamhJc8pGSIWOUDQYvFiX7splK+uEkbBJ5huAhXtLF4Qgl86bCWbEXYzN7rvn0DQfpJAovyFMNRMnfo70XhwqWzFsaYa7Z0YbqYsJE4=
-    # Travis by default also have "-Dcext.enabled=false" set in
-    # JRUBY_OPTS, but JRuby 9 does not support C extensions at all
-    # so it issues warning that will mess up the stderr checks.
-    - JRUBY_OPTS="--dev --debug"
     - JAVA_OPTS="
         --add-opens java.base/java.io=ALL-UNNAMED
         --add-opens java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Use latest JRuby and Ubuntu in Travis build

## Details

* Remove pinning of Ubuntu distribution
* Always supply JAVA_OPTS to avoid errors/warnings about opens, and update it with latest needed additions.
* Remove outdated override for JRUBY_OPTS

## Motivation and Context

We were testing on 9.2.6 because 9.2.7 broke scenario skipping in Cucumber. Now that 9.2.8 is out we should be able to safely move to that.

## How Has This Been Tested?

Needed options were tested locally by running the specs. Travis will do its thing.