### PR TITLE
Fix getting started with minitest framework feature

### DIFF
--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -72,7 +72,7 @@ Feature: Supported Testing Frameworks
       include Aruba::Api
 
       def setup
-        aruba_setup
+        setup_aruba
       end
 
       def test_getting_started_with_aruba

--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -75,7 +75,7 @@ Feature: Supported Testing Frameworks
         aruba_setup
       end
 
-      def getting_started_with_aruba
+      def test_getting_started_with_aruba
         file = 'file.txt'
         content = 'Hello World'
 

--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -80,7 +80,7 @@ Feature: Supported Testing Frameworks
         content = 'Hello World'
 
         write_file file, content
-        read(file).must_equal [content]
+				assert_equal read(file), [content]
       end
     end
     """

--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -80,7 +80,7 @@ Feature: Supported Testing Frameworks
         content = 'Hello World'
 
         write_file file, content
-				assert_equal read(file), [content]
+        assert_equal read(file), [content]
       end
     end
     """

--- a/features/README.md
+++ b/features/README.md
@@ -160,7 +160,7 @@ for the most up to date documentation.
      include Aruba::Api
 
      def setup
-       setup_aruba
+       aruba_setup
      end
 
      def test_getting_started_with_aruba

--- a/features/README.md
+++ b/features/README.md
@@ -160,7 +160,7 @@ for the most up to date documentation.
      include Aruba::Api
 
      def setup
-       aruba_setup
+       setup_aruba
      end
 
      def test_getting_started_with_aruba


### PR DESCRIPTION
## Summary

I followed the [Getting Started with Aruba feature](https://github.com/cucumber/aruba/blob/master/features/01_getting_started_with_aruba/supported_testing_frameworks.feature) in order to use Aruba in my Minitest build and discovered a typo in the Aruba's setup method name, and also the reason why it wasn't detected by Aruba's current build: the test method name in the feature didn't start with "test_", so it never runs.

## Details

* I add *"test_"* to the test method name
* I update the Aruba's setup call (from *aruba_setup* to *setup_aruba*)
* I use *assert_equal* instead of *#must_equal* in the test implementation to avoid [Minitest error](https://github.com/cucumber/aruba/pull/746/commits/241dec7206b14790bfac28909522f715c04f6942).