### PR TITLE
Remove unneeded appveyor step

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,6 @@ install:
   - gem --version
   - bundler --version
   - bundle install
-  - cinst ansicon
 
 test_script:
   - bundle exec rake spec --trace


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Remove an uneeded appveyor step.

## Details

The appveyor script always installs `ansicon` (ANSI control sequences library).

This step can fail sometimes, so removing it should make the build more reliable and faster.

## Motivation and Context

I created this PR because [this appveyor build](https://ci.appveyor.com/project/cucumberbdd/aruba/builds/29844043/job/p2vvugowi47p35wx) failed because of this unnecessary step.