### PR TITLE
Check the manifest as part of the linting task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -43,6 +43,9 @@ end
 desc 'Run all linters.'
 task lint: %w(lint:coding_guidelines lint:licenses)
 
+# Also check the manifest as part of the linting
+task lint: 'manifest:check'
+
 Bundler::GemHelper.install_tasks
 
 require 'rake/manifest/task'


### PR DESCRIPTION
## Summary

Check the manifest as part of the linting task

## Details

Add the `manifest:check` task as a dependency of `lint`.

## Motivation and Context

It's good to know this is broken way before trying to push a release.

## How Has This Been Tested?

Ran the task.

## Types of changes

- Developer experience improvement