### PR TITLE
Clean up hook methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ cucumber-pro.log
 
 # Temp files of yar
 .yardoc
+
+# RSpec example status
+spec/examples.txt

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -256,7 +256,7 @@ module Aruba
       end
 
       def start_command(command)
-        aruba.config.before(:command, self, command)
+        aruba.config.run_before_hook(:command, self, command)
 
         in_current_directory do
           command.start
@@ -265,7 +265,7 @@ module Aruba
         stop_signal = command.stop_signal
         aruba.announcer.announce(:stop_signal, command.pid, stop_signal) if stop_signal
 
-        aruba.config.after(:command, self, command)
+        aruba.config.run_after_hook(:command, self, command)
       end
     end
   end

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -90,8 +90,6 @@ module Aruba
     attr_accessor :local_options
     attr_writer :hooks
 
-    # attr_reader :hooks
-
     public
 
     # Create configuration
@@ -120,68 +118,68 @@ module Aruba
       obj
     end
 
-    # Define or run before-hook
+    # Define before-hook
+    #
+    # @param [Symbol, String] name
+    #   The name of the hook
+    #
+    # @yield
+    #   The code block which should be run. This is a configure time only option
+    def before(name, &block)
+      name = format('%s_%s', 'before_', name.to_s).to_sym
+      raise ArgumentError, 'A block is required' unless block
+
+      @hooks.append(name, block)
+
+      self
+    end
+
+    # Run before-hook
     #
     # @param [Symbol, String] name
     #   The name of the hook
     #
     # @param [Proc] context
-    #   The context a hook should run in. This is a runtime only option.
+    #   The context a hook should run in
     #
     # @param [Array] args
-    #   Arguments for the run of hook. This is a runtime only option.
+    #   Arguments for the run of hook
+    def run_before_hook(name, context, *args)
+      name = format('%s_%s', 'before_', name.to_s).to_sym
+
+      @hooks.execute(name, context, *args)
+    end
+
+    # Define after-hook
+    #
+    # @param [Symbol, String] name
+    #   The name of the hook
     #
     # @yield
     #   The code block which should be run. This is a configure time only option
-    def before(name, context = proc { nil }, *args, &block)
-      name = format('%s_%s', 'before_', name.to_s).to_sym
+    def after(name, &block)
+      name = format('%s_%s', 'after_', name.to_s).to_sym
+      raise ArgumentError, 'A block is required' unless block
 
-      if block
-        @hooks.append(name, block)
+      @hooks.append(name, block)
 
-        self
-      else
-        @hooks.execute(name, context, *args)
-      end
+      self
     end
 
-    # Define or run after-hook
+    # Run after-hook
     #
     # @param [Symbol, String] name
     #   The name of the hook
     #
     # @param [Proc] context
-    #   The context a hook should run in. This is a runtime only option.
+    #   The context a hook should run in
     #
     # @param [Array] args
-    #   Arguments for the run of hook. This is a runtime only option.
-    #
-    # @yield
-    #   The code block which should be run. This is a configure time only option
-    def after(name, context = proc { nil }, *args, &block)
+    #   Arguments for the run of hook
+    def run_after_hook(name, context, *args)
       name = format('%s_%s', 'after_', name.to_s).to_sym
 
-      if block
-        @hooks.append(name, block)
-
-        self
-      else
-        @hooks.execute(name, context, *args)
-      end
-    end
-
-    # Check if before-hook <name> is defined
-    def before?(name)
-      name = format('%s_%s', 'before_', name.to_s).to_sym
-
-      @hooks.exist? name
-    end
-
-    # Check if after-hook <name> is defined
-    def after?(name)
-      name = format('%s_%s', 'after_', name.to_s).to_sym
-
-      @hooks.exist? name
+      @hooks.execute(name, context, *args)
     end
 
     # Check if <name> is option

--- a/spec/aruba/jruby_spec.rb
+++ b/spec/aruba/jruby_spec.rb
@@ -24,7 +24,7 @@ describe 'Aruba JRuby Startup Helper' do
 
     it 'keeps the existing JRUBY_OPTS and JAVA_OPTS environment values' do
       # Run defined before :command hook
-      Aruba.config.before :command, self, command
+      Aruba.config.run_before_hook :command, self, command
 
       aggregate_failures do
         expect(command_environment['JRUBY_OPTS']).to eq '--1.9'
@@ -46,7 +46,7 @@ describe 'Aruba JRuby Startup Helper' do
 
     it 'updates the existing JRuby but not Java option values' do
       # Run defined before :command hook
-      Aruba.config.before :command, self, command
+      Aruba.config.run_before_hook :command, self, command
 
       aggregate_failures do
         expect(command_environment['JRUBY_OPTS']).to eq '--dev -X-C --1.9'
@@ -68,7 +68,7 @@ describe 'Aruba JRuby Startup Helper' do
 
     it 'keeps the existing JRuby and Java option values' do
       # Run defined before :command hook
-      Aruba.config.before :command, self, command
+      Aruba.config.run_before_hook :command, self, command
 
       aggregate_failures do
         expect(command_environment['JRUBY_OPTS']).to eq '--dev -X-C --1.9'

--- a/spec/support/configs/rspec.rb
+++ b/spec/support/configs/rspec.rb
@@ -6,6 +6,8 @@ RSpec.configure do |config|
 
   config.run_all_when_everything_filtered = true
 
+  config.example_status_persistence_file_path = 'spec/examples.txt'
+
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end


### PR DESCRIPTION
## Summary

Clean up hook methods

## Details

- Use separate methods for defining and running hooks
- Remove unused methods for checking if hooks are defined

## Motivation and Context

Makes the hook methods more robust by making them require the arguments
needed for the narrower context in which each of them is used.
Simplifies the code in the hook methods by having to deal with fewer
cases.

## How Has This Been Tested?

Running the tests.

## Types of changes

- Refactoring (cleanup of codebase without changing any existing functionality)