### PR TITLE
Update development infrastructure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 jobs:
   include:
     - rvm: ruby-head
-      stage: test
       os: linux
     - rvm: ruby-head
       os: osx
@@ -29,12 +28,19 @@ jobs:
       os: linux
     - rvm: jruby-9.2
       os: linux
+      name: "Specs on JRuby 9.2 on Linux"
+      script: bundle exec rake spec
+    - rvm: jruby-9.2
+      os: linux
+      name: "Cucumber scenarios on JRuby 9.2 on Linux"
+      script: bundle exec rake cucumber
     - rvm: jruby-9.2
       os: osx
+      name: "Specs on JRuby 9.2 on OS X"
       script: bundle exec rake spec
-    - stage: lint
+    - rvm: 2.7.1
       script: bundle exec rake lint
-      rvm: 2.6.3
+      name: "Run linters"
       os: linux
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
## Summary

Update to the development infrastructure to reduce repetitive work and waiting

## Details

- Configure Dependabot, so dependency updates are done mostly automatically
- Restructure Travis build tasks to reduce waiting

## Motivation and Context

Making pull requests just to keep the dependencies updated is boring, so let's make the cloud do it. Also, the sooner Travis is done building the better.

## How Has This Been Tested?

We'll know if it works once Travis does its thing

## Types of changes

- Developer experience improvement