### PR TITLE
Set JRUBY_OPTS for speedier tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CUCUMBER_PUBLISH_QUIET: true
+  JRUBY_OPTS: "--dev"
 
 jobs:
   test-ubuntu:


### PR DESCRIPTION
## Summary

Set JRUBY_OPTS to `--dev` in GitHub Actions

## Motivation and Context

This setting got lost in the move from Travis CI to GitHub Actions. Setting this makes a huge difference in Aruba's case because the cucumber features launch a lot of Ruby processes.

## Types of changes

- Dev infra