### PR TITLE
Build 0-14-stable branch on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ matrix:
 branches:
   only:
     - master
-    - still
+    - 0-14-stable
 env:
   - JRUBY_OPTS='--dev'


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Travis was set up to build only on the master and still branches, but we don't use still anymore. So instead, build on 0-14-stable.

## Details

Just changed the TravisCI config to replace still with 0-14-stable

## Motivation and Context

Let's see if we can get TravisCI to build the last few pull requests on 0-14-stable before travis-ci.org goes down.

## How Has This Been Tested?

Travis will hopefully build ...

## Types of changes

- Project support files.
