### PR TITLE
Update rubocop dependencies

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rake-manifest', '~> 0.1.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
-  spec.add_development_dependency 'rubocop', '~> 0.89.0'
-  spec.add_development_dependency 'rubocop-packaging', '~> 0.3.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.7.1'
+  spec.add_development_dependency 'rubocop', '~> 0.90.0'
+  spec.add_development_dependency 'rubocop-packaging', '~> 0.4.0'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.8.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.43.1'
   spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.20.0']
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'


### PR DESCRIPTION
## Summary

Update rubocop dependencies

## Details

- Update rubocop to 0.90.0
- Update rubocop-packaging to 0.4.0
- Update rubocop-performance to 1.8.0

## Motivation and Context

Keeps things up-to-date.

## How Has This Been Tested?

I ran rubocop

## Types of changes

- Update dependencies