### PR TITLE
Disable bundler using bundler tooling (0-14-stable)

### DIFF
--- a/features/03_testing_frameworks/cucumber/disable_bunder.feature
+++ b/features/03_testing_frameworks/cucumber/disable_bunder.feature
@@ -1,11 +1,9 @@
 Feature: Disable Bundler environment
   Use the @disable-bundler tag to escape from your project's Gemfile.
 
-  Background:
-    Given I use the fixture "cli-app"
-
+  @disable-bundler
   Scenario: Clear the Bundler environment
-
+    Given I use the fixture "cli-app"
     Given a file named "features/run.feature" with:
     """
     Feature: My Feature
@@ -13,6 +11,41 @@ Feature: Disable Bundler environment
       Scenario: Check environment
         When I run `env`
         Then the output should not match /^BUNDLE_GEMFILE=/
+
+      @disable-bundler
+      Scenario: Run bundle in a fresh bundler environment
+        Given a file named "Gemfile" with:
+        \"\"\"
+        source 'https://rubygems.org'
+        \"\"\"
+        When I run `bundle`
+        Then the output should not contain "aruba"
+
+      @disable-bundler
+      Scenario: Run programs that are not in the outer bundle
+        Given a file named "Gemfile" with:
+        \"\"\"
+        source 'https://rubygems.org'
+
+        gem 'rubocop'
+        \"\"\"
+        When I run `bundle`
+        When I run `bundle exec rubocop --help`
+        Then the output should contain "Usage: rubocop"
     """
-    When I run `cucumber`
+    When I run `bundle`
+    When I run `bundle exec cucumber`
     Then the features should all pass
+
+  @disable-bundler
+  Scenario: Direct test
+    Given I use the fixture "cli-app"
+    Given a file named "Gemfile" with:
+    """
+    source 'https://rubygems.org'
+
+    gem 'parallel_tests'
+    """
+    When I successfully run `bundle`
+    When I successfully run `bundle exec parallel_rspec --help`
+    Then the output should contain "Run all tests in parallel"

--- a/fixtures/cli-app/Gemfile
+++ b/fixtures/cli-app/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Use dependencies from gemspec
+gemspec

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake'
   spec.add_development_dependency 'aruba'
 end

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.9'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'aruba'
 end

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 end

--- a/lib/aruba/api/bundler.rb
+++ b/lib/aruba/api/bundler.rb
@@ -7,8 +7,23 @@ module Aruba
 
       # Unset variables used by bundler
       def unset_bundler_env_vars
-        %w[RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH BUNDLE_GEMFILE].each do |key|
-          delete_environment_variable(key)
+        empty_env = with_environment { with_unbundled_env { ENV.to_h } }
+        aruba_env = aruba.environment.to_h
+        (aruba_env.keys - empty_env.keys).each do |key|
+          delete_environment_variable key
+        end
+        empty_env.each do |k, v|
+          set_environment_variable k, v
+        end
+      end
+
+      private
+
+      def with_unbundled_env
+        if ::Bundler.respond_to?(:with_unbundled_env)
+          ::Bundler.with_unbundled_env { yield }
+        else
+          ::Bundler.with_clean_env { yield }
         end
       end
     end


### PR DESCRIPTION
## Summary

Use Bundler's own tooling to break out of the Bundler environment, instead of just unsetting a bunch of environment variables.

## Details

Use `Bunder.with_unbundled_env` to inform us how manipulate the environment instead of guessing ourselves: We fetch the environment inside the `Bunder.with_unbundled_env` block and record the changes that were applied. Then we manipulate Aruba's environment to have the same changes.

## Motivation and Context

#699.

## How Has This Been Tested?

Let's see what TravisCI has to say ...

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
