### PR TITLE
Find relative commands from the current Aruba directory

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
@@ -121,7 +121,7 @@ Feature: Check exit status of commands
     Given an executable named "bin/aruba-test-cli" with:
     """
     #!/bin/bash
-    sleep 0.1
+    sleep 1
     """
     And a file named "features/exit_status.feature" with:
     """

--- a/features/03_testing_frameworks/cucumber/steps/command/run_a_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/run_a_command.feature
@@ -53,6 +53,22 @@ Feature: Run commands
     Given a file named "features/run.feature" with:
     """
     Feature: Run it
+
+    Scenario: Run command
+      Given an executable named "bin/local_cli" with:
+      \"\"\"
+      #!/bin/bash
+      exit 0
+      \"\"\"
+      When I successfully run `bin/local_cli`
+    """
+    When I run `cucumber`
+    Then the features should all pass
+
+  Scenario: Run command found in "bin"-directory which is found in the current directory
+    Given a file named "features/run.feature" with:
+    """
+    Feature: Run it
       Scenario: Run command
         Given an executable named "bin/local_cli" with:
         \"\"\"

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -23,7 +23,7 @@ Feature: Run command
   Background:
     Given I use a fixture named "cli-app"
 
-  Scenario: Existing executable
+  Scenario: Executable in the project's path 
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
@@ -41,19 +41,24 @@ Feature: Run command
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Relative path to executable
-    Given an executable named "bin/aruba-test-cli" with:
-    """bash
-    #!/bin/bash
-    exit 0
-    """
-    And a file named "spec/run_spec.rb" with:
+  Scenario: Executable in a relative path in the Aruba working directory
+    Given a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('bin/aruba-test-cli') }
-      it { expect(last_command_started).to be_successfully_executed }
+      before do
+        write_file 'bin/aruba-test-cli', <<~BASH
+          #!/bin/bash
+          exit 0
+        BASH
+        chmod 0x755, 'bin/aruba-test-cli'
+      end
+
+      it "runs the command" do
+        run_command('bin/aruba-test-cli')
+        expect(last_command_started).to be_successfully_executed
+      end
     end
     """
     When I run `rspec`

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -52,7 +52,7 @@ Feature: Run command
           #!/bin/bash
           exit 0
         BASH
-        chmod 0x755, 'bin/aruba-test-cli'
+        chmod 0o755, 'bin/aruba-test-cli'
       end
 
       it "runs the command" do

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -261,7 +261,9 @@ module Aruba
       def start_command(command)
         aruba.config.before(:command, self, command)
 
-        command.start
+        in_current_directory do
+          command.start
+        end
 
         stop_signal = command.stop_signal
         aruba.announcer.announce(:stop_signal, command.pid, stop_signal) if stop_signal

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -43,5 +43,18 @@ RSpec.describe Aruba::Api::Commands do
         expect { @aruba.run_command 'cat' }.to raise_error NotImplementedError
       end
     end
+
+    context 'when running a relative command' do
+      it 'finds the command from the test directory' do
+        @aruba.write_file 'bin/aruba-test-cli', <<~BASH
+          #!/bin/bash
+          exit 0
+        BASH
+        chmod 0o755, 'bin/aruba-test-cli'
+
+        run_command('bin/aruba-test-cli')
+        expect(last_command_started).to be_successfully_executed
+      end
+    end
   end
 end

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -45,14 +45,24 @@ RSpec.describe Aruba::Api::Commands do
     end
 
     context 'when running a relative command' do
-      it 'finds the command from the test directory' do
-        @aruba.write_file 'bin/aruba-test-cli', <<~BASH
-          #!/bin/bash
-          exit 0
-        BASH
-        chmod 0o755, 'bin/aruba-test-cli'
+      let(:cmd) { FFI::Platform.windows? ? 'bin/testcmd.bat' : 'bin/testcmd' }
 
-        run_command('bin/aruba-test-cli')
+      before do
+        if FFI::Platform.windows?
+          @aruba.write_file cmd, <<~BAT
+            exit 0
+          BAT
+        else
+          @aruba.write_file cmd, <<~BASH
+            #!/bin/bash
+            exit 0
+          BASH
+          chmod 0o755, cmd
+        end
+      end
+
+      it 'finds the command from the test directory' do
+        run_command(cmd)
         expect(last_command_started).to be_successfully_executed
       end
     end


### PR DESCRIPTION
## Summary

Find relative commands from the current Aruba directory

## Details

In an Arabu spec or scenario, files are created relative to the current Aruba directory. When creating an executable in that way, it should be possible to run that executable using the same relative path.

This change means that executables in the project under test can no longer be find using the relative path from the project directory. They should be added to the path. This is done automatically by Bundler.

Technically this is accomplished by doing the command lookup inside an `in_current_directory` block.

## Motivation and Context

Fixes #552. 

## How Has This Been Tested?

Specs and cukes were added.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (cleanup of codebase without changing any existing functionality)
- [x] Update documentation

## Checklist:

- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
