### PR TITLE
Bump JRuby 9.2 build version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ jobs:
       os: linux
     - rvm: jruby-9.1
       os: linux
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.8.0
       os: linux
-    - rvm: jruby-9.2.6.0
+    - rvm: jruby-9.2.8.0
       os: osx
       env: JAVA_OPTS="--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/javax.crypto=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --illegal-access=warn"
       script: bundle exec rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,17 @@ jobs:
       os: linux
     - rvm: jruby-9.2.8.0
       os: osx
-      env: JAVA_OPTS="--add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/javax.crypto=ALL-UNNAMED --add-opens java.base/java.security.cert=ALL-UNNAMED --add-opens java.base/java.security=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --illegal-access=warn"
+      env: JAVA_OPTS="
+        --add-opens java.base/java.io=ALL-UNNAMED
+        --add-opens java.base/java.lang=ALL-UNNAMED
+        --add-opens java.base/java.util=ALL-UNNAMED
+        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+        --add-opens java.base/java.security.cert=ALL-UNNAMED
+        --add-opens java.base/java.security=ALL-UNNAMED
+        --add-opens java.base/javax.crypto=ALL-UNNAMED
+        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+        --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+        --illegal-access=warn"
       script: bundle exec rake spec
     - stage: lint
       script: bundle exec rake lint


### PR DESCRIPTION
## Summary

Use latest JRuby in Travis build

## Details

Bump JRuby version to 9.2.8.0 for the Linux and OSX builds.

## Motivation and Context

We were testing on 9.2.6 because 9.2.7 broke scenario skipping in Cucumber. Now that 9.2.8 is out we should be able to safely move to that.

I broke this out from #670 since setting the JAVA_OPTS correctly turns out to be more difficult than I anticipated.

## How Has This Been Tested?

Travis will do its thing.