### PR TITLE
Make Cucumber features more robust on MacOS CI runners.

### DIFF
--- a/features/02_configure_aruba/exit_timeout.feature
+++ b/features/02_configure_aruba/exit_timeout.feature
@@ -30,14 +30,14 @@ Feature: Configure timeout for command execution
     Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
-      config.exit_timeout = 0.2
+      config.exit_timeout = 1.0
     end
     """
     And a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Fast command
-        When I run `aruba-test-cli 0.1`
+        When I run `aruba-test-cli 0.5`
         Then the exit status should be 0
     """
     Then I successfully run `cucumber`
@@ -46,14 +46,14 @@ Feature: Configure timeout for command execution
     Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
-      config.exit_timeout = 0.1
+      config.exit_timeout = 0.5
     end
     """
     And a file named "features/run.feature" with:
     """
     Feature: Run it
       Scenario: Fast command
-        When I run `aruba-test-cli 0.5`
+        When I run `aruba-test-cli 2.5`
         Then the exit status should be 0
     """
     Then I run `cucumber`

--- a/features/03_testing_frameworks/cucumber/steps/command/send_signal_to_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/send_signal_to_command.feature
@@ -23,8 +23,8 @@ Feature: Send a signal to command
     And a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
-      config.startup_wait_time = 0.2
-      config.exit_timeout = 0.2
+      config.startup_wait_time = 1.0
+      config.exit_timeout = 1.0
     end
     """
 


### PR DESCRIPTION
## Summary

Make some changes to cucumber features to ensure MacOS runners succeed
in CI.

## Details

- Increase timeout values in cucumber features

## Motivation and Context

MacOS builds fail regularly. This seems to be timeout related.

## How Has This Been Tested?

The CI runners have to run to check this. More changes may be needed to
make them all pass.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)