### PR TITLE
Make disabling Bundler more robust

### DIFF
--- a/features/03_testing_frameworks/cucumber/disable_bunder.feature
+++ b/features/03_testing_frameworks/cucumber/disable_bunder.feature
@@ -1,11 +1,9 @@
 Feature: Disable Bundler environment
   Use the @disable-bundler tag to escape from your project's Gemfile.
 
-  Background:
-    Given I use the fixture "cli-app"
-
+  @disable-bundler
   Scenario: Clear the Bundler environment
-
+    Given I use the fixture "cli-app"
     Given a file named "features/run.feature" with:
     """
     Feature: My Feature
@@ -13,6 +11,41 @@ Feature: Disable Bundler environment
       Scenario: Check environment
         When I run `env`
         Then the output should not match /^BUNDLE_GEMFILE=/
+
+      @disable-bundler
+      Scenario: Run bundle in a fresh bundler environment
+        Given a file named "Gemfile" with:
+        \"\"\"
+        source 'https://rubygems.org'
+        \"\"\"
+        When I run `bundle`
+        Then the output should not contain "aruba"
+
+      @disable-bundler
+      Scenario: Run programs that are not in the outer bundle
+        Given a file named "Gemfile" with:
+        \"\"\"
+        source 'https://rubygems.org'
+
+        gem 'rubocop'
+        \"\"\"
+        When I run `bundle`
+        When I run `bundle exec rubocop --help`
+        Then the output should contain "Usage: rubocop"
     """
-    When I run `cucumber`
+    When I run `bundle`
+    When I run `bundle exec cucumber`
     Then the features should all pass
+
+  @disable-bundler
+  Scenario: Direct test
+    Given I use the fixture "cli-app"
+    Given a file named "Gemfile" with:
+    """
+    source 'https://rubygems.org'
+
+    gem 'parallel_tests'
+    """
+    When I successfully run `bundle`
+    When I successfully run `bundle exec parallel_rspec --help`
+    Then the output should contain "Run all tests in parallel"

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -91,7 +91,7 @@ Feature: Run command in a simpler fashion
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.3 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.4 do
       before { run_command_and_stop('aruba-test-cli') }
 
       it 'runs the command with the expected results' do

--- a/fixtures/cli-app/Gemfile
+++ b/fixtures/cli-app/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Use dependencies from gemspec
+gemspec

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = ['bin/aruba-test-cli']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 end

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['bin/aruba-test-cli']
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'aruba'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
 end

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.9'
-  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 end

--- a/lib/aruba/api/bundler.rb
+++ b/lib/aruba/api/bundler.rb
@@ -7,8 +7,23 @@ module Aruba
 
       # Unset variables used by bundler
       def unset_bundler_env_vars
-        %w(RUBYOPT BUNDLE_PATH BUNDLE_BIN_PATH BUNDLE_GEMFILE).each do |key|
-          delete_environment_variable(key)
+        empty_env = with_environment { with_unbundled_env { ENV.to_h } }
+        aruba_env = aruba.environment.to_h
+        (aruba_env.keys - empty_env.keys).each do |key|
+          delete_environment_variable key
+        end
+        empty_env.each do |k, v|
+          set_environment_variable k, v
+        end
+      end
+
+      private
+
+      def with_unbundled_env(&block)
+        if ::Bundler.respond_to?(:with_unbundled_env)
+          ::Bundler.with_unbundled_env(&block)
+        else
+          ::Bundler.with_clean_env(&block)
         end
       end
     end


### PR DESCRIPTION
## Summary

Use Bundler's tooling to break out of the main bundle

## Details

The `@disable_bundler` tag doesn't always work very well because it just guesses at what enironment variables to disable. Use
`Bundler.with_unbundled_env` instead to find the exact set of environment variables to change.

## Motivation and Context

Inspired by #699. While getting `keep_up` to build with GitHub Actions I found out that the simple method of unsetting the environment variables does not work in all cases. See https://github.com/mvz/keep_up/pull/40.

## How Has This Been Tested?

I ran the updated feature file.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)