### PR TITLE
Update and loosen dependency on RuboCop

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-doc', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
-  spec.add_development_dependency 'rubocop', '~> 0.84.0'
+  spec.add_development_dependency 'rubocop', '~> 0.85'
   spec.add_development_dependency 'rubocop-performance', '~> 1.5'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.39'
   spec.add_development_dependency 'simplecov', '~> 0.18.0'


### PR DESCRIPTION
## Summary

Loosen dependency on RuboCop

## Details

Makes the dependency allow any later pre-1.0 version of RuboCop. RuboCop will not activate any new cops by default before the 1.0 release, so this should be perfectly safe.

## Motivation and Context

Don't require updating dependencies every time a new minor RuboCop release happens.

## How Has This Been Tested?

There's not much to test at the moment.

## Types of changes

- Developer experience