### PR TITLE
Loosen dependency on simplecov

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.9.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.0.0'
-  spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.20.0']
+  spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.21.0']
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'
 
   spec.rubygems_version = '>= 1.6.1'


### PR DESCRIPTION
## Summary

Loosen dependency on simplecov

## Motivation and Context

The dependency of simplecov is a bit hard for dependabot to update automatically.

## How Has This Been Tested?

Updated the bundle and ran the specs.

## Types of changes

- Update development infrastructure