### PR TITLE
Remove superfluous :each from before hooks in RSpec examples

### DIFF
--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -45,7 +45,7 @@ Feature: Supported Testing Frameworks
       let(:file) { 'file.txt' }
       let(:content) { 'Hello World' }
 
-      before(:each) { write_file file, content }
+      before { write_file file, content }
 
       it { expect(read(file)).to eq [content] }
     end

--- a/features/02_configure_aruba/basics.feature
+++ b/features/02_configure_aruba/basics.feature
@@ -33,12 +33,12 @@ Feature: Usage of configuration
 
     RSpec.describe 'Run command', :type => :aruba do
       context 'when fast command' do
-        before(:each) { run_command('aruba-test-cli 0') }
+        before { run_command('aruba-test-cli 0') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command' do
-        before(:each) { run_command('aruba-test-cli 1') }
+        before { run_command('aruba-test-cli 1') }
         it { expect(last_command_started).not_to be_successfully_executed }
       end
     end
@@ -74,17 +74,17 @@ Feature: Usage of configuration
 
     RSpec.describe 'Run command', :type => :aruba do
       context 'when fast command' do
-        before(:each) { run_command('aruba-test-cli 0') }
+        before { run_command('aruba-test-cli 0') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command and this is known by the developer', :slow_command => true do
-        before(:each) { run_command('aruba-test-cli 1') }
+        before { run_command('aruba-test-cli 1') }
         it { expect(last_command_started).to be_successfully_executed }
       end
 
       context 'when slow command, but this might be a failure' do
-        before(:each) { run_command('aruba-test-cli 1') }
+        before { run_command('aruba-test-cli 1') }
         it { expect(last_command_started).not_to be_successfully_executed }
       end
     end

--- a/features/02_configure_aruba/command_runtime_environment.feature
+++ b/features/02_configure_aruba/command_runtime_environment.feature
@@ -27,8 +27,8 @@ Feature: Define default process environment
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=x' }
     end
@@ -48,10 +48,10 @@ Feature: Define default process environment
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', 'z' }
+      before { set_environment_variable 'LONG_LONG_VARIABLE', 'z' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=z' }
     end
@@ -71,10 +71,10 @@ Feature: Define default process environment
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'z' }
+      before { append_environment_variable 'LONG_LONG_VARIABLE', 'z' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=xz' }
     end
@@ -94,10 +94,10 @@ Feature: Define default process environment
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'z' }
+      before { prepend_environment_variable 'LONG_LONG_VARIABLE', 'z' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=zx' }
     end
@@ -117,10 +117,10 @@ Feature: Define default process environment
     end
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
+      before { delete_environment_variable 'LONG_LONG_VARIABLE' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE' }
     end

--- a/features/03_testing_frameworks/rspec/hooks/define_after_hook_for_commands.feature
+++ b/features/03_testing_frameworks/rspec/hooks/define_after_hook_for_commands.feature
@@ -30,7 +30,7 @@ Feature: After command hooks
     require 'spec_helper'
 
     RSpec.describe 'Hooks', :type => :aruba do
-      before(:each) { run_command_and_stop 'echo running' }
+      before { run_command_and_stop 'echo running' }
 
       it { expect(last_command_started.stdout.chomp).to eq 'running' }
     end

--- a/features/03_testing_frameworks/rspec/hooks/define_before_hook_for_commands.feature
+++ b/features/03_testing_frameworks/rspec/hooks/define_before_hook_for_commands.feature
@@ -32,7 +32,7 @@ Feature: before_cmd hooks
     require 'spec_helper'
 
     RSpec.describe 'Hooks', :type => :aruba do
-      before(:each) { run_command_and_stop 'echo running' }
+      before { run_command_and_stop 'echo running' }
 
       it { expect(last_command_started.stdout.chomp).to eq 'running' }
     end

--- a/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
+++ b/features/03_testing_frameworks/rspec/setup_aruba_for_rspec.feature
@@ -9,7 +9,7 @@ Feature: Getting started with RSpec and aruba
     `spec_helper.rb`. After that you only need to flag your tests with `type:
     :aruba` and some things are set up for.
 
-    The simple integration adds some `before(:each)` hooks for you:
+    The simple integration adds some `before` hooks for you:
 
       \* Setup Aruba Test directory
       \* Clear environment (ENV)
@@ -19,7 +19,7 @@ Feature: Getting started with RSpec and aruba
 
     Be careful, if you are going to use a `before(:all)` hook to set up
     files/directories. Those will be deleted by the `setup_aruba` call within
-    the `before(:each)` hook. Look for some custom integration further down the
+    the `before` hook. Look for some custom integration further down the
     documentation for a solution.
 
     Given a file named "spec/spec_helper.rb" with:
@@ -38,7 +38,7 @@ Feature: Getting started with RSpec and aruba
       context 'when write file' do
         let(:file) { 'file.txt' }
 
-        before(:each) { write_file file, 'Hello World' }
+        before { write_file file, 'Hello World' }
 
         it { expect(file).to be_an_existing_file }
         it { expect([file]).to include an_existing_file }
@@ -72,8 +72,8 @@ Feature: Getting started with RSpec and aruba
     RSpec.describe 'Custom Integration of aruba' do
       let(:file) { 'file.txt' }
 
-      before(:each) { setup_aruba }
-      before(:each) { write_file file, 'Hello World' }
+      before { setup_aruba }
+      before { write_file file, 'Hello World' }
 
       it { expect(file).to be_an_existing_file }
     end
@@ -85,13 +85,13 @@ Feature: Getting started with RSpec and aruba
 
     You can even use `aruba` within a `before(:all)` hook. But again, make sure
     that `setup_aruba` is run before you use any method of `aruba`. Using
-    `setup_aruba` both in a `before(:all)` and a `before(:each)` hook is not
+    `setup_aruba` both in a `before(:all)` and a `before` hook is not
     possible and therefore not supported:
 
     Running `setup_aruba` removes `tmp/aruba`, creates a new `tmp/aruba`, and
     makes that the working directory. Running it within a `before(:all)` hook,
     running some `aruba` method and, then running `setup_aruba` again within a
-    `before(:each)` hook, will remove the files and directories created within
+    `before` hook, will remove the files and directories created within
     the `before(:all)` hook.
 
     Given a file named "spec/spec_helper.rb" with:

--- a/features/04_aruba_api/command/find_a_started_command.feature
+++ b/features/04_aruba_api/command/find_a_started_command.feature
@@ -11,10 +11,10 @@ Feature: Find a started command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('echo hello') }
+      before { run_command('echo hello') }
       let(:command) { find_command('echo hello') }
 
-      before(:each) { stop_all_commands }
+      before { stop_all_commands }
 
       it { expect(command).to be_successfully_executed }
       it { expect(command.commandline).to eq 'echo hello' }
@@ -44,11 +44,11 @@ Feature: Find a started command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('echo hello1') }
-      before(:each) { run_command('echo hello2') }
+      before { run_command('echo hello1') }
+      before { run_command('echo hello2') }
       let(:command) { find_command('echo hello1') }
 
-      before(:each) { stop_all_commands }
+      before { stop_all_commands }
 
       it { expect(command).to be_successfully_executed }
       it { expect(command.commandline).to eq 'echo hello1' }
@@ -66,14 +66,14 @@ Feature: Find a started command
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { set_environment_variable 'ENV_VAR', '1' }
-      before(:each) { run_command('bash -c "echo -n $ENV_VAR"') }
-      before(:each) { set_environment_variable 'ENV_VAR', '2' }
-      before(:each) { run_command('bash -c "echo -n $ENV_VAR"') }
+      before { set_environment_variable 'ENV_VAR', '1' }
+      before { run_command('bash -c "echo -n $ENV_VAR"') }
+      before { set_environment_variable 'ENV_VAR', '2' }
+      before { run_command('bash -c "echo -n $ENV_VAR"') }
 
       let(:command) { find_command('bash -c "echo -n $ENV_VAR"') }
 
-      before(:each) { stop_all_commands }
+      before { stop_all_commands }
 
       it { expect(command).to be_successfully_executed }
       it { expect(command.stdout).to eq '2' }

--- a/features/04_aruba_api/command/read_stderr_of_command.feature
+++ b/features/04_aruba_api/command/read_stderr_of_command.feature
@@ -18,8 +18,8 @@ Feature: Access STDERR of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
       it { expect(last_command_started.stderr).to start_with  'Hello' }
     end
     """
@@ -38,7 +38,7 @@ Feature: Access STDERR of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.3 do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       it { expect(last_command_started.stderr).to start_with 'Hello' }
     end
     """

--- a/features/04_aruba_api/command/read_stdout_of_command.feature
+++ b/features/04_aruba_api/command/read_stdout_of_command.feature
@@ -18,8 +18,8 @@ Feature: Access STDOUT of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
       it { expect(last_command_started.stdout).to start_with  'Hello' }
     end
     """
@@ -38,7 +38,7 @@ Feature: Access STDOUT of command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.3 do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       it { expect(last_command_started.stdout).to start_with 'Hello' }
     end
     """

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -34,7 +34,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -319,7 +319,7 @@ Feature: Run command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       let!(:found_command) { find_command('aruba-test-cli') }
       it { expect { found_command.start }.to raise_error Aruba::CommandAlreadyStartedError }
     end

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -92,7 +92,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.3 do
-      before(:each) { run_command_and_stop('aruba-test-cli') }
+      before { run_command_and_stop('aruba-test-cli') }
 
       it 'runs the command with the expected results' do
         aggregate_failures do
@@ -126,7 +126,7 @@ Feature: Run command in a simpler fashion
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.3 do
-      before(:each) { run_command_and_stop('aruba-test-cli') }
+      before { run_command_and_stop('aruba-test-cli') }
 
       it 'runs the command with the expected results' do
         aggregate_failures do

--- a/features/04_aruba_api/command/send_signal_to_command.feature
+++ b/features/04_aruba_api/command/send_signal_to_command.feature
@@ -26,8 +26,8 @@ Feature: Send running command a signal
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 1, startup_wait_time: 0.2 do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { last_command_started.send_signal 'HUP' }
+      before { run_command('aruba-test-cli') }
+      before { last_command_started.send_signal 'HUP' }
       it { expect(last_command_started).to have_output /Exit/ }
     end
     """
@@ -45,7 +45,7 @@ Feature: Send running command a signal
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 1, startup_wait_time: 0.1 do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       it { expect { last_command_started.send_signal 'HUP' }.to raise_error Aruba::CommandAlreadyStoppedError, /Command "aruba-test-cli" with PID/ }
     end
     """

--- a/features/04_aruba_api/command/stop_all_commands.feature
+++ b/features/04_aruba_api/command/stop_all_commands.feature
@@ -16,10 +16,10 @@ Feature: Stop all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.3 do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
 
-      before(:each) { stop_all_commands }
+      before { stop_all_commands }
 
       it { expect(all_commands).to all be_stopped }
     end
@@ -38,11 +38,11 @@ Feature: Stop all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.2 do
-      before(:each) { @cmd1 = run_command('aruba-test-cli') }
-      before(:each) { @cmd2 = run_command('aruba-test-cli') }
-      before(:each) { @cmd3 = run_command('sleep 1') }
+      before { @cmd1 = run_command('aruba-test-cli') }
+      before { @cmd2 = run_command('aruba-test-cli') }
+      before { @cmd3 = run_command('sleep 1') }
 
-      before(:each) { stop_all_commands { |c| c.commandline == 'aruba-test-cli' } }
+      before { stop_all_commands { |c| c.commandline == 'aruba-test-cli' } }
 
       it 'only stops selected commands' do
         aggregate_failures do

--- a/features/04_aruba_api/command/stop_single_command.feature
+++ b/features/04_aruba_api/command/stop_single_command.feature
@@ -28,8 +28,8 @@ Feature: Stop command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.2 do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { last_command_started.stop }
+      before { run_command('aruba-test-cli') }
+      before { last_command_started.stop }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -53,8 +53,8 @@ Feature: Stop command
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.2 do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { find_command('aruba-test-cli').stop }
+      before { run_command('aruba-test-cli') }
+      before { find_command('aruba-test-cli').stop }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -89,7 +89,7 @@ Feature: Stop command
     end
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       it { expect(last_command_started).to be_successfully_executed }
     end
     """
@@ -124,7 +124,7 @@ Feature: Stop command
     end
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
       it { expect(last_command_started).to have_exit_status 2 }
     end
     """

--- a/features/04_aruba_api/command/terminate_all_commands.feature
+++ b/features/04_aruba_api/command/terminate_all_commands.feature
@@ -16,10 +16,10 @@ Feature: Terminate all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 5 do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
 
-      before(:each) { terminate_all_commands }
+      before { terminate_all_commands }
 
       it { expect(all_commands).to all be_stopped }
     end
@@ -38,11 +38,11 @@ Feature: Terminate all commands
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 1 do
-      before(:each) { @cmd1 = run_command('aruba-test-cli') }
-      before(:each) { @cmd2 = run_command('aruba-test-cli') }
-      before(:each) { @cmd3 = run_command('sleep 1') }
+      before { @cmd1 = run_command('aruba-test-cli') }
+      before { @cmd2 = run_command('aruba-test-cli') }
+      before { @cmd3 = run_command('sleep 1') }
 
-      before(:each) { terminate_all_commands { |c| c.commandline == 'aruba-test-cli' } }
+      before { terminate_all_commands { |c| c.commandline == 'aruba-test-cli' } }
 
       it 'only terminates selected commands' do
         aggregate_failures do

--- a/features/04_aruba_api/command/use_last_command_started.feature
+++ b/features/04_aruba_api/command/use_last_command_started.feature
@@ -9,8 +9,8 @@ Feature: Return last command started
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('echo hello') }
-      before(:each) { stop_all_commands }
+      before { run_command('echo hello') }
+      before { stop_all_commands }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started.commandline).to eq 'echo hello' }
@@ -25,10 +25,10 @@ Feature: Return last command started
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('echo hello') }
-      before(:each) { run_command('echo world') }
+      before { run_command('echo hello') }
+      before { run_command('echo world') }
 
-      before(:each) { stop_all_commands }
+      before { stop_all_commands }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started.commandline).to eq 'echo world' }

--- a/features/04_aruba_api/command/use_last_command_stopped.feature
+++ b/features/04_aruba_api/command/use_last_command_stopped.feature
@@ -9,8 +9,8 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('echo hello') }
-      before(:each) { stop_all_commands }
+      before { run_command('echo hello') }
+      before { stop_all_commands }
 
       it { expect(last_command_stopped).to be_successfully_executed }
       it { expect(last_command_stopped.commandline).to eq 'echo hello' }
@@ -25,10 +25,10 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('echo hello') }
-      before(:each) { run_command('echo world') }
+      before { run_command('echo hello') }
+      before { run_command('echo world') }
 
-      before(:each) { stop_all_commands }
+      before { stop_all_commands }
 
       it { expect(last_command_stopped).to be_successfully_executed }
       it { expect(last_command_stopped.commandline).to eq 'echo world' }
@@ -43,9 +43,9 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba do
-      before(:each) { run_command('echo hello') }
-      before(:each) { find_command('echo hello').stop }
-      before(:each) { run_command('echo world') }
+      before { run_command('echo hello') }
+      before { find_command('echo hello').stop }
+      before { run_command('echo world') }
 
       it { expect(last_command_stopped).to be_successfully_executed }
       it { expect(last_command_stopped.commandline).to eq 'echo hello' }
@@ -78,7 +78,7 @@ Feature: Return last command stopped
     require 'spec_helper'
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.2 do
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
 
       it { expect{ last_command_stopped.commandline }.to raise_error Aruba::NoCommandHasBeenStoppedError }
     end

--- a/features/04_aruba_api/core/expand_path.feature
+++ b/features/04_aruba_api/core/expand_path.feature
@@ -87,7 +87,7 @@ Feature: Expand paths with aruba
     require 'spec_helper'
 
     RSpec.describe 'Expand path', :type => :aruba do
-      before(:each) { remove('.') }
+      before { remove('.') }
 
       let(:path) { 'path/to/dir' }
 

--- a/features/04_aruba_api/environment/append_environment_variable.feature
+++ b/features/04_aruba_api/environment/append_environment_variable.feature
@@ -19,10 +19,10 @@ Feature: Append environment variable
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'a' }
+      before { append_environment_variable 'LONG_LONG_VARIABLE', 'a' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=a' }
     end
@@ -36,11 +36,11 @@ Feature: Append environment variable
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'a' }
-      before(:each) { append_environment_variable 'LONG_LONG_VARIABLE', 'b' }
+      before { append_environment_variable 'LONG_LONG_VARIABLE', 'a' }
+      before { append_environment_variable 'LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=ab' }
     end
@@ -57,10 +57,10 @@ Feature: Append environment variable
     ENV['REALLY_LONG_LONG_VARIABLE'] = 'a'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
+      before { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=ab' }
 
@@ -79,10 +79,10 @@ Feature: Append environment variable
     ENV['REALLY_LONG_LONG_VARIABLE'] = 'a'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
+      before { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         with_environment do
@@ -109,10 +109,10 @@ Feature: Append environment variable
     ENV['REALLY_LONG_LONG_VARIABLE'] = 'a'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
+      before { append_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         with_environment 'REALLY_LONG_LONG_VARIABLE' => 'a' do

--- a/features/04_aruba_api/environment/delete_environment_variable.feature
+++ b/features/04_aruba_api/environment/delete_environment_variable.feature
@@ -13,10 +13,10 @@ Feature: Delete existing environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
+      before { delete_environment_variable 'LONG_LONG_VARIABLE' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE=1' }
     end
@@ -30,11 +30,11 @@ Feature: Delete existing environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
-      before(:each) { delete_environment_variable 'LONG_LONG_VARIABLE' }
+      before { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
+      before { delete_environment_variable 'LONG_LONG_VARIABLE' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'LONG_LONG_VARIABLE' }
     end
@@ -51,10 +51,10 @@ Feature: Delete existing environment variable via API-method
     ENV['REALLY_LONG_LONG_VARIABLE'] = '1'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { delete_environment_variable 'REALLY_LONG_LONG_VARIABLE' }
+      before { delete_environment_variable 'REALLY_LONG_LONG_VARIABLE' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).not_to include 'REALLY_LONG_LONG_VARIABLE' }
     end

--- a/features/04_aruba_api/environment/prepend_environment_variable.feature
+++ b/features/04_aruba_api/environment/prepend_environment_variable.feature
@@ -19,10 +19,10 @@ Feature: Prepend environment variable
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'a' }
+      before { prepend_environment_variable 'LONG_LONG_VARIABLE', 'a' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=a' }
     end
@@ -36,11 +36,11 @@ Feature: Prepend environment variable
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'a' }
-      before(:each) { prepend_environment_variable 'LONG_LONG_VARIABLE', 'b' }
+      before { prepend_environment_variable 'LONG_LONG_VARIABLE', 'a' }
+      before { prepend_environment_variable 'LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=ba' }
     end
@@ -57,10 +57,10 @@ Feature: Prepend environment variable
     ENV['REALLY_LONG_LONG_VARIABLE'] = 'a'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
+      before { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=ba' }
 
@@ -79,10 +79,10 @@ Feature: Prepend environment variable
     ENV['REALLY_LONG_LONG_VARIABLE'] = 'a'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
+      before { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         with_environment do
@@ -109,10 +109,10 @@ Feature: Prepend environment variable
     ENV['REALLY_LONG_LONG_VARIABLE'] = 'a'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
+      before { prepend_environment_variable 'REALLY_LONG_LONG_VARIABLE', 'b' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         with_environment 'REALLY_LONG_LONG_VARIABLE' => 'a' do

--- a/features/04_aruba_api/environment/set_environment_variable.feature
+++ b/features/04_aruba_api/environment/set_environment_variable.feature
@@ -18,10 +18,10 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
+      before { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
     end
@@ -35,11 +35,11 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
-      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '2' }
+      before { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
+      before { set_environment_variable 'LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=2' }
     end
@@ -57,10 +57,10 @@ Feature: Set environment variable via API-method
     ENV['REALLY_LONG_LONG_VARIABLE'] = '1'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
+      before { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=2' }
       it { expect(ENV['REALLY_LONG_LONG_VARIABLE']).to eq '1' }
@@ -76,10 +76,10 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
+      before { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=2' }
     end
@@ -97,11 +97,11 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '1' }
-      before(:each) { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
+      before { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '1' }
+      before { ENV['REALLY_LONG_LONG_VARIABLE'] = '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
     end
@@ -121,10 +121,10 @@ Feature: Set environment variable via API-method
     ENV['REALLY_LONG_LONG_VARIABLE'] = '1'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
+      before { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         with_environment do
@@ -151,10 +151,10 @@ Feature: Set environment variable via API-method
     ENV['REALLY_LONG_LONG_VARIABLE'] = '1'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
+      before { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         with_environment 'REALLY_LONG_LONG_VARIABLE' => '3' do
@@ -178,20 +178,20 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
+      before { set_environment_variable 'LONG_LONG_VARIABLE', '1' }
 
       describe 'Method XX' do
-        before(:each) { run_command('env') }
-        before(:each) { stop_all_commands }
+        before { run_command('env') }
+        before { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
       end
 
       describe 'Method YY' do
-        before(:each) { set_environment_variable 'LONG_LONG_VARIABLE', '2' }
+        before { set_environment_variable 'LONG_LONG_VARIABLE', '2' }
 
-        before(:each) { run_command('env') }
-        before(:each) { stop_all_commands }
+        before { run_command('env') }
+        before { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=2' }
       end
@@ -208,10 +208,10 @@ Feature: Set environment variable via API-method
     ENV['REALLY_LONG_LONG_VARIABLE'] = '1'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
+      before { set_environment_variable 'REALLY_LONG_LONG_VARIABLE', '2' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it do
         begin
@@ -262,7 +262,7 @@ Feature: Set environment variable via API-method
   Scenario: Re-use `#with_environment` for multiple `RSpec`-`it`-blocks
 
     If you chose to run wrap examples via `RSpec`'s `around`-hook, make sure you
-    use `before(:context) {}` instead of `before(:each)` to set an environment
+    use `before(:context) {}` instead of `before` to set an environment
     variable. Only then the `before`-hook is run before the `around`-hook is
     run.
 
@@ -283,8 +283,8 @@ Feature: Set environment variable via API-method
 
         it { expect(ENV['REALLY_LONG_LONG_VARIABLE']).to eq '1' }
 
-        before(:each) { run_command('env') }
-        before(:each) { stop_all_commands }
+        before { run_command('env') }
+        before { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
       end
@@ -298,8 +298,8 @@ Feature: Set environment variable via API-method
 
         it { expect(ENV['LONG_LONG_VARIABLE']).to eq '2' }
 
-        before(:each) { run_command('env') }
-        before(:each) { stop_all_commands }
+        before { run_command('env') }
+        before { stop_all_commands }
 
         it { expect(last_command_started.output).to include 'REALLY_LONG_LONG_VARIABLE=1' }
       end
@@ -315,10 +315,10 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'long_LONG_VARIABLE', '1' }
+      before { set_environment_variable 'long_LONG_VARIABLE', '1' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'long_LONG_VARIABLE=1' }
     end
@@ -334,10 +334,10 @@ Feature: Set environment variable via API-method
     require 'spec_helper'
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) { set_environment_variable 'long_LONG_VARIABLE', '1' }
+      before { set_environment_variable 'long_LONG_VARIABLE', '1' }
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
     end
@@ -358,12 +358,12 @@ Feature: Set environment variable via API-method
     $LOAD_PATH <<  File.expand_path('../../lib', __FILE__)
 
     RSpec.describe 'Environment command', :type => :aruba do
-      before(:each) do
+      before do
         require 'my_library'
       end
 
-      before(:each) { run_command('env') }
-      before(:each) { stop_all_commands }
+      before { run_command('env') }
+      before { stop_all_commands }
 
       it { expect(last_command_started.output).to include 'LONG_LONG_VARIABLE=1' }
     end

--- a/features/04_aruba_api/filesystem/cd_to_directory.feature
+++ b/features/04_aruba_api/filesystem/cd_to_directory.feature
@@ -19,12 +19,12 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) do 
+      before do 
         create_directory 'new_dir.d'
         cd 'new_dir.d'
       end
 
-      before(:each) { run_command_and_stop 'pwd' }
+      before { run_command_and_stop 'pwd' }
 
       it { expect(last_command_started.output).to include 'new_dir.d' }
     end
@@ -38,8 +38,8 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) { cd 'new_dir.d' }
-      before(:each) { run_command_and_stop 'pwd' }
+      before { cd 'new_dir.d' }
+      before { run_command_and_stop 'pwd' }
 
       it { expect(last_command_started.output).to include 'new_dir.d' }
       it { expect(last_command_started).to be_executed_in_time }
@@ -54,7 +54,7 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) do
+      before do
         create_directory 'new_dir.d/subdir.d'
       end
 
@@ -78,7 +78,7 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) do
+      before do
         create_directory 'new_dir.d/subdir.d'
       end
 
@@ -105,7 +105,7 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) do
+      before do
         create_directory 'new_dir.d/subdir.d'
       end
 
@@ -129,7 +129,7 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) do
+      before do
         create_directory 'new_dir.d'
       end
 
@@ -157,7 +157,7 @@ Feature: Change current working directory
     require 'spec_helper'
 
     RSpec.describe 'cd to directory', :type => :aruba do
-      before(:each) do
+      before do
         create_directory 'new_dir.d/subdir.d'
       end
 

--- a/features/04_aruba_api/filesystem/check_existence_file_or_directory.feature
+++ b/features/04_aruba_api/filesystem/check_existence_file_or_directory.feature
@@ -15,8 +15,8 @@ Feature: Check existence of files and directories
     let(:directory) { 'dir.d' }
     let(:file) { 'file.txt' }
 
-    before(:each) { create_directory(directory) }
-    before(:each) { touch(file) }
+    before { create_directory(directory) }
+    before { touch(file) }
 
     it { expect(exist?(directory)).to be true }
     it { expect(exist?(file)).to be true }
@@ -35,8 +35,8 @@ Feature: Check existence of files and directories
       let(:directory) { 'dir.d' }
       let(:file) { 'file.txt' }
 
-      before(:each) { create_directory(directory) }
-      before(:each) { touch(file) }
+      before { create_directory(directory) }
+      before { touch(file) }
 
       it { expect(exist?(directory)).to be true }
       it { expect(exist?(file)).to be true }

--- a/features/04_aruba_api/filesystem/check_if_path_is_directory.feature
+++ b/features/04_aruba_api/filesystem/check_if_path_is_directory.feature
@@ -13,7 +13,7 @@ Feature: Check existence of directories
   RSpec.describe 'Check if directory and file exist' do
     let(:directory) { 'dir.d' }
 
-    before(:each) { create_directory(directory) }
+    before { create_directory(directory) }
 
     it { expect(directory?(directory)).to be true }
   end
@@ -29,7 +29,7 @@ Feature: Check existence of directories
 
     RSpec.describe 'Check if directory and file exist', :type => :aruba do
       let(:directory) { 'dir.d' }
-      before(:each) { create_directory(directory) }
+      before { create_directory(directory) }
 
       it { expect(directory?(directory)).to be true }
     end
@@ -44,7 +44,7 @@ Feature: Check existence of directories
 
     RSpec.describe 'Check if directory and file exist', :type => :aruba do
       let(:file) { 'file.txt' }
-      before(:each) { touch(file) }
+      before { touch(file) }
 
       it { expect(directory?(file)).to be false }
     end

--- a/features/04_aruba_api/filesystem/check_if_path_is_file.feature
+++ b/features/04_aruba_api/filesystem/check_if_path_is_file.feature
@@ -13,7 +13,7 @@ Feature: Check existence of files
   RSpec.describe 'Check if directory and file exist' do
     let(:file) { 'file.txt' }
 
-    before(:each) { touch(file) }
+    before { touch(file) }
 
     it { expect(file?(file)).to be true }
   end
@@ -30,7 +30,7 @@ Feature: Check existence of files
     RSpec.describe 'Check if directory and file exist', :type => :aruba do
       let(:file) { 'file.txt' }
 
-      before(:each) { touch(file) }
+      before { touch(file) }
 
       it { expect(file?(file)).to be true }
     end
@@ -45,7 +45,7 @@ Feature: Check existence of files
 
     RSpec.describe 'Check if directory and file exist', :type => :aruba do
       let(:directory) { 'dir.d' }
-      before(:each) { create_directory(directory) }
+      before { create_directory(directory) }
 
       it { expect(file?(directory)).to be false }
     end

--- a/features/04_aruba_api/filesystem/create_directory.feature
+++ b/features/04_aruba_api/filesystem/create_directory.feature
@@ -12,7 +12,7 @@ Feature: Create Directory
 
   RSpec.describe 'Create directory' do
     let(:directory) { 'dir.d' }
-    before(:each) { create_directory(directory) }
+    before { create_directory(directory) }
 
     it { expect(directory).to be_an_existing_directory }
   end
@@ -28,7 +28,7 @@ Feature: Create Directory
 
     RSpec.describe 'Create directory', :type => :aruba do
       let(:directory) { 'dir.d' }
-      before(:each) { create_directory(directory) }
+      before { create_directory(directory) }
 
       it { expect(directory).to be_an_existing_directory }
     end
@@ -47,8 +47,8 @@ Feature: Create Directory
     RSpec.describe 'Create directory', :type => :aruba do
       let(:directory) { 'dir.d' }
 
-      before(:each) { create_directory(directory) }
-      before(:each) { create_directory(directory) }
+      before { create_directory(directory) }
+      before { create_directory(directory) }
 
       it { expect(directory).to be_an_existing_directory }
     end

--- a/features/04_aruba_api/filesystem/move_file_or_directory.feature
+++ b/features/04_aruba_api/filesystem/move_file_or_directory.feature
@@ -15,7 +15,7 @@ Feature: Move file/directory
       let(:old_location) { 'old_dir.d' }
       let(:new_location) { 'new_dir.d' }
 
-      before(:each) do 
+      before do 
         create_directory old_location
         move old_location, new_location
       end
@@ -35,7 +35,7 @@ Feature: Move file/directory
       let(:old_location) { 'old_dir.d' }
       let(:new_location) { 'new_dir.d' }
 
-      before(:each) do 
+      before do 
         create_directory old_location
         create_directory new_location
 

--- a/features/04_aruba_api/filesystem/report_disk_usage.feature
+++ b/features/04_aruba_api/filesystem/report_disk_usage.feature
@@ -42,7 +42,7 @@ Feature: Report disk usage
     RSpec.describe 'disk usage', :type => :aruba do
       let(:file) { 'file.txt' }
 
-      before(:each) do 
+      before do 
         write_file file, 'a'
       end
 
@@ -66,7 +66,7 @@ Feature: Report disk usage
       let(:file1) { 'file1.txt' }
       let(:file2) { 'file2.txt' }
 
-      before(:each) do 
+      before do 
         write_file file1, 'a'
         write_file file2, 'a'
       end
@@ -88,7 +88,7 @@ Feature: Report disk usage
     RSpec.describe 'disk usage', :type => :aruba do
       let(:file) { 'file.txt' }
 
-      before(:each) do 
+      before do 
         write_file file, 'a'
       end
 
@@ -108,7 +108,7 @@ Feature: Report disk usage
     RSpec.describe 'disk usage', :type => :aruba do
       let(:file) { 'file.txt' }
 
-      before(:each) do 
+      before do 
         write_file file, 'a'
       end
 
@@ -128,7 +128,7 @@ Feature: Report disk usage
     RSpec.describe 'disk usage', :type => :aruba do
       let(:file) { 'file.txt' }
 
-      before(:each) do 
+      before do 
         write_file file, 'a'
       end
 
@@ -149,7 +149,7 @@ Feature: Report disk usage
       let(:file1) { 'file1.txt' }
       let(:file2) { 'file2.txt' }
 
-      before(:each) do 
+      before do 
         write_file file1, 'a' * 10_000
         write_file file2, 'a'
       end

--- a/features/04_aruba_api/filesystem/use_fixtures.feature
+++ b/features/04_aruba_api/filesystem/use_fixtures.feature
@@ -17,7 +17,7 @@ Feature: Use fixtures in your tests
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before(:each) { copy '%/song.mp3', 'file.mp3' }
+          before { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -35,8 +35,8 @@ Feature: Use fixtures in your tests
     require 'spec_helper'
 
     RSpec.describe 'My Feature', :type => :aruba do
-      before(:each) { copy '%/my_file.txt', 'new_file.txt' }
-      before(:each) { run_command 'aruba-test-cli new_file.txt' }
+      before { copy '%/my_file.txt', 'new_file.txt' }
+      before { run_command 'aruba-test-cli new_file.txt' }
 
       it { expect(last_command_started).to have_output 'Hello Aruba!' }
     end
@@ -63,7 +63,7 @@ Feature: Use fixtures in your tests
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before(:each) { copy '%/song.mp3', 'file.mp3' }
+          before { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -83,7 +83,7 @@ Feature: Use fixtures in your tests
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before(:each) { copy '%/song.mp3', 'file.mp3' }
+          before { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end
@@ -103,7 +103,7 @@ Feature: Use fixtures in your tests
     RSpec.describe 'My Feature', :type => :aruba do
       describe 'Copy file' do
         context 'when the file exists' do
-          before(:each) { copy '%/song.mp3', 'file.mp3' }
+          before { copy '%/song.mp3', 'file.mp3' }
 
           it { expect('file.mp3').to be_an_existing_file }
         end

--- a/features/04_aruba_api/text/extract_text.feature
+++ b/features/04_aruba_api/text/extract_text.feature
@@ -17,8 +17,8 @@ Feature: Extract text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(extract_text(unescape_text(last_command_started.output))).to eq "Text" }
     end
@@ -37,8 +37,8 @@ Feature: Extract text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(extract_text(unescape_text(last_command_started.output))).to eq "Text" }
     end
@@ -57,8 +57,8 @@ Feature: Extract text from output
     #   require 'spec_helper'
     #
     #   RSpec.describe 'Run command', :type => :aruba do
-    #     before(:each) { run_command('aruba-test-cli') }
-    #     before(:each) { stop_all_commands }
+    #     before { run_command('aruba-test-cli') }
+    #     before { stop_all_commands }
     #
     #     it { expect(extract_text(unescape_text(last_command_started.output))).to eq "Text" }
     #   end
@@ -77,8 +77,8 @@ Feature: Extract text from output
     #   require 'spec_helper'
     #
     #   RSpec.describe 'Run command', :type => :aruba do
-    #     before(:each) { run_command('aruba-test-cli') }
-    #     before(:each) { stop_all_commands }
+    #     before { run_command('aruba-test-cli') }
+    #     before { stop_all_commands }
     #
     #     it { expect(extract_text(unescape_text(last_command_started.output))).to eq "Text" }
     #   end

--- a/features/04_aruba_api/text/replace_variables.feature
+++ b/features/04_aruba_api/text/replace_variables.feature
@@ -22,8 +22,8 @@ Feature: Replace variables
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
  
       it { expect(replace_variables('<pid-last-command-started>')).to eq last_command_started.pid.to_s }
     end

--- a/features/04_aruba_api/text/sanitize_text.feature
+++ b/features/04_aruba_api/text/sanitize_text.feature
@@ -18,8 +18,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "text\ntext" }
     end
@@ -38,8 +38,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
     end
@@ -58,8 +58,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "text\"text" }
     end
@@ -78,8 +78,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
     end
@@ -98,8 +98,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
     end
@@ -118,8 +118,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
     end
@@ -138,8 +138,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "Text" }
     end
@@ -158,8 +158,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "Text" }
     end
@@ -178,8 +178,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :remove_ansi_escape_sequences => false do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
     end
@@ -198,8 +198,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :remove_ansi_escape_sequences => false do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "texttext" }
     end
@@ -218,8 +218,8 @@ Feature: Sanitize text from output
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba, :remove_ansi_escape_sequences => false do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(sanitize_text(last_command_started.output)).to eq "\e[31mText" }
     end

--- a/features/04_aruba_api/text/unescape_text.feature
+++ b/features/04_aruba_api/text/unescape_text.feature
@@ -17,8 +17,8 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(unescape_text(last_command_started.output)).to eq "text\ntext" }
     end
@@ -37,8 +37,8 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(unescape_text(last_command_started.output)).to eq "texttext" }
     end
@@ -57,8 +57,8 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(unescape_text(last_command_started.output)).to eq "text\"text" }
     end
@@ -77,8 +77,8 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(unescape_text(last_command_started.output)).to eq "texttext" }
     end
@@ -97,8 +97,8 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(unescape_text(last_command_started.output)).to eq "texttext" }
     end
@@ -117,8 +117,8 @@ Feature: Unescape special characters in text
     require 'spec_helper'
 
     RSpec.describe 'Run command', :type => :aruba do
-      before(:each) { run_command('aruba-test-cli') }
-      before(:each) { stop_all_commands }
+      before { run_command('aruba-test-cli') }
+      before { stop_all_commands }
 
       it { expect(unescape_text(last_command_started.output)).to eq "texttext" }
     end

--- a/features/05_use_rspec_matchers/command/check_timeouts.feature
+++ b/features/05_use_rspec_matchers/command/check_timeouts.feature
@@ -16,9 +16,9 @@ Feature: Check if a timeout occured during command execution
     require 'spec_helper'
 
     RSpec.describe 'Long running command', :type => :aruba do
-      before(:each) { aruba.config.exit_timeout = 0 }
+      before { aruba.config.exit_timeout = 0 }
 
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
 
       it { expect(last_command_started).to run_too_long }
     end
@@ -37,9 +37,9 @@ Feature: Check if a timeout occured during command execution
     require 'spec_helper'
 
     RSpec.describe 'Short running command', :type => :aruba do
-      before(:each) { aruba.config.exit_timeout = 5 }
+      before { aruba.config.exit_timeout = 5 }
 
-      before(:each) { run_command('aruba-test-cli') }
+      before { run_command('aruba-test-cli') }
 
       it { expect(last_command_started).to have_finished_in_time }
     end

--- a/features/05_use_rspec_matchers/directory/have_sub_directory.feature
+++ b/features/05_use_rspec_matchers/directory/have_sub_directory.feature
@@ -8,7 +8,7 @@ Feature: Check if directory has given sub directories
 
   RSpec.describe 'Check if directory has sub-directory', :type => :aruba do
     let(:file) { 'file.txt' }
-    before(:each) { touch(file) }
+    before { touch(file) }
 
     it { expect(file).to be_an_existing_file }
   end
@@ -26,7 +26,7 @@ Feature: Check if directory has given sub directories
       let(:directory) { 'dir.d' }
       let(:sub_directory) { 'sub-dir.d' }
 
-      before(:each) { create_directory(File.join(directory, sub_directory)) }
+      before { create_directory(File.join(directory, sub_directory)) }
 
       it { expect(directory).to have_sub_directory sub_directory }
     end
@@ -43,7 +43,7 @@ Feature: Check if directory has given sub directories
       let(:directory) { 'dir.d' }
       let(:sub_directories) { %w(sub-dir1.d sub-dir2.d) }
 
-      before(:each) do
+      before do
         sub_directories.each { |d| create_directory(File.join(directory, d)) }
       end
 
@@ -62,7 +62,7 @@ Feature: Check if directory has given sub directories
       let(:directory) { 'dir.d' }
       let(:sub_directory) { 'sub-dir.d' }
 
-      before(:each) { create_directory(directory) }
+      before { create_directory(directory) }
 
       it { expect(directory).not_to have_sub_directory sub_directory }
     end
@@ -79,7 +79,7 @@ Feature: Check if directory has given sub directories
       let(:directories) { %w(dir1.d dir2.d) }
       let(:sub_directory) { 'sub-dir.d' }
 
-      before(:each) do
+      before do
         directories.each { |d| create_directory(File.join(d, sub_directory)) }
       end
 
@@ -98,7 +98,7 @@ Feature: Check if directory has given sub directories
       let(:directories) { %w(dir1.d dir2.d) }
       let(:sub_directory) { 'sub-dir.d' }
 
-      before(:each) do
+      before do
         create_directory(File.join(directories.first, sub_directory))
       end
 

--- a/features/05_use_rspec_matchers/file/be_a_command_found_in_path.feature
+++ b/features/05_use_rspec_matchers/file/be_a_command_found_in_path.feature
@@ -8,9 +8,9 @@ Feature: Check if command can be found in PATH
 
   RSpec.describe 'Check if command can be found in PATH', :type => :aruba do
     let(:file) { 'file.sh' }
-    before(:each) { touch(file) }
-    before(:each) { chmod(0o755, file) }
-    before(:each) { prepend_environment_variable('PATH', format('%s:', expand_path('.')) }
+    before { touch(file) }
+    before { chmod(0o755, file) }
+    before { prepend_environment_variable('PATH', format('%s:', expand_path('.')) }
 
     it { expect(file).to be_an_existing_executable }
   end
@@ -27,9 +27,9 @@ Feature: Check if command can be found in PATH
     RSpec.describe 'Check if command can be found in PATH', :type => :aruba do
       let(:file) { 'file.sh' }
 
-      before(:each) { touch(file) }
-      before(:each) { chmod(0o755, file) }
-      before(:each) { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
+      before { touch(file) }
+      before { chmod(0o755, file) }
+      before { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
 
       it { expect(file).to be_a_command_found_in_path }
     end
@@ -45,7 +45,7 @@ Feature: Check if command can be found in PATH
     RSpec.describe 'Check if command can be found in PATH', :type => :aruba do
       let(:file) { 'file.sh' }
 
-      before(:each) { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
+      before { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
 
       it { expect(file).not_to be_a_command_found_in_path }
     end
@@ -61,8 +61,8 @@ Feature: Check if command can be found in PATH
     RSpec.describe 'Check if command can be found in PATH', :type => :aruba do
       let(:file) { 'file.sh' }
 
-      before(:each) { touch(file) }
-      before(:each) { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
+      before { touch(file) }
+      before { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
 
       it { expect(file).not_to be_a_command_found_in_path }
     end
@@ -85,7 +85,7 @@ Feature: Check if command can be found in PATH
         end
       end
 
-      before(:each) { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
+      before { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
 
       it { expect(files).to all be_a_command_found_in_path }
     end
@@ -106,7 +106,7 @@ Feature: Check if command can be found in PATH
         chmod(0o755, files.first)
       end
 
-      before(:each) { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
+      before { prepend_environment_variable('PATH', format('%s:', expand_path('.'))) }
 
       it { expect(files).to include a_command_found_in_path }
     end

--- a/features/05_use_rspec_matchers/file/be_existing_executable.feature
+++ b/features/05_use_rspec_matchers/file/be_existing_executable.feature
@@ -8,8 +8,8 @@ Feature: Check if path exists and is an executable file
 
   RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
     let(:file) { 'file.txt' }
-    before(:each) { touch(file) }
-    before(:each) { chmod(0o755, file) }
+    before { touch(file) }
+    before { chmod(0o755, file) }
 
     it { expect(file).to be_an_existing_executable }
   end
@@ -25,8 +25,8 @@ Feature: Check if path exists and is an executable file
 
     RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
       let(:file) { 'file.txt' }
-      before(:each) { touch(file) }
-      before(:each) { chmod(0o755, file) }
+      before { touch(file) }
+      before { chmod(0o755, file) }
 
       it { expect(file).to be_an_existing_executable }
     end

--- a/features/05_use_rspec_matchers/file/be_existing_file.feature
+++ b/features/05_use_rspec_matchers/file/be_existing_file.feature
@@ -8,7 +8,7 @@ Feature: Check if path exists and is file
 
   RSpec.describe 'Check if file exists and is file', :type => :aruba do
     let(:file) { 'file.txt' }
-    before(:each) { touch(file) }
+    before { touch(file) }
 
     it { expect(file).to be_an_existing_file }
   end
@@ -24,7 +24,7 @@ Feature: Check if path exists and is file
 
     RSpec.describe 'Check if file exists and is file', :type => :aruba do
       let(:file) { 'file.txt' }
-      before(:each) { touch(file) }
+      before { touch(file) }
       it { expect(file).to be_an_existing_file }
     end
     """

--- a/features/05_use_rspec_matchers/file/have_file_content.feature
+++ b/features/05_use_rspec_matchers/file/have_file_content.feature
@@ -11,7 +11,7 @@ Feature: Check if file has content
     let(:file) { 'file.txt' }
     let(:content) { 'Hello World' }
 
-    before(:each) { write_file(file, content) }
+    before { write_file(file, content) }
 
     it { expect(file).to have_file_content content }
   end
@@ -29,7 +29,7 @@ Feature: Check if file has content
       let(:file) { 'file.txt' }
       let(:content) { 'Hello World' }
 
-      before(:each) { write_file(file, content) }
+      before { write_file(file, content) }
 
       it { expect(file).to have_file_content content }
     end
@@ -46,7 +46,7 @@ Feature: Check if file has content
       let(:file) { 'file.txt' }
       let(:content) { 'Hello World' }
 
-      before(:each) { write_file(file, content) }
+      before { write_file(file, content) }
 
       it { expect(file).to have_file_content /Hello/ }
     end
@@ -63,7 +63,7 @@ Feature: Check if file has content
       let(:file) { 'file.txt' }
       let(:content) { 'Hello World' }
 
-      before(:each) { write_file(file, content) }
+      before { write_file(file, content) }
 
       it { expect(file).to have_file_content a_string_starting_with('Hello') }
     end
@@ -99,7 +99,7 @@ Feature: Check if file has content
       let(:files) { %w(file1.txt file2.txt) }
       let(:content) { 'Hello World' }
 
-      before(:each) { write_file(files.first, content) }
+      before { write_file(files.first, content) }
 
       it { expect(files).to include a_file_having_content content }
     end

--- a/features/05_use_rspec_matchers/file/have_file_size.feature
+++ b/features/05_use_rspec_matchers/file/have_file_size.feature
@@ -10,7 +10,7 @@ Feature: Check if path has size
     let(:file) { 'file.txt' }
     let(:size) { 1 }
 
-    before(:each) { write_fixed_size_file(file, size) }
+    before { write_fixed_size_file(file, size) }
 
     it { expect(file).to have_file_size size }
   end
@@ -28,7 +28,7 @@ Feature: Check if path has size
       let(:file) { 'file.txt' }
       let(:size) { 1 }
 
-      before(:each) { write_fixed_size_file(file, size) }
+      before { write_fixed_size_file(file, size) }
 
       it { expect(file).to have_file_size size }
     end
@@ -83,7 +83,7 @@ Feature: Check if path has size
       let(:file) { 'file.txt' }
       let(:size) { 1 }
 
-      before(:each) { write_fixed_size_file(file, size) }
+      before { write_fixed_size_file(file, size) }
 
       it { expect(file).to have_file_size 2 }
     end

--- a/features/05_use_rspec_matchers/path/be_an_absolute_path.feature
+++ b/features/05_use_rspec_matchers/path/be_an_absolute_path.feature
@@ -9,7 +9,7 @@ Feature: Check if path is absolute
 
   RSpec.describe 'Check if path is absolute', :type => :aruba do
     let(:path) { 'file.txt' }
-    before(:each) { touch(path) }
+    before { touch(path) }
 
     it { expect(path).to be_an_absolute_path }
   end

--- a/features/05_use_rspec_matchers/path/be_an_existing_path.feature
+++ b/features/05_use_rspec_matchers/path/be_an_existing_path.feature
@@ -9,7 +9,7 @@ Feature: Check if path exists
 
   RSpec.describe 'Check if path exists', :type => :aruba do
     let(:path) { 'file.txt' }
-    before(:each) { touch(path) }
+    before { touch(path) }
 
     it { expect(path).to be_an_existing_path }
   end
@@ -25,7 +25,7 @@ Feature: Check if path exists
 
     RSpec.describe 'Check if path exists', :type => :aruba do
       let(:path) { 'file.txt' }
-      before(:each) { touch(path) }
+      before { touch(path) }
       it { expect(path).to be_an_existing_path }
     end
     """
@@ -39,7 +39,7 @@ Feature: Check if path exists
 
     RSpec.describe 'Check if path exists', :type => :aruba do
       let(:path) { 'dir.d' }
-      before(:each) { create_directory(path) }
+      before { create_directory(path) }
       it { expect(path).to be_an_existing_path }
     end
     """

--- a/features/05_use_rspec_matchers/path/have_permissions.feature
+++ b/features/05_use_rspec_matchers/path/have_permissions.feature
@@ -14,8 +14,8 @@ Feature: Check if path has permissions in filesystem
       let(:file) { 'file.txt' }
       let(:permissions) { 0700 }
 
-      before(:each) { touch(file) }
-      before(:each) { chmod(permissions, file }
+      before { touch(file) }
+      before { chmod(permissions, file }
 
       it { expect(file).to have_permissions permissions }
     end
@@ -34,8 +34,8 @@ Feature: Check if path has permissions in filesystem
       let(:file) { 'file.txt' }
       let(:permissions) { 0600 }
 
-      before(:each) { touch(file) }
-      before(:each) { chmod(permissions, file) }
+      before { touch(file) }
+      before { chmod(permissions, file) }
 
       it { expect(file).to have_permissions permissions }
     end
@@ -52,8 +52,8 @@ Feature: Check if path has permissions in filesystem
       let(:directory) { 'directory.d' }
       let(:permissions) { 0700 }
 
-      before(:each) { create_directory(directory) }
-      before(:each) { chmod(permissions, directory) }
+      before { create_directory(directory) }
+      before { chmod(permissions, directory) }
 
       it { expect(directory).to have_permissions permissions }
     end

--- a/features/README.md
+++ b/features/README.md
@@ -125,8 +125,8 @@ for the most up to date documentation.
      let(:file) { 'file.txt' }
      let(:content) { 'Hello, Aruba!' }
 
-     before(:each) { write_file file, content }
-     before(:each) { run_command('aruba-test-cli file.txt') }
+     before { write_file file, content }
+     before { run_command('aruba-test-cli file.txt') }
 
      # Full string
      it { expect(last_command_started).to have_output content }


### PR DESCRIPTION
## Summary

Remove superfluous `:each` from before hooks in RSpec examples

## Details

In all the examples in the cucumber features, I replaced `before(:each)`
with `before`, because `:each` is the default.

## Motivation and Context

It is generally recommended not to use explicit `:each` and our examples
should reflect best practices.

## How Has This Been Tested?

CI

## Types of changes

- Update documentation