### PR TITLE
Update supported set of rubies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
     - tmp/**/*
     - vendor/**/*
   DisplayCopNames: true
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 
 # Use older RuboCop default
 Style/PercentLiteralDelimiters:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ jobs:
       os: linux
     - rvm: ruby-head
       os: osx
+    - rvm: 2.7.0
+      os: linux
+    - rvm: 2.7.0
+      os: osx
     - rvm: 2.6.5
       os: linux
     - rvm: 2.6.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,13 +23,7 @@ jobs:
       os: linux
     - rvm: 2.4.6
       os: osx
-    - rvm: 2.3.8
-      os: linux
-    - rvm: 2.3.8
-      os: osx
-    - rvm: 2.3.0
-      os: linux
-    - rvm: jruby-9.1
+    - rvm: 2.4.0
       os: linux
     - rvm: jruby-9.2.8.0
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 script: bundle exec rake test
-before_install:
-  - gem install bundler -v '< 2'
 bundler_args: --without debug
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ jobs:
       os: linux
     - rvm: ruby-head
       os: osx
-    - rvm: 2.6.3
+    - rvm: 2.6.5
       os: linux
-    - rvm: 2.6.3
+    - rvm: 2.6.5
       os: osx
-    - rvm: 2.5.5
+    - rvm: 2.5.7
       os: linux
-    - rvm: 2.5.5
+    - rvm: 2.5.7
       os: osx
-    - rvm: 2.4.6
+    - rvm: 2.4.9
       os: linux
-    - rvm: 2.4.6
+    - rvm: 2.4.9
       os: osx
     - rvm: 2.4.0
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,21 +11,21 @@ jobs:
       os: linux
     - rvm: ruby-head
       os: osx
-    - rvm: 2.7.0
+    - rvm: 2.7
       os: linux
-    - rvm: 2.7.0
+    - rvm: 2.7
       os: osx
-    - rvm: 2.6.5
+    - rvm: 2.6
       os: linux
-    - rvm: 2.6.5
+    - rvm: 2.6
       os: osx
-    - rvm: 2.5.7
+    - rvm: 2.5
       os: linux
-    - rvm: 2.5.7
+    - rvm: 2.5
       os: osx
-    - rvm: 2.4.9
+    - rvm: 2.4
       os: linux
-    - rvm: 2.4.9
+    - rvm: 2.4
       os: osx
     - rvm: 2.4.0
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-# Use old Ubuntu distribution to avoid JRuby issues
-dist: trusty
 language: ruby
 script: bundle exec rake test
 before_install:
@@ -37,17 +35,6 @@ jobs:
       os: linux
     - rvm: jruby-9.2.8.0
       os: osx
-      env: JAVA_OPTS="
-        --add-opens java.base/java.io=ALL-UNNAMED
-        --add-opens java.base/java.lang=ALL-UNNAMED
-        --add-opens java.base/java.util=ALL-UNNAMED
-        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-        --add-opens java.base/java.security.cert=ALL-UNNAMED
-        --add-opens java.base/java.security=ALL-UNNAMED
-        --add-opens java.base/javax.crypto=ALL-UNNAMED
-        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-        --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
-        --illegal-access=warn"
       script: bundle exec rake spec
     - stage: lint
       script: bundle exec rake lint
@@ -71,3 +58,14 @@ env:
     # JRUBY_OPTS, but JRuby 9 does not support C extensions at all
     # so it issues warning that will mess up the stderr checks.
     - JRUBY_OPTS="--dev --debug"
+    - JAVA_OPTS="
+        --add-opens java.base/java.io=ALL-UNNAMED
+        --add-opens java.base/java.lang=ALL-UNNAMED
+        --add-opens java.base/java.util=ALL-UNNAMED
+        --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+        --add-opens java.base/java.security.cert=ALL-UNNAMED
+        --add-opens java.base/java.security=ALL-UNNAMED
+        --add-opens java.base/javax.crypto=ALL-UNNAMED
+        --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+        --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+        --illegal-access=warn"

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,10 +54,6 @@ branches:
 env:
   global:
     - secure: l8uznA5K4K9mZ1krmP3lTMD8WcJ32qGxFOR3jubKHcOBSLB4xSzU2aIqjyJdO+rLzebkwamhJc8pGSIWOUDQYvFiX7splK+uEkbBJ5huAhXtLF4Qgl86bCWbEXYzN7rvn0DQfpJAovyFMNRMnfo70XhwqWzFsaYa7Z0YbqYsJE4=
-    # Travis by default also have "-Dcext.enabled=false" set in
-    # JRUBY_OPTS, but JRuby 9 does not support C extensions at all
-    # so it issues warning that will mess up the stderr checks.
-    - JRUBY_OPTS="--dev --debug"
     - JAVA_OPTS="
         --add-opens java.base/java.io=ALL-UNNAMED
         --add-opens java.base/java.lang=ALL-UNNAMED

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,4 +27,4 @@ environment:
     - ruby_version: '24'
     - ruby_version: '25'
     - ruby_version: '26'
-    - ruby_version: '27'
+    # Note: ruby version 2.7 is not available as of 2019-12-31

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ test_script:
 
 environment:
   matrix:
-    - ruby_version: '23'
     - ruby_version: '24'
     - ruby_version: '25'
     - ruby_version: '26'
+    - ruby_version: '27'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -33,7 +33,7 @@ to make testing commandline applications meaningful, easy and fun.'
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'
 
   spec.rubygems_version = '>= 1.6.1'
-  spec.required_ruby_version = '>= 2.3'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
@@ -95,7 +95,7 @@ Feature: Check exit status of commands
     """
     Feature: Failing program
       Scenario: Run command
-        Given the default aruba exit timeout is 0.2 seconds
+        Given the default aruba exit timeout is 0.3 seconds
         When I successfully run `aruba-test-cli`
     """
     When I run `cucumber`
@@ -112,7 +112,7 @@ Feature: Check exit status of commands
     Feature: Failing program
       Scenario: Run command
         Given the default aruba exit timeout is 0 seconds
-        When I successfully run `aruba-test-cli` for up to 0.2 seconds
+        When I successfully run `aruba-test-cli` for up to 0.3 seconds
     """
     When I run `cucumber`
     Then the features should all pass

--- a/features/04_aruba_api/command/read_stderr_of_command.feature
+++ b/features/04_aruba_api/command/read_stderr_of_command.feature
@@ -37,7 +37,7 @@ Feature: Access STDERR of command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.2 do
+    RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.3 do
       before(:each) { run_command('aruba-test-cli') }
       it { expect(last_command_started.stderr).to start_with 'Hello' }
     end

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -111,7 +111,7 @@ Feature: Run command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.2 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.3 do
       before do
         run_command('aruba-test-cli')
         last_command_started.send_signal 'HUP'
@@ -139,7 +139,7 @@ Feature: Run command
     #!/usr/bin/env bash
 
     function do_some_work {
-      sleep 0.2
+      sleep 0.1
       echo "Hello, Aruba here"
     }
 
@@ -284,7 +284,7 @@ Feature: Run command
 
     RSpec.describe 'Run command', type: :aruba do
       before do
-        run_command 'aruba-test-cli1', exit_timeout: 0.3
+        run_command 'aruba-test-cli1', exit_timeout: 0.4
         run_command 'aruba-test-cli2', exit_timeout: 0.1
       end
 

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -115,7 +115,7 @@ Feature: Run command in a simpler fashion
     #!/usr/bin/env bash
 
     function do_some_work {
-      sleep 0.2
+      sleep 0.1
       echo "Hello, Aruba here"
     }
 

--- a/features/06_use_aruba_cli/open_console.feature
+++ b/features/06_use_aruba_cli/open_console.feature
@@ -41,9 +41,12 @@ Feature: Aruba Console
     * setup_aruba
     """
 
-  Scenario: Has history
+  Scenario: Has its own history file
     Given I run `aruba console` interactively
-    And I type "aruba_methods"
+    And I type "IRB.conf[:HISTORY_FILE]"
     And I type "exit"
     When I close the stdin stream
-    Then the file "~/.aruba_history" should exist
+    Then the output should contain:
+    """
+    ~/.aruba_history
+    """

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -136,13 +136,13 @@ module Aruba
       end
 
       # Copy file/directory
-      def cp(args, options)
-        FileUtils.cp_r(args, options)
+      def cp(src, dest)
+        FileUtils.cp_r(src, dest)
       end
 
       # Move file/directory
-      def mv(args, options)
-        FileUtils.mv(args, options)
+      def mv(src, dest)
+        FileUtils.mv(src, dest)
       end
 
       # Change mode of file/directory

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -204,7 +204,11 @@ module Aruba
             # ... and set the exit status
             wait
           else
-            @process.stop
+            begin
+              @process.stop
+            rescue Errno::EPERM # This can occur on MacOS
+              nil
+            end
           end
         end
 
@@ -212,9 +216,6 @@ module Aruba
   
         @stdout_cache = read_temporary_output_file @stdout_file
         @stderr_cache = read_temporary_output_file @stderr_file
-
-        # @stdout_file = nil
-        # @stderr_file = nil
 
         @started = false
 


### PR DESCRIPTION
## Summary

Drop support for Ruby 2.3 in master, so Aruba 1.0.0 will target 2.4+

## Details

Updates build set on Travis, and sets minimum supported version in gemspec and RuboCop config.

## Motivation and Context

Ruby 2.3 has been deprecated for a long time, we can't get the JRuby 9.1 build working on Travis' Xenial environment, and even 2.4 is nearing its end-of-life.

## How Has This Been Tested?

Travis will run it!

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
