### PR TITLE
Speed up test suite for Aruba and its users

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,8 +48,10 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run tests
-      run: bundle exec rake
+    - name: Run specs
+      run: bundle exec rake spec
+    - name: Run cukes
+      run: bundle exec rake cucumber
 
   lint:
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -29,6 +29,8 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
+    - name: Configure bundler globally
+      run: bundle config --global path $PWD/vendor/bundle
     - name: Run specs
       run: bundle exec rake spec
     - name: Run cukes

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'childprocess', ['>= 2.0', '< 5.0']
   spec.add_runtime_dependency 'contracts', '~> 0.16.0'
   spec.add_runtime_dependency 'cucumber', ['>= 2.4', '< 6.0']
-  spec.add_runtime_dependency 'ffi', '~> 1.9'
   spec.add_runtime_dependency 'rspec-expectations', '~> 3.4'
   spec.add_runtime_dependency 'thor', '~> 1.0'
 

--- a/features/01_getting_started_with_aruba/run_commands.feature
+++ b/features/01_getting_started_with_aruba/run_commands.feature
@@ -173,34 +173,6 @@ Feature: Run commands with Aruba
     When I successfully run `cucumber`
     Then the features should all pass
 
-  @requires-java
-  Scenario: Java Program
-
-    It's even possible to compile and run Java programs with Aruba.
-
-    Given a file named "features/hello_aruba.feature" with:
-    """cucumber
-    Feature: Getting Started With Aruba
-      Scenario: First Run of Command
-        Given a file named "tmp/HelloArubaApp.java" with:
-        \"\"\"
-        class HelloArubaApp {
-          public static void main(String[] args) {
-            System.out.println("Hello, Aruba!");
-          }
-        }
-        \"\"\"
-        And I successfully run `javac tmp/HelloArubaApp.java` for up to 20 seconds
-        And I cd to "tmp/"
-        And I successfully run `java HelloArubaApp`
-        Then the output should contain:
-        \"\"\"
-        Hello, Aruba!
-        \"\"\"
-    """
-    When I successfully run `cucumber` for up to 21 seconds
-    Then the features should all pass
-
   @requires-posix-standard-tools
   Scenario: POSIX standard tools
     Given a file named "features/hello_aruba.feature" with:

--- a/features/01_getting_started_with_aruba/run_commands.feature
+++ b/features/01_getting_started_with_aruba/run_commands.feature
@@ -2,13 +2,8 @@ Feature: Run commands with Aruba
 
   As long as you've got the neccessary programs, libraries, runtime
   environments, interpreters installed, it doesn't matter in which programming
-  language your command line application is implemented. You can even use POSIX
-  standard tools like "printf".
-
-  Below you find some examples of the "Hello, Aruba!"-application implemented
-  with different programming languages and a single example for a POSIX
-  standard tool. This is NOT an exclusive list. Every command line application
-  should run with `aruba`.
+  language your command line application is implemented. You can also run any
+  program that is in your $PATH.
 
   Background:
     Given I use a fixture named "getting-started-app"
@@ -85,101 +80,6 @@ Feature: Run commands with Aruba
         puts "Hello, Aruba!"
         \"\"\"
         When I successfully run `ruby ./cli.rb`
-        Then the output should contain:
-        \"\"\"
-        Hello, Aruba!
-        \"\"\"
-    """
-    When I successfully run `cucumber`
-    Then the features should all pass
-
-  @requires-python
-  Scenario: Python Program
-    Given an executable named "bin/aruba-test-cli" with:
-    """python
-    #!/usr/bin/env python
-
-    print("Hello, Aruba!")
-    """
-    And a file named "features/hello_aruba.feature" with:
-    """
-    Feature: Getting Started With Aruba
-      Scenario: First Run of Command
-        Given I successfully run `aruba-test-cli`
-        Then the output should contain:
-        \"\"\"
-        Hello, Aruba!
-        \"\"\"
-    """
-    When I successfully run `cucumber`
-    Then the features should all pass
-
-  @requires-python
-  Scenario: Python Program via "python"
-    Given a file named "features/hello_aruba.feature" with:
-    """
-    Feature: Getting Started With Aruba
-      Scenario: First Run of Command
-        Given a file named "cli.py" with:
-        \"\"\"
-        print("Hello, Aruba!")
-        \"\"\"
-        When I successfully run `python ./cli.py`
-        Then the output should contain:
-        \"\"\"
-        Hello, Aruba!
-        \"\"\"
-    """
-    When I successfully run `cucumber`
-    Then the features should all pass
-
-  @requires-perl
-  Scenario: Perl Program
-    Given an executable named "bin/aruba-test-cli" with:
-    """perl
-    #!/usr/bin/env perl
-
-    print "Hello, Aruba!\n";
-    """
-    And a file named "features/hello_aruba.feature" with:
-    """
-    Feature: Getting Started With Aruba
-      Scenario: First Run of Command
-        Given I successfully run `aruba-test-cli`
-        Then the output should contain:
-        \"\"\"
-        Hello, Aruba!
-        \"\"\"
-    """
-    When I successfully run `cucumber`
-    Then the features should all pass
-
-  @requires-perl
-  Scenario: Perl Program via "perl"
-    Given a file named "features/hello_aruba.feature" with:
-    """
-    Feature: Getting Started With Aruba
-      Scenario: First Run of Command
-        Given a file named "cli.pl" with:
-        \"\"\"perl
-        print "Hello, Aruba!\n";
-        \"\"\"
-        When I successfully run `perl ./cli.pl`
-        Then the output should contain:
-        \"\"\"
-        Hello, Aruba!
-        \"\"\"
-    """
-    When I successfully run `cucumber`
-    Then the features should all pass
-
-  @requires-posix-standard-tools
-  Scenario: POSIX standard tools
-    Given a file named "features/hello_aruba.feature" with:
-    """
-    Feature: Getting Started With Aruba
-      Scenario: First Run of Command
-        Given I successfully run `printf "%s" "Hello, Aruba!"`
         Then the output should contain:
         \"\"\"
         Hello, Aruba!

--- a/features/02_configure_aruba/basics.feature
+++ b/features/02_configure_aruba/basics.feature
@@ -122,7 +122,7 @@ Feature: Usage of configuration
     Given a file named "features/support/aruba_config.rb" with:
     """ruby
     Aruba.configure do |config|
-      config.exit_timeout = 0.5
+      config.exit_timeout = 0.2
     end
     """
     And a file named "features/support/hooks.rb" with:
@@ -140,11 +140,11 @@ Feature: Usage of configuration
 
       @slow-command
       Scenario: Slow command known by the developer
-        When I run `aruba-test-cli 1.0`
+        When I run `aruba-test-cli 0.5`
         Then the exit status should be 0
 
       Scenario: Slow command which might be a failure
-        When I run `aruba-test-cli 1.0`
+        When I run `aruba-test-cli 0.5`
         Then the exit status should be 128
     """
     When I run `cucumber`

--- a/features/03_testing_frameworks/cucumber/disable_bundler.feature
+++ b/features/03_testing_frameworks/cucumber/disable_bundler.feature
@@ -1,7 +1,6 @@
 Feature: Disable Bundler environment
   Use the @disable-bundler tag to escape from your project's Gemfile.
 
-  @disable-bundler
   Scenario: Clear the Bundler environment
     Given I use the fixture "cli-app"
     Given a file named "features/run.feature" with:
@@ -18,34 +17,16 @@ Feature: Disable Bundler environment
         \"\"\"
         source 'https://rubygems.org'
         \"\"\"
-        When I run `bundle`
+        When I run `bundle --local`
         Then the output should not contain "aruba"
 
-      @disable-bundler
-      Scenario: Run programs that are not in the outer bundle
+      Scenario: Run bundle in the existing bundler environment
         Given a file named "Gemfile" with:
         \"\"\"
         source 'https://rubygems.org'
-
-        gem 'rubocop'
         \"\"\"
-        When I run `bundle`
-        When I run `bundle exec rubocop --help`
-        Then the output should contain "Usage: rubocop"
+        When I run `bundle --local`
+        Then the output should contain "aruba"
     """
-    When I run `bundle`
     When I run `bundle exec cucumber`
     Then the features should all pass
-
-  @disable-bundler
-  Scenario: Direct test
-    Given I use the fixture "cli-app"
-    Given a file named "Gemfile" with:
-    """
-    source 'https://rubygems.org'
-
-    gem 'parallel_tests'
-    """
-    When I successfully run `bundle`
-    When I successfully run `bundle exec parallel_rspec --help`
-    Then the output should contain "Run all tests in parallel"

--- a/features/04_aruba_api/command/terminate_all_commands.feature
+++ b/features/04_aruba_api/command/terminate_all_commands.feature
@@ -9,19 +9,22 @@ Feature: Terminate all commands
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 3
+    sleep 0.4
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 5 do
-      before { run_command('aruba-test-cli') }
-      before { run_command('aruba-test-cli') }
+    RSpec.describe 'terminating commands', type: :aruba, exit_timeout: 0.4 do
+      before do
+        run_command('aruba-test-cli')
+        run_command('aruba-test-cli')
+      end
 
-      before { terminate_all_commands }
-
-      it { expect(all_commands).to all be_stopped }
+      it 'stops all commands' do
+        terminate_all_commands
+        expect(all_commands).to all be_stopped
+      end
     end
     """
     When I run `rspec`
@@ -31,20 +34,22 @@ Feature: Terminate all commands
     Given an executable named "bin/aruba-test-cli" with:
     """bash
     #!/bin/bash
-    sleep 0.5
+    sleep 0.4
     """
     And a file named "spec/run_spec.rb" with:
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 1 do
-      before { @cmd1 = run_command('aruba-test-cli') }
-      before { @cmd2 = run_command('aruba-test-cli') }
-      before { @cmd3 = run_command('sleep 1') }
-
-      before { terminate_all_commands { |c| c.commandline == 'aruba-test-cli' } }
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.4 do
+      before do
+        @cmd1 = run_command('aruba-test-cli')
+        @cmd2 = run_command('aruba-test-cli')
+        @cmd3 = run_command('sleep 0.4')
+      end
 
       it 'only terminates selected commands' do
+        terminate_all_commands { |c| c.commandline == 'aruba-test-cli' }
+
         aggregate_failures do
           expect(@cmd1).to be_stopped
           expect(@cmd2).to be_stopped

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -37,24 +37,15 @@ Before '@requires-posix-standard-tools' do
 end
 
 Before '@requires-ruby-platform-java' do
-  # leave if java
-  next if RUBY_PLATFORM.include? 'java'
-
-  skip_this_scenario
+  skip_this_scenario unless Cucumber::JRUBY
 end
 
 Before '@unsupported-on-platform-java' do
-  # leave if not java
-  next unless RUBY_PLATFORM.include? 'java'
-
-  skip_this_scenario
+  skip_this_scenario if Cucumber::JRUBY
 end
 
 Before '@unsupported-on-platform-windows' do
-  # leave if not windows
-  next unless FFI::Platform.windows?
-
-  skip_this_scenario
+  skip_this_scenario if Cucumber::WINDOWS
 end
 
 Before '@requires-readline' do
@@ -66,15 +57,9 @@ Before '@requires-readline' do
 end
 
 Before '@unsupported-on-platform-unix' do
-  # leave if not windows
-  next unless FFI::Platform.unix?
-
-  skip_this_scenario
+  skip_this_scenario unless Cucumber::WINDOWS
 end
 
 Before '@unsupported-on-platform-mac' do
-  # leave if not windows
-  next unless FFI::Platform.mac?
-
-  skip_this_scenario
+  skip_this_scenario if Cucumber::OS_X
 end

--- a/lib/aruba/platforms/filesystem_status.rb
+++ b/lib/aruba/platforms/filesystem_status.rb
@@ -1,28 +1,34 @@
-require 'forwardable'
-
 module Aruba
   module Platforms
     # File System Status object
     #
     # This is a wrapper for File::Stat returning only a subset of information.
     class FilesystemStatus
-      METHODS = [
-        :executable?,
-        :ctime,
-        :atime,
-        :mtime,
-        :size
-      ].freeze
-
-      extend Forwardable
-
       private
 
       attr_reader :status
 
       public
 
-      def_delegators :@status, *METHODS
+      def executable?
+        status.executable?
+      end
+
+      def ctime
+        status.ctime
+      end
+
+      def atime
+        status.atime
+      end
+
+      def mtime
+        status.mtime
+      end
+
+      def size
+        status.size
+      end
 
       def initialize(path)
         @status = File::Stat.new(path)

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -31,7 +31,7 @@ module Aruba
     # @private
     class UnixPlatform
       def self.match?
-        !FFI::Platform.windows?
+        !Cucumber::WINDOWS
       end
 
       def environment_variables

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -1,4 +1,4 @@
-require 'ffi'
+require 'cucumber/platform'
 
 require 'aruba/platforms/unix_platform'
 require 'aruba/platforms/windows_command_string'
@@ -20,7 +20,7 @@ module Aruba
     # @private
     class WindowsPlatform < UnixPlatform
       def self.match?
-        FFI::Platform.windows?
+        Cucumber::WINDOWS
       end
 
       # @see UnixPlatform#command_string

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe Aruba::Api::Commands do
     end
 
     context 'when running a relative command' do
-      let(:cmd) { FFI::Platform.windows? ? 'bin/testcmd.bat' : 'bin/testcmd' }
+      let(:cmd) { Cucumber::WINDOWS ? 'bin/testcmd.bat' : 'bin/testcmd' }
 
       before do
-        if FFI::Platform.windows?
+        if Cucumber::WINDOWS
           @aruba.write_file cmd, <<~BAT
             exit 0
           BAT


### PR DESCRIPTION
## Summary

Several measures to improve test suite speed; Some also improve test suite speed for Aruba's users.

## Details

- Remove some slow scenarios
- Don't let bundle access network inside scenario
- Lower some timeouts again
- Don't load FFI just to check platforms
- Don't use Forwardable: Its method creation is slow

## Motivation and Context

Slow test suite is slow.

## How Has This Been Tested?

Ran the specs and the changed cukes.

## Types of changes

- Refactoring (cleanup of codebase without changing any existing functionality)