### PR TITLE
Give stderr output example a little more time

### DIFF
--- a/features/04_aruba_api/command/read_stderr_of_command.feature
+++ b/features/04_aruba_api/command/read_stderr_of_command.feature
@@ -5,7 +5,6 @@ Feature: Access STDERR of command
 
   Background:
     Given I use a fixture named "cli-app"
-    And the default aruba io wait timeout is 0.1 seconds
 
   Scenario: Existing executable
     Given an executable named "bin/aruba-test-cli" with:
@@ -37,7 +36,7 @@ Feature: Access STDERR of command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.3 do
+    RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.4 do
       before { run_command('aruba-test-cli') }
       it { expect(last_command_started.stderr).to start_with 'Hello' }
     end

--- a/features/04_aruba_api/command/read_stdout_of_command.feature
+++ b/features/04_aruba_api/command/read_stdout_of_command.feature
@@ -5,7 +5,6 @@ Feature: Access STDOUT of command
 
   Background:
     Given I use a fixture named "cli-app"
-    And the default aruba io wait timeout is 0 seconds
 
   Scenario: Existing executable
     Given an executable named "bin/aruba-test-cli" with:


### PR DESCRIPTION
## Summary

Increase io_wait_timeout a little larger so it's not exceeded during
MacOS cucumber runs in CI.

## Details

Increase io_wait_timeout in one cucumber scenario. Also remove pointless
setting of that value outside of the fixture app directory.

## Motivation and Context

Somehow it seems there's always at lease one MacOS build failing.

## How Has This Been Tested?

I ran the scenarios locally but that doesn't really tell much.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)