### PR TITLE
Update build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 script: bundle exec rake test
-bundler_args: --without debug
+cache: bundler
 
 jobs:
   include:
@@ -27,9 +27,9 @@ jobs:
       os: osx
     - rvm: 2.4.0
       os: linux
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2
       os: linux
-    - rvm: jruby-9.2.8.0
+    - rvm: jruby-9.2
       os: osx
       script: bundle exec rake spec
     - stage: lint
@@ -43,7 +43,6 @@ jobs:
 branches:
   only:
     - master
-    - still
 
 # notifications:
 #   slack: cucumberbdd:oQFVhzsx4R94KWmjlejAJYnM

--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,7 @@ gemspec
 # Load local Gemfile
 load File.expand_path('Gemfile.local', __dir__) if File.file? File.expand_path('Gemfile.local', __dir__)
 
-# Debug aruba
-group :debug do
-  unless RUBY_PLATFORM.include?('java')
-    gem 'byebug', '~> 11.0'
-    gem 'pry-byebug', '~> 3.4'
-  end
+unless RUBY_PLATFORM.include?('java')
+  gem 'byebug', '~> 11.0'
+  gem 'pry-byebug', '~> 3.4'
 end


### PR DESCRIPTION
* Remove debug group since bundler's --without option is deprecated
* Build on latest jruby 9.2
* Remove old stale branch from branch list
