### PR TITLE
Run rubocop only once (0-14-stable branche)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,5 +28,20 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+    - name: Run RSpec specs
+      run: bundle exec rake spec
+    - name: Run Cucumber senarios
+      run: bundle exec rake cucumber
+
+  rubocop:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - name: Run RuboCop
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,7 +45,7 @@ Metrics/LineLength:
 
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 18
+  Max: 21
 
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.

--- a/Gemfile
+++ b/Gemfile
@@ -71,12 +71,11 @@ group :development, :test do
 
   # Code Coverage
   unless RUBY_PLATFORM.include?('java')
-    gem 'simplecov', '~> 0.10' 
+    gem 'simplecov', '~> 0.10'
     if RUBY_VERSION < '2.0.0'
       gem 'json', '< 2.3.0'
     end
   end
-
 
   # Test api
   gem 'rspec', '~> 3.4'

--- a/Rakefile
+++ b/Rakefile
@@ -21,20 +21,6 @@ RSpec::Core::RakeTask.new do |spec|
   spec.rspec_opts = ['--color', '--format progress', '--warnings']
 end
 
-namespace :travis do
-  desc 'Lint travis.yml'
-  task :lint do
-    begin
-      require 'travis/yaml'
-
-      puts 'Linting .travis.yml ... No output is good!'
-      Travis::Yaml.parse! File.read('.travis.yml')
-    rescue LoadError
-      $stderr.puts 'Your ruby is not supported for linting the .travis.yml file'
-    end
-  end
-end
-
 task :rubocop do
   if RUBY_VERSION >= '2'
     sh 'bundle exec rubocop --fail-level E'
@@ -44,6 +30,6 @@ task :rubocop do
 end
 
 desc "Run tests, both RSpec and Cucumber"
-task :test => [ 'travis:lint', :rubocop, :spec, :cucumber, :cucumber_wip]
+task :test => [:spec, :cucumber, :cucumber_wip]
 
 task :default => :test

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -173,9 +173,10 @@ module Aruba
           stop_signal       = opts[:stop_signal].nil? ? aruba.config.stop_signal : opts[:stop_signal]
           startup_wait_time = opts[:startup_wait_time].nil? ? aruba.config.startup_wait_time : opts[:startup_wait_time]
         else
-          if args.size > 0
+          unless args.empty?
             Aruba.platform.deprecated(
-              "Please pass options to `#run_command` as named parameters/hash and don\'t use the old style, e.g. `#run_command('cmd', :exit_timeout => 5)`.")
+              "Please pass options to `#run_command` as named parameters/hash and don\'t use the old style, e.g. `#run_command('cmd', :exit_timeout => 5)`."
+            )
           end
 
           exit_timeout      = args[0].nil? ? aruba.config.exit_timeout : args[0]
@@ -277,7 +278,7 @@ module Aruba
           opts = args.pop
           fail_on_error = opts.delete(:fail_on_error) == true ? true : false
         else
-          if args.size > 0
+          unless args.empty?
             # rubocop:disable Metrics/LineLength
             Aruba.platform.deprecated("Please pass options to `#run_command_and_stop` as named parameters/hash and don\'t use the old style with positional parameters, NEW: e.g. `#run_command_and_stop('cmd', :exit_timeout => 5)`.")
             # rubocop:enable Metrics/LineLength

--- a/lib/aruba/api/deprecated.rb
+++ b/lib/aruba/api/deprecated.rb
@@ -285,11 +285,9 @@ module Aruba
       # @param [true,false] expect_presence
       #   Should the given paths be present (true) or absent (false)
       def check_file_presence(paths, expect_presence = true)
-        Aruba.platform.deprecated(
-          'The use of "check_file_presence" is deprecated.' \
+        Aruba.platform.deprecated('The use of "check_file_presence" is deprecated.' \
           ' Use "expect(path).to be_an_existing_file" or' \
-          ' "expect(all_paths).to all match /pattern/" instead'
-        )
+          ' "expect(all_paths).to all match /pattern/" instead')
 
         stop_all_commands
 
@@ -702,37 +700,27 @@ module Aruba
       # @deprecated
       def check_for_deprecated_variables
         if defined? @aruba_exit_timeout
-          Aruba.platform.deprecated(
-            'The use of "@aruba_exit_timeout" is deprecated.' \
-            ' Use "#aruba.config.exit_timeout = <numeric>" instead'
-          )
+          Aruba.platform.deprecated('The use of "@aruba_exit_timeout" is deprecated.' \
+            ' Use "#aruba.config.exit_timeout = <numeric>" instead')
           aruba.config.exit_timeout = @aruba_exit_timeout
         end
 
         if defined? @aruba_io_wait_seconds
-          Aruba.platform.deprecated(
-            'The use of "@aruba_io_wait_seconds" is deprecated.' \
-            ' Use "#aruba.config.io_wait_timeout = <numeric>" instead'
-          )
+          Aruba.platform.deprecated('The use of "@aruba_io_wait_seconds" is deprecated.' \
+            ' Use "#aruba.config.io_wait_timeout = <numeric>" instead')
           aruba.config.io_wait_timeout = @aruba_io_wait_seconds
         end
 
         if defined? @keep_ansi
-          Aruba.platform.deprecated(
-            'The use of "@aruba_keep_ansi" is deprecated.' \
+          Aruba.platform.deprecated('The use of "@aruba_keep_ansi" is deprecated.' \
             ' Use "#aruba.config.remove_ansi_escape_sequences = <true|false>" instead.' \
-            ' Be aware that it uses an inverted logic'
-          )
-
+            ' Be aware that it uses an inverted logic')
           aruba.config.remove_ansi_escape_sequences = false
         end
 
         if defined? @aruba_root_directory
-          Aruba.platform.deprecated(
-            'The use of "@aruba_root_directory" is deprecated.' \
-            ' Use "#aruba.config.root_directory = <string>" instead'
-          )
-
+          Aruba.platform.deprecated('The use of "@aruba_root_directory" is deprecated.' \
+            ' Use "#aruba.config.root_directory = <string>" instead')
           aruba.config.root_directory = @aruba_root_directory.to_s
         end
       end

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -212,7 +212,6 @@ module Aruba
       #   needs to be a directory
       #
       # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       def move(*args)
         args = args.flatten
         destination = args.pop
@@ -244,7 +243,6 @@ module Aruba
 
         self
       end
-      # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/CyclomaticComplexity
 
       # Create a file with the given size

--- a/lib/aruba/cucumber/deprecated.rb
+++ b/lib/aruba/cucumber/deprecated.rb
@@ -36,7 +36,6 @@ Before('@ansi') do
   aruba.config.remove_ansi_escape_sequences = false
 end
 
-
 Before '@mocked_home_directory' do
   Aruba.platform.deprecated('The use of "@mocked_home_directory" is deprecated. Use "@mocked-home-directory" instead')
 
@@ -90,4 +89,3 @@ Then(/^the mode of filesystem object "([^"]*)" should (not )?match "([^"]*)"$/) 
     expect(file).to have_permissions(permissions)
   end
 end
-

--- a/lib/aruba/matchers/base/object_formatter.rb
+++ b/lib/aruba/matchers/base/object_formatter.rb
@@ -12,7 +12,6 @@ module Aruba
         prepare_for_inspection(object).inspect
       end
 
-      # rubocop:disable MethodLength
       # rubocop:disable Metrics/CyclomaticComplexity
 
       # @private
@@ -48,7 +47,6 @@ module Aruba
         InspectableItem.new(inspection)
       end
       # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable MethodLength
 
       # @private
       def self.prepare_hash(input)

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -90,7 +90,8 @@ module Aruba
         output_format :wait_time, '# %s: %s seconds'
         output_format :command_filesystem_status, proc { |status|
           format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS",
-                 Aruba.platform.simple_table(status.to_h, :sort => false)) }
+                 Aruba.platform.simple_table(status.to_h, :sort => false))
+        }
 
         # rubocop:disable Metrics/LineLength
         if @options[:stdout]

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -126,7 +126,7 @@ module Aruba
         paths = Array(paths).map { |p| ::File.expand_path(p) }
 
         FileUtils.rm_r(paths, :force => options[:force], :noop => options[:noop],
-                       :verbose => options[:verbose], :secure => options[:secure])
+                              :verbose => options[:verbose], :secure => options[:secure])
       end
 
       # Get current working directory
@@ -146,7 +146,7 @@ module Aruba
       # Touch file, directory
       def touch(args, options)
         FileUtils.touch(args, :noop => options[:noop], :verbose => options[:verbose],
-                        :mtime => options[:mtime], :nocreate => options[:nocreate])
+                              :mtime => options[:mtime], :nocreate => options[:nocreate])
       end
 
       # Copy file/directory
@@ -162,7 +162,7 @@ module Aruba
       # Change mode of file/directory
       def chmod(mode, args, options)
         FileUtils.chmod_R(mode, args, :noop => options[:noop],
-                          :verbose => options[:verbose], :force => options[:force])
+                                      :verbose => options[:verbose], :force => options[:force])
       end
 
       # Exists and is file

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Aruba::Api::Core do
       end
 
       it 'does not touch other environment variables in the passed block' do
-        keys = ENV.keys - ['PWD', 'OLDPWD']
+        keys = ENV.keys - %w(PWD OLDPWD)
         old_values = ENV.values_at(*keys)
         @aruba.create_directory @directory_name
         @aruba.cd @directory_name do
@@ -118,7 +118,7 @@ RSpec.describe Aruba::Api::Core do
       end
 
       it 'does not touch other environment variables in the passed block' do
-        keys = ENV.keys - ['PWD', 'OLDPWD']
+        keys = ENV.keys - %w(PWD OLDPWD)
         old_values = ENV.values_at(*keys)
         @aruba.in_current_directory do
           expect(ENV.values_at(*keys)).to eq old_values


### PR DESCRIPTION
## Summary

Don't run RuboCop so much: Once is enough.

## Details

- Run RuboCop in a GitHub Actions job
- Remove RuboCop run from the TravisCI builds
- Remove travis:lint task

## Motivation and Context

Make test run faster, use as little TravisCI as possible.

## How Has This Been Tested?

Running the builds.

## Types of changes

- Dev infrastructure
