### PR TITLE
Allow simplecov 0.21 to be used

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.9.0'
   spec.add_development_dependency 'rubocop-rspec', '~> 2.1.0'
-  spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.21.0']
+  spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.22.0']
   spec.add_development_dependency 'yard-junk', '~> 0.0.7'
 
   spec.rubygems_version = '>= 1.6.1'


### PR DESCRIPTION
## Summary

Allow simplecov 0.21 to be used

## Motivation and Context

Keep development dependencies up-to-date.

## How Has This Been Tested?

I updated the bundle.

## Types of changes

- Dependency update