### PR TITLE
Fix travis.yml lint task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,14 +33,8 @@ RSpec::Core::RakeTask.new
 namespace :lint do
   desc 'Lint our .travis.yml'
   task :travis do
-    begin
-      require 'travis/yaml'
-
-      puts 'Linting .travis.yml ... No output is good!'
-      Travis::Yaml.parse! File.read('.travis.yml')
-    rescue LoadError => e
-      $stderr.puts "You ruby is not supported for linting the .travis.yml: #{e.message}"
-    end
+    puts 'Linting .travis.yml ...'
+    sh 'travis lint'
   end
 
   desc 'Lint our code with "rubocop"'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -37,7 +37,7 @@ to make testing commandline applications meaningful, easy and fun.'
   spec.add_development_dependency 'rubocop', '~> 0.78.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'travis-yaml', '~> 0.2.0'
+  spec.add_development_dependency 'travis', '~> 1.8'
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'
 
   spec.rubygems_version = '>= 1.6.1'


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

The previous library being used seems abandoned and not really working.


## Details

Before:

```console
$ bundle exec rake lint:travis
Linting .travis.yml ... No output is good!
.travis.yml: unexpected key "jobs", dropping
```

After:

```console
$ bundle exec rake lint:travis
Linting .travis.yml ...
travis lint
Hooray, .travis.yml looks valid :)
```