### PR TITLE
Run tests on Ruby 3.0 in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,7 +18,7 @@ jobs:
   test-ubuntu:
     strategy:
       matrix:
-        ruby: [2.4.0, 2.4, 2.5, 2.6, 2.7, jruby-9.2, ruby-head]
+        ruby: [2.4.0, 2.4, 2.5, 2.6, 2.7, "3.0", jruby-9.2, ruby-head]
 
     runs-on: ubuntu-latest
 
@@ -37,7 +37,7 @@ jobs:
   test-macos:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7, "3.0"]
 
     runs-on: macos-latest
 


### PR DESCRIPTION
## Summary

Add Ruby 3.0 to the list of Rubies to test on with GitHub Actions

## Motivation and Context

Ruby 3.0 is out!