### PR TITLE
Update RuboCop and correct new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,22 @@ Style/FrozenStringLiteralComment:
 Layout/LineLength:
   Max: 94
 
+# Enable new cops from RuboCop 0.80, 0.81 and 0.82
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
+
 # We only permit it in this one area which is internal code testing. Never exposed to users
 Security/Eval:
   Exclude:

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-doc', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
-  spec.add_development_dependency 'rubocop', '~> 0.79.0'
+  spec.add_development_dependency 'rubocop', '~> 0.82.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'simplecov', '~> 0.18.0'
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'

--- a/lib/aruba/platforms/unix_environment_variables.rb
+++ b/lib/aruba/platforms/unix_environment_variables.rb
@@ -9,7 +9,7 @@ module Aruba
         attr_reader :other_env, :block
 
         def initialize(other_env, &block)
-          @other_env = other_env.to_h.each_with_object({}) { |(k, v), a| a[k] = v.to_s }
+          @other_env = other_env.to_h.transform_values(&:to_s)
 
           @block = (block if block_given?)
         end

--- a/spec/aruba/api/filesystem_spec.rb
+++ b/spec/aruba/api/filesystem_spec.rb
@@ -541,7 +541,7 @@ RSpec.describe Aruba::Api::Filesystem do
             expect(full_content).to     match(/foo/)
             expect(full_content).not_to match(/zoo/)
           end
-        end . not_to raise_error
+        end.not_to raise_error
       end
 
       it "raises ExpectationNotMetError when the inner expectations don't match" do
@@ -550,7 +550,7 @@ RSpec.describe Aruba::Api::Filesystem do
             expect(full_content).to     match(/zoo/)
             expect(full_content).not_to match(/foo/)
           end
-        end . to raise_error RSpec::Expectations::ExpectationNotMetError
+        end.to raise_error RSpec::Expectations::ExpectationNotMetError
       end
     end
   end


### PR DESCRIPTION
## Summary

Update to RuboCop 0.82 and autocorrect new offenses

## Details

* Update RuboCop dependency to 0.82
* Enable new cops from RuboCop 0.80-0.82 
* Autocorrect new offenses

## Motivation and Context

Keeps stuff up-to-date.

## How Has This Been Tested?

I ran RuboCop.

## Types of changes

- Refactoring (cleanup of codebase without changing any existing functionality)