### PR TITLE
Stop depending on ancient Rake in fixtures

### DIFF
--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
 end


### PR DESCRIPTION
This old version of Rake has security issues. Avoid referencing it and tripping up security scanners.

## Summary

Bump rake versions in gemspec files used for testing.

## Motivation and Context

GitHub's security scanner was complaining.

## How Has This Been Tested?

Travis ...

## Types of changes

- Bug fix (non-breaking change which fixes an issue)