### PR TITLE
Fix cucumber deprecations

### DIFF
--- a/cucumber.yml
+++ b/cucumber.yml
@@ -1,6 +1,6 @@
 <%
-std_opts = "--format pretty --color --exclude features/fixtures --require features --tags ~@unsupported-on"
-ignore_opts = '--tags ~@ignore'
+std_opts = "--format pretty --color --exclude features/fixtures --require features --tags 'not @unsupported-on'"
+ignore_opts = "--tags 'not @ignore'"
 %>
-default: <%= std_opts %> --tags ~@wip <%= ignore_opts %>
+default: <%= std_opts %> --tags 'not @wip' <%= ignore_opts %>
 wip: <%= std_opts %> --wip --tags @wip:3 <%= ignore_opts %>


### PR DESCRIPTION
## Summary

This PR fixes several cucumber deprecations.

## Details

In particular,

```
Deprecated: Found tags option '~@unsupported-on'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tags option '~@wip'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
Deprecated: Found tags option '~@ignore'. Support for '~@tag' will be removed from the next release of Cucumber. Please use 'not @tag' instead.
```

## Motivation and Context

Warnings are annoying and can get things broken in the future.

## How Has This Been Tested?

Running aruba's tests.
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [ ] Update documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
