### PR TITLE
Update RuboCop depenencies and fix new offenses

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -35,10 +35,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rake-manifest', '~> 0.1.0'
   spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.93.0'
+  spec.add_development_dependency 'rubocop', '~> 1.2.0'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.8.1'
-  spec.add_development_dependency 'rubocop-rspec', '~> 1.43.1'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.0.0'
   spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.20.0']
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'
 

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -133,7 +133,7 @@ module Aruba
     #
     # @yield
     #   The code block which should be run. This is a configure time only option
-    def before(name, context = proc {}, *args, &block)
+    def before(name, context = proc { nil }, *args, &block)
       name = format('%s_%s', 'before_', name.to_s).to_sym
 
       if block_given?
@@ -158,7 +158,7 @@ module Aruba
     #
     # @yield
     #   The code block which should be run. This is a configure time only option
-    def after(name, context = proc {}, *args, &block)
+    def after(name, context = proc { nil }, *args, &block)
       name = format('%s_%s', 'after_', name.to_s).to_sym
 
       if block_given?

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -256,6 +256,7 @@ RSpec.describe Aruba::Api::Core do
       @aruba.delete_environment_variable variable
 
       @aruba.with_environment do
+        expect(ENV[variable]).to be_nil
       end
 
       @aruba.with_environment do
@@ -268,6 +269,7 @@ RSpec.describe Aruba::Api::Core do
       variable = 'THIS_IS_A_ENV_VAR'
 
       @aruba.with_environment variable => 2 do
+        expect(ENV[variable]).to eq '2'
       end
 
       @aruba.with_environment do

--- a/spec/aruba/processes/in_process_spec.rb
+++ b/spec/aruba/processes/in_process_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe Aruba::Processes::InProcess do
     end
 
     it 'exits success' do
-      expect(run_process {}.exit_status).to eq 0
+      expect(run_process { nil }.exit_status).to eq 0
     end
 
     it 'exits with given status' do

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -60,7 +60,7 @@ describe Aruba::EventBus do
       let(:received_payload) { [] }
 
       before do
-        bus.register(event_name, proc {})
+        bus.register(event_name, proc { nil })
       end
 
       it { expect { bus.notify event_klass }.to raise_error Aruba::NoEventError }


### PR DESCRIPTION
## Summary

Update RuboCop depenencies and fix new offenses

## Details

Update `rubocop` and `rubocop-rspec` and fix `Lint/EmptyBlock` offenses.

## Motivation and Context

Keep things up-to-date. A hand-rolled pull request is needed because both dependencies need to be updated at the same time.

## How Has This Been Tested?

I ran RuboCop

## Types of changes

- Refactoring (cleanup of codebase without changing any existing functionality)
