### PR TITLE
Simplify configuration specification

### DIFF
--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -29,7 +29,7 @@ module Aruba
       # @option [Object] default
       #   The default value
       def option_reader(name, opts = {})
-        contract = opts[:contract]
+        contract = opts[:contract] || { None => opts[:type] }
         default  = opts[:default]
 
         raise ArgumentError, 'Either use block or default value' if block_given? && default
@@ -58,7 +58,7 @@ module Aruba
       #   The default value
       #
       def option_accessor(name, opts = {})
-        contract = opts[:contract]
+        contract = opts[:contract] || { opts[:type] => opts[:type] }
         default  = opts[:default]
 
         raise ArgumentError, 'Either use block or default value' if block_given? && default

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -20,20 +20,13 @@ module Aruba
       # @param [Symbol] name
       #   The name of the reader
       #
-      # @param [Hash] opts
-      #   Options
-      #
       # @option [Class, Module] type
       #   The type contract for the option
       #
       # @option [Object] default
       #   The default value
-      def option_reader(name, opts = {})
-        type = opts[:type]
-        default = opts[:default]
-
+      def option_reader(name, type:, default: nil)
         raise ArgumentError, 'Either use block or default value' if block_given? && default
-        raise ArgumentError, 'type option is required' if type.nil?
 
         Contract None => type
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
@@ -48,21 +41,14 @@ module Aruba
       # @param [Symbol] name
       #   The name of the reader
       #
-      # @param [Hash] opts
-      #   Options
-      #
       # @option [Class, Module] type
       #   The type contract for the option
       #
       # @option [Object] default
       #   The default value
       #
-      def option_accessor(name, opts = {})
-        type = opts[:type]
-        default = opts[:default]
-
+      def option_accessor(name, type:, default: nil)
         raise ArgumentError, 'Either use block or default value' if block_given? && default
-        raise ArgumentError, 'type option is required' if type.nil?
 
         # Add writer
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -23,19 +23,19 @@ module Aruba
       # @param [Hash] opts
       #   Options
       #
-      # @option [Class, Module] contract
-      #   The contract for the option
+      # @option [Class, Module] type
+      #   The type contract for the option
       #
       # @option [Object] default
       #   The default value
       def option_reader(name, opts = {})
-        contract = opts[:contract] || { None => opts[:type] }
-        default  = opts[:default]
+        type = opts[:type]
+        default = opts[:default]
 
         raise ArgumentError, 'Either use block or default value' if block_given? && default
-        raise ArgumentError, 'contract-options is required' if contract.nil?
+        raise ArgumentError, 'type option is required' if type.nil?
 
-        Contract contract
+        Contract None => type
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
 
         define_method(name) { find_option(name).value }
@@ -51,27 +51,27 @@ module Aruba
       # @param [Hash] opts
       #   Options
       #
-      # @option [Class, Module] contract
-      #   The contract for the option
+      # @option [Class, Module] type
+      #   The type contract for the option
       #
       # @option [Object] default
       #   The default value
       #
       def option_accessor(name, opts = {})
-        contract = opts[:contract] || { opts[:type] => opts[:type] }
-        default  = opts[:default]
+        type = opts[:type]
+        default = opts[:default]
 
         raise ArgumentError, 'Either use block or default value' if block_given? && default
-        raise ArgumentError, 'contract-options is required' if contract.nil?
+        raise ArgumentError, 'type option is required' if type.nil?
 
         # Add writer
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
 
-        Contract contract
+        Contract type => type
         define_method("#{name}=") { |v| find_option(name).value = v }
 
         # Add reader
-        option_reader name, contract: { None => contract.values.first }
+        option_reader name, type: type
       end
 
       private

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -28,12 +28,10 @@ module Aruba
       def option_reader(name, type:, default: nil)
         raise ArgumentError, 'Either use block or default value' if block_given? && default
 
-        Contract None => type
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
 
+        Contract None => type
         define_method(name) { find_option(name).value }
-
-        self
       end
 
       # Define an option reader and writer

--- a/lib/aruba/configuration.rb
+++ b/lib/aruba/configuration.rb
@@ -23,62 +23,53 @@ module Aruba
                     type: Aruba::Contracts::RelativePath,
                     default: 'tmp/aruba'
 
-    option_reader :fixtures_path_prefix, contract: { None => String }, default: '%'
+    option_reader :fixtures_path_prefix, type: String, default: '%'
 
-    option_accessor :exit_timeout, contract: { Num => Num }, default: 15
-    option_accessor :stop_signal, contract: { Maybe[String] => Maybe[String] }, default: nil
-    option_accessor :io_wait_timeout, contract: { Num => Num }, default: 0.1
-    option_accessor :startup_wait_time, contract: { Num => Num }, default: 0
+    option_accessor :exit_timeout, type: Num, default: 15
+    option_accessor :stop_signal, type: Maybe[String], default: nil
+    option_accessor :io_wait_timeout, type: Num, default: 0.1
+    option_accessor :startup_wait_time, type: Num, default: 0
     option_accessor :fixtures_directories,
-                    contract: { Array => ArrayOf[String] },
+                    type: ArrayOf[String],
                     default: %w(features/fixtures spec/fixtures test/fixtures fixtures)
 
-    option_accessor :command_runtime_environment, contract: { Hash => Hash }, default: {}
+    option_accessor :command_runtime_environment, type: Hash, default: {}
     option_accessor :command_search_paths,
-                    contract: { ArrayOf[String] => ArrayOf[String] } do |config|
+                    type: ArrayOf[String] do |config|
                       [File.join(config.root_directory.value, 'bin'),
                        File.join(config.root_directory.value, 'exe')]
                     end
-    option_accessor :remove_ansi_escape_sequences, contract: { Bool => Bool }, default: true
+    option_accessor :remove_ansi_escape_sequences, type: Bool, default: true
     option_accessor :command_launcher,
-                    contract: {
-                      Aruba::Contracts::Enum[:in_process, :spawn, :debug] =>
-                        Aruba::Contracts::Enum[:in_process, :spawn, :debug]
-                    },
+                    type: Aruba::Contracts::Enum[:in_process, :spawn, :debug],
                     default: :spawn
-    option_accessor :main_class, contract: { Class => Maybe[Class] }, default: nil
+    option_accessor :main_class, type: Maybe[Class], default: nil
 
     option_accessor :home_directory,
-                    contract: {
-                      Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath] =>
-                        Or[Aruba::Contracts::AbsolutePath, Aruba::Contracts::RelativePath]
-                    } do |config|
-                      File.join(config.root_directory.value, config.working_directory.value)
-                    end
+                    type: Or[Aruba::Contracts::AbsolutePath,
+                             Aruba::Contracts::RelativePath] do |config|
+      File.join(config.root_directory.value, config.working_directory.value)
+    end
 
     option_accessor :log_level,
-                    contract: {
-                      Aruba::Contracts::Enum[:fatal, :warn, :debug, :info,
-                                             :error, :unknown, :silent] =>
+                    type:
                         Aruba::Contracts::Enum[:fatal, :warn, :debug, :info,
-                                               :error, :unknown, :silent]
-                    },
+                                               :error, :unknown, :silent],
                     default: :info
 
     # TODO: deprecate this value and replace with "filesystem allocation unit"
     # equal to 4096 by default. "filesystem allocation unit" would represent
     # the actual MINIMUM space taken in bytes by a 1-byte file
     option_accessor :physical_block_size,
-                    contract: { Aruba::Contracts::IsPowerOfTwo =>
-                                Aruba::Contracts::IsPowerOfTwo },
+                    type: Aruba::Contracts::IsPowerOfTwo,
                     default: 512
-    option_accessor :console_history_file, contract: { String => String },
+    option_accessor :console_history_file, type: String,
                                            default: '~/.aruba_history'
 
     option_accessor :activate_announcer_on_command_failure,
-                    contract: { ArrayOf[Symbol] => ArrayOf[Symbol] },
+                    type: ArrayOf[Symbol],
                     default: []
-    option_accessor :allow_absolute_paths, contract: { Bool => Bool }, default: false
+    option_accessor :allow_absolute_paths, type: Bool, default: false
   end
 end
 

--- a/lib/aruba/configuration.rb
+++ b/lib/aruba/configuration.rb
@@ -17,11 +17,10 @@ module Aruba
   #
   # This defines the configuration options of aruba
   class Configuration < BasicConfiguration
-    option_reader :root_directory, contract: { None => String }, default: Dir.getwd
+    option_reader :root_directory, type: String, default: Dir.getwd
 
     option_accessor :working_directory,
-                    contract: { Aruba::Contracts::RelativePath =>
-                                Aruba::Contracts::RelativePath },
+                    type: Aruba::Contracts::RelativePath,
                     default: 'tmp/aruba'
 
     option_reader :fixtures_path_prefix, contract: { None => String }, default: '%'

--- a/spec/aruba/configuration_spec.rb
+++ b/spec/aruba/configuration_spec.rb
@@ -2,4 +2,12 @@ require 'spec_helper'
 
 RSpec.describe Aruba::Configuration do
   it_behaves_like 'a basic configuration'
+
+  context 'when is modified' do
+    let(:config) { described_class.new }
+
+    it "won't allow bad values" do
+      expect { config.fixtures_directories = [1, 2] }.to raise_error ReturnContractError
+    end
+  end
 end

--- a/spec/aruba/configuration_spec.rb
+++ b/spec/aruba/configuration_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Aruba::Configuration do
     let(:config) { described_class.new }
 
     it "won't allow bad values" do
-      expect { config.fixtures_directories = [1, 2] }.to raise_error ReturnContractError
+      expect { config.fixtures_directories = [1, 2] }.to raise_error ParamContractError
     end
   end
 end

--- a/spec/support/shared_examples/configuration.rb
+++ b/spec/support/shared_examples/configuration.rb
@@ -1,7 +1,7 @@
 RSpec.shared_examples 'a basic configuration' do
   subject(:config) do
     Class.new(described_class) do
-      option_accessor :use_test, contract: { Contracts::Bool => Contracts::Bool },
+      option_accessor :use_test, type: Contracts::Bool,
                                  default: false
     end.new
   end
@@ -14,7 +14,7 @@ RSpec.shared_examples 'a basic configuration' do
     let(:config_klass) { Class.new(described_class) }
 
     before do
-      config_klass.option_reader :new_opt, contract: { Contracts::Num => Contracts::Num },
+      config_klass.option_reader :new_opt, type: Contracts::Num,
                                            default: 1
     end
 
@@ -30,7 +30,7 @@ RSpec.shared_examples 'a basic configuration' do
       before do
         config_klass.option_reader(
           :new_opt2,
-          contract: { Contracts::Num => Contracts::Num }
+          type: Contracts::Num
         ) { |c| c.new_opt.value + 1 }
       end
 
@@ -43,7 +43,7 @@ RSpec.shared_examples 'a basic configuration' do
       it 'complains that only one or the other can be specified' do
         expect do
           config_klass
-            .option_accessor(:new_opt2, contract: { Contracts::Num => Contracts::Num },
+            .option_accessor(:new_opt2, type: Contracts::Num,
                                         default: 2) { |c| c.new_opt.value + 1 }
         end.to raise_error ArgumentError, 'Either use block or default value'
       end
@@ -56,7 +56,7 @@ RSpec.shared_examples 'a basic configuration' do
     let(:config_klass) { Class.new(described_class) }
 
     before do
-      config_klass.option_accessor :new_opt, contract: { Contracts::Num => Contracts::Num },
+      config_klass.option_accessor :new_opt, type: Contracts::Num,
                                              default: 1
     end
 
@@ -73,7 +73,7 @@ RSpec.shared_examples 'a basic configuration' do
     context 'when block is defined' do
       before do
         config_klass.option_accessor(
-          :new_opt2, contract: { Contracts::Num => Contracts::Num }
+          :new_opt2, type: Contracts::Num
         ) do |c|
           c.new_opt.value + 1
         end
@@ -88,7 +88,7 @@ RSpec.shared_examples 'a basic configuration' do
       it 'complains that only one or the other can be specified' do
         expect do
           config_klass.option_accessor(:new_opt2,
-                                       contract: { Contracts::Num => Contracts::Num },
+                                       type: Contracts::Num,
                                        default: 2) { |c| c.new_opt1 + 1 }
         end.to raise_error ArgumentError, 'Either use block or default value'
       end


### PR DESCRIPTION
## Summary

Remove redundant type specifications in configuration reader and
accessor specifications

## Details

Adjust the configuration specification DSL so the type of the option
only needs to be specified once.

## Motivation and Context

Cleans up the codebase and is one step toward removing the dependency on
the contracts gem (see #770).

## How Has This Been Tested?

I ran the specs.

## Types of changes

- Refactoring (cleanup of codebase without changing any existing functionality)