### PR TITLE
Clean up linting and fix environment nesting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,6 @@ Aruba's Rakefile provides the following linting tasks
 bundle exec rake lint                         # Run all linters
 bundle exec rake lint:coding_guidelines       # Lint our code with "rubocop"
 bundle exec rake lint:licenses                # Check for relevant licenses in project
-bundle exec rake lint:travis                  # Lint our .travis.yml
 ```
 
 ### Building and installing your local Aruba version

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ Bundler.setup
 task default: %w(spec cucumber cucumber:wip lint)
 
 desc 'Run all linters.'
-task lint: %w(lint:travis lint:coding_guidelines lint:licenses)
+task lint: %w(lint:coding_guidelines lint:licenses)
 
 desc 'Run the whole test suite.'
 task test: %w(spec cucumber cucumber:wip)
@@ -31,12 +31,6 @@ end
 RSpec::Core::RakeTask.new
 
 namespace :lint do
-  desc 'Lint our .travis.yml'
-  task :travis do
-    puts 'Linting .travis.yml ...'
-    sh 'travis lint'
-  end
-
   desc 'Lint our code with "rubocop"'
   task :coding_guidelines do
     sh 'bundle exec rubocop --fail-level E'

--- a/Rakefile
+++ b/Rakefile
@@ -33,7 +33,7 @@ RSpec::Core::RakeTask.new
 namespace :lint do
   desc 'Lint our code with "rubocop"'
   task :coding_guidelines do
-    sh 'bundle exec rubocop --fail-level E'
+    sh 'bundle exec rubocop'
   end
 
   desc 'Check for relevant licenses in project'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -37,7 +37,6 @@ to make testing commandline applications meaningful, easy and fun.'
   spec.add_development_dependency 'rubocop', '~> 0.78.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'simplecov', '~> 0.17.1'
-  spec.add_development_dependency 'travis', '~> 1.8'
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'
 
   spec.rubygems_version = '>= 1.6.1'

--- a/lib/aruba/platforms/unix_environment_variables.rb
+++ b/lib/aruba/platforms/unix_environment_variables.rb
@@ -188,11 +188,11 @@ module Aruba
         value
       end
 
-      def nest(&block)
-        old_actions = actions
-        block.call(self)
+      def nest
+        old_actions = @actions.dup
+        yield(self)
       ensure
-        actions = old_actions
+        @actions = old_actions
       end
 
       def self.hash_from_env

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -262,6 +262,17 @@ RSpec.describe Aruba::Api::Core do
       expect(ENV[variable]).to eq '2'
     end
 
+    it 'forgets passed argument when called again' do
+      variable = 'THIS_IS_A_ENV_VAR'
+
+      @aruba.with_environment variable => 2 do
+      end
+
+      @aruba.with_environment do
+        expect(ENV[variable]).to be_nil
+      end
+    end
+
     it 'keeps values not set in argument' do
       variable = 'THIS_IS_A_ENV_VAR'
       ENV[variable] = '2'


### PR DESCRIPTION
## Summary

* Remove Travis YML linting
* Make all RuboCop warnings failures
* Fix environment nesting

## Motivation and Context

I don't want RuboCop warnings to pile up, and the Travis gem introduces a lot of outdated dependencies. Fixing the RuboCop warnings found a bug in the new environment nesting code.

## How Has This Been Tested?

The lint task was run locally, and a new spec was added.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
