### PR TITLE
Fix JRuby support specs when using rspec-expectations 3.10.1

### DIFF
--- a/spec/aruba/jruby_spec.rb
+++ b/spec/aruba/jruby_spec.rb
@@ -35,7 +35,10 @@ describe 'Aruba JRuby Startup Helper' do
 
   context 'when running under JRuby but not on Solaris' do
     before do
-      stub_const 'RUBY_PLATFORM', 'java'
+      unless RUBY_PLATFORM == 'java'
+        stub_const 'RUBY_PLATFORM', 'java'
+        stub_const 'JRUBY_VERSION', '9.2.0.0'
+      end
       stub_const 'RbConfig::CONFIG', rb_config
 
       allow(rb_config).to receive(:[]).with('host_os').and_return('foo-os')
@@ -54,7 +57,10 @@ describe 'Aruba JRuby Startup Helper' do
 
   context 'when running under JRuby on Solaris' do
     before do
-      stub_const 'RUBY_PLATFORM', 'java'
+      unless RUBY_PLATFORM == 'java'
+        stub_const 'RUBY_PLATFORM', 'java'
+        stub_const 'JRUBY_VERSION', '9.2.0.0'
+      end
       stub_const 'RbConfig::CONFIG', rb_config
 
       allow(rb_config).to receive(:[]).with('host_os').and_return('solaris')


### PR DESCRIPTION
## Summary

Fix JRuby support specs when using rspec-expectations 3.10.1

## Details

The latest version of rspec-expectations added a check for JRUBY_VERSION to its implementation of aggregate_failures, so stub that constant as well in order to succesfully pretend to run on JRuby.

## Motivation and Context

Build failures for #764

## How Has This Been Tested?

Ran the relevant specs, watched them pass again.

## Screenshots (if appropriate):

## Types of changes

- Bug fix (non-breaking change which fixes an issue)