### PR TITLE
Suppress keyward argument warnings in Ruby 2.7

### DIFF
--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -113,7 +113,7 @@ module Aruba
       def rm(paths, options = {})
         paths = Array(paths).map { |p| ::File.expand_path(p) }
 
-        FileUtils.rm_r(paths, options)
+        FileUtils.rm_r(paths, **options)
       end
 
       # Get current working directory
@@ -132,7 +132,7 @@ module Aruba
 
       # Touch file, directory
       def touch(args, options)
-        FileUtils.touch(args, options)
+        FileUtils.touch(args, **options)
       end
 
       # Copy file/directory
@@ -147,7 +147,7 @@ module Aruba
 
       # Change mode of file/directory
       def chmod(mode, args, options)
-        FileUtils.chmod_R(mode, args, options)
+        FileUtils.chmod_R(mode, args, **options)
       end
 
       # Exists and is file


### PR DESCRIPTION
This PR suppresses the following keyward argument warnings when using Ruby 2.7.

```console
% ruby -v
ruby 2.7.0dev (2019-09-12T15:35:29Z master 69acf40b45) [x86_64-darwin17]
% bundle exec rake

(snip)

/Users/koic/src/github.com/cucumber/aruba/lib/aruba/platforms/unix_platform.rb:116:
warning: The last argument is used as the keyword parameter
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:605:
warning: for `rm_r' defined here
/Users/koic/src/github.com/cucumber/aruba/lib/aruba/platforms/unix_platform.rb:135:
warning: The last argument is used as the keywo
rd parameter
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:1120:
warning: for `touch' defined here
./Users/koic/src/github.com/cucumber/aruba/lib/aruba/platforms/unix_platform.rb:150:
warning: The last argument is used as the keyword parameter
/Users/koic/.rbenv/versions/2.7.0-dev/lib/ruby/2.7.0/fileutils.rb:1012:
warning: for `chmod_R' defined here
```

cf. https://bugs.ruby-lang.org/issues/14183
