### PR TITLE
Update matcher specs for changed RSpec failure message

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry-doc', '~> 1.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rake-manifest', '~> 0.1.0'
-  spec.add_development_dependency 'rspec', '~> 3.6'
+  spec.add_development_dependency 'rspec', '~> 3.10.0'
   spec.add_development_dependency 'rubocop', '~> 0.93.0'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.8.1'

--- a/spec/aruba/matchers/collection_spec.rb
+++ b/spec/aruba/matchers/collection_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Collection Matchers' do
             expected [14, "a"] to include an object be odd
 
                object at index 0 failed to match:
-                  expected `14.odd?` to return true, got false
+                  expected `14.odd?` to be truthy, got false
 
                object at index 1 failed to match:
                   expected "a" to respond to `odd?`
@@ -38,7 +38,7 @@ RSpec.describe 'Collection Matchers' do
       it 'skips boiler plate if only one candidate object is given' do
         only_one = [14]
         expect { expect(only_one).to include_an_object(be_odd) }
-          .to fail_with 'expected `14.odd?` to return true, got false'
+          .to fail_with 'expected `14.odd?` to be truthy, got false'
       end
     end
 


### PR DESCRIPTION
## Summary

Update matcher specs for changed RSpec failure message.

## Details

RSpec 3.10 chnages some failure messages. Require this version explicitly and update the expected messages in the relevant specs.

## Motivation and Context

Specs started failing unexpectedly.

## How Has This Been Tested?

Ran the full suite.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)