### PR TITLE
Use double quotes in strings by default

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,10 @@ Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     '%w': ()
 
+# Do not commit to use of interpolation
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
 # SupportedStyles: percent, brackets
 Style/SymbolArray:
   EnforcedStyle: brackets

--- a/.simplecov
+++ b/.simplecov
@@ -3,12 +3,12 @@ SimpleCov.configure do
   enable_coverage :branch
 
   # ignore this file
-  add_filter '.simplecov'
-  add_filter 'features'
+  add_filter ".simplecov"
+  add_filter "features"
 
   # Rake tasks aren't tested with rspec
-  add_filter 'Rakefile'
-  add_filter 'lib/tasks'
+  add_filter "Rakefile"
+  add_filter "lib/tasks"
 
   #
   # Changed Files in Git Group
@@ -19,18 +19,18 @@ SimpleCov.configure do
   all               = untracked + unstaged + staged
   changed_filenames = all.split("\n")
 
-  add_group 'Changed' do |source_file|
+  add_group "Changed" do |source_file|
     changed_filenames.select do |changed_filename|
       source_file.filename.end_with?(changed_filename)
     end
   end
 
-  add_group 'Libraries', 'lib'
+  add_group "Libraries", "lib"
 
   # Specs are reported on to ensure that all examples are being run and all
   # lets, befores, afters, etc are being used.
-  add_group 'Specs', 'spec/'
+  add_group "Specs", "spec/"
 end
 
 # Run simplecov by default
-SimpleCov.start unless ENV.key? 'ARUBA_NO_COVERAGE'
+SimpleCov.start unless ENV.key? "ARUBA_NO_COVERAGE"

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Use dependencies from gemspec
 gemspec
 
 # Load local Gemfile
-if File.file? File.expand_path('Gemfile.local', __dir__)
-  load File.expand_path('Gemfile.local', __dir__)
+if File.file? File.expand_path("Gemfile.local", __dir__)
+  load File.expand_path("Gemfile.local", __dir__)
 end
 
-unless RUBY_PLATFORM.include?('java')
-  gem 'byebug', '~> 11.0'
-  gem 'pry-byebug', '~> 3.4'
+unless RUBY_PLATFORM.include?("java")
+  gem "byebug", "~> 11.0"
+  gem "pry-byebug", "~> 3.4"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,70 +1,70 @@
 $LOAD_PATH << File.expand_path(__dir__)
 
-require 'aruba/tasks/docker_helpers'
-require 'aruba/platform'
+require "aruba/tasks/docker_helpers"
+require "aruba/platform"
 
-require 'bundler'
+require "bundler"
 Bundler.setup
 
-require 'cucumber/rake/task'
-require 'rspec/core/rake_task'
+require "cucumber/rake/task"
+require "rspec/core/rake_task"
 
 Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = %w(--format progress)
 end
 
-Cucumber::Rake::Task.new('cucumber:wip', 'Run Cucumber features '\
+Cucumber::Rake::Task.new("cucumber:wip", "Run Cucumber features "\
                          'which are "WORK IN PROGRESS" and '\
-                         'are allowed to fail') do |t|
+                         "are allowed to fail") do |t|
   t.cucumber_opts = %w(--format progress)
-  t.profile = 'wip'
+  t.profile = "wip"
 end
 
 RSpec::Core::RakeTask.new
 
-desc 'Run the whole test suite.'
+desc "Run the whole test suite."
 task test: [:spec, :cucumber]
 
 namespace :lint do
   desc 'Lint our code with "rubocop"'
   task :coding_guidelines do
-    sh 'bundle exec rubocop'
+    sh "bundle exec rubocop"
   end
 
-  desc 'Check for relevant licenses in project'
+  desc "Check for relevant licenses in project"
   task :licenses do
-    sh 'bundle exec license_finder'
+    sh "bundle exec license_finder"
   end
 
-  require 'yard-junk/rake'
+  require "yard-junk/rake"
   YardJunk::Rake.define_task
 end
 
-desc 'Run all linters.'
+desc "Run all linters."
 task lint: %w(lint:coding_guidelines lint:licenses)
 
 # Also check the manifest as part of the linting
-task lint: 'manifest:check'
+task lint: "manifest:check"
 
 Bundler::GemHelper.install_tasks
 
-require 'rake/manifest/task'
+require "rake/manifest/task"
 
 Rake::Manifest::Task.new do |t|
-  t.patterns = ['lib/**/*', 'exe/*', 'CHANGELOG.md', 'CONTRIBUTING.md',
-                'LICENSE', 'README.md']
+  t.patterns = ["lib/**/*", "exe/*", "CHANGELOG.md", "CONTRIBUTING.md",
+                "LICENSE", "README.md"]
 end
 
-task build: 'manifest:check'
+task build: "manifest:check"
 
 namespace :docker do
-  desc 'Build docker image'
+  desc "Build docker image"
   task :build, :cache, :version do |_, args|
-    args.with_defaults(version: 'latest')
+    args.with_defaults(version: "latest")
     args.with_defaults(cache: true)
 
     docker_compose_file =
-      Aruba::DockerComposeFile.new(File.expand_path('docker-compose.yml', __dir__))
+      Aruba::DockerComposeFile.new(File.expand_path("docker-compose.yml", __dir__))
     docker_run_instance = Aruba::DockerRunInstance.new(docker_compose_file, :base)
 
     builder = Aruba::DockerBuildCommandLineBuilder.new(
@@ -76,10 +76,10 @@ namespace :docker do
     sh builder.to_cli
   end
 
-  desc 'Run docker container'
+  desc "Run docker container"
   task :run, :command do |_, args|
     docker_compose_file =
-      Aruba::DockerComposeFile.new(File.expand_path('docker-compose.yml', __dir__))
+      Aruba::DockerComposeFile.new(File.expand_path("docker-compose.yml", __dir__))
     docker_run_instance = Aruba::DockerRunInstance.new(docker_compose_file, :base)
 
     builder = Aruba::DockerRunCommandLineBuilder.new(

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -1,54 +1,54 @@
-require_relative 'lib/aruba/version'
+require_relative "lib/aruba/version"
 
 Gem::Specification.new do |spec|
-  spec.name        = 'aruba'
+  spec.name        = "aruba"
   spec.version     = Aruba::VERSION
-  spec.author      = 'Aslak Hellesøy, Matt Wynne and other Aruba Contributors'
+  spec.author      = "Aslak Hellesøy, Matt Wynne and other Aruba Contributors"
   spec.description = <<~TEXT
     Extension for popular TDD and BDD frameworks like "Cucumber", "RSpec" and "Minitest",
     to make testing command line applications meaningful, easy and fun.
   TEXT
   spec.summary     = "aruba-#{spec.version}"
-  spec.license     = 'MIT'
-  spec.email       = 'cukes@googlegroups.com'
-  spec.homepage    = 'https://github.com/cucumber/aruba'
+  spec.license     = "MIT"
+  spec.email       = "cukes@googlegroups.com"
+  spec.homepage    = "https://github.com/cucumber/aruba"
 
   spec.metadata    = {
-    'bug_tracker_uri' => 'https://github.com/cucumber/aruba/issues',
-    'changelog_uri' => 'https://www.rubydoc.info/gems/aruba/file/CHANGELOG.md',
-    'documentation_uri' => 'https://www.rubydoc.info/gems/aruba',
-    'homepage_uri' => spec.homepage,
-    'source_code_uri' => 'https://github.com/cucumber/aruba'
+    "bug_tracker_uri" => "https://github.com/cucumber/aruba/issues",
+    "changelog_uri" => "https://www.rubydoc.info/gems/aruba/file/CHANGELOG.md",
+    "documentation_uri" => "https://www.rubydoc.info/gems/aruba",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/cucumber/aruba"
   }
 
-  spec.add_runtime_dependency 'childprocess', ['>= 2.0', '< 5.0']
-  spec.add_runtime_dependency 'contracts', '~> 0.16.0'
-  spec.add_runtime_dependency 'cucumber', ['>= 2.4', '< 6.0']
-  spec.add_runtime_dependency 'rspec-expectations', '~> 3.4'
-  spec.add_runtime_dependency 'thor', '~> 1.0'
+  spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
+  spec.add_runtime_dependency "contracts", "~> 0.16.0"
+  spec.add_runtime_dependency "cucumber", [">= 2.4", "< 6.0"]
+  spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
+  spec.add_runtime_dependency "thor", "~> 1.0"
 
-  spec.add_development_dependency 'json', '~> 2.1'
-  spec.add_development_dependency 'license_finder', '~> 6.0'
-  spec.add_development_dependency 'minitest', '~> 5.10'
-  spec.add_development_dependency 'pry-doc', '~> 1.0'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rake-manifest', '~> 0.2.0'
-  spec.add_development_dependency 'rspec', '~> 3.10.0'
-  spec.add_development_dependency 'rubocop', '~> 1.8.0'
-  spec.add_development_dependency 'rubocop-packaging', '~> 0.5.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.9.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.1.0'
-  spec.add_development_dependency 'simplecov', ['>= 0.18.0', '< 0.22.0']
-  spec.add_development_dependency 'yard-junk', '~> 0.0.7'
+  spec.add_development_dependency "json", "~> 2.1"
+  spec.add_development_dependency "license_finder", "~> 6.0"
+  spec.add_development_dependency "minitest", "~> 5.10"
+  spec.add_development_dependency "pry-doc", "~> 1.0"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
+  spec.add_development_dependency "rspec", "~> 3.10.0"
+  spec.add_development_dependency "rubocop", "~> 1.8.0"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
+  spec.add_development_dependency "rubocop-performance", "~> 1.9.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.1.0"
+  spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.22.0"]
+  spec.add_development_dependency "yard-junk", "~> 0.0.7"
 
-  spec.rubygems_version = '>= 1.6.1'
-  spec.required_ruby_version = '>= 2.4'
+  spec.rubygems_version = ">= 1.6.1"
+  spec.required_ruby_version = ">= 2.4"
 
-  spec.files = File.readlines('Manifest.txt', chomp: true)
+  spec.files = File.readlines("Manifest.txt", chomp: true)
 
-  spec.executables      = ['aruba']
-  spec.rdoc_options     = ['--charset', 'UTF-8', '--main', 'README.md']
-  spec.extra_rdoc_files = ['CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'LICENSE']
-  spec.bindir           = 'exe'
-  spec.require_paths    = ['lib']
+  spec.executables      = ["aruba"]
+  spec.rdoc_options     = ["--charset", "UTF-8", "--main", "README.md"]
+  spec.extra_rdoc_files = ["CHANGELOG.md", "CONTRIBUTING.md", "README.md", "LICENSE"]
+  spec.bindir           = "exe"
+  spec.require_paths    = ["lib"]
 end

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
-require 'aruba/console'
+require "aruba/console"
 
 Aruba::Console.new.start

--- a/exe/aruba
+++ b/exe/aruba
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH << File.expand_path('../lib', __dir__)
+$LOAD_PATH << File.expand_path("../lib", __dir__)
 
-require 'aruba/cli'
+require "aruba/cli"
 
 Aruba::Cli.start

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -1,65 +1,65 @@
-require 'cucumber/platform'
+require "cucumber/platform"
 
-Before '@requires-python' do
-  next unless Aruba.platform.which('python').nil?
-
-  skip_this_scenario
-end
-
-Before '@requires-zsh' do
-  next unless Aruba.platform.which('zsh').nil?
+Before "@requires-python" do
+  next unless Aruba.platform.which("python").nil?
 
   skip_this_scenario
 end
 
-Before '@requires-java' do
-  next unless Aruba.platform.which('javac').nil?
+Before "@requires-zsh" do
+  next unless Aruba.platform.which("zsh").nil?
 
   skip_this_scenario
 end
 
-Before '@requires-perl' do
-  next unless Aruba.platform.which('perl').nil?
+Before "@requires-java" do
+  next unless Aruba.platform.which("javac").nil?
 
   skip_this_scenario
 end
 
-Before '@requires-ruby' do
-  next unless Aruba.platform.which('ruby').nil?
+Before "@requires-perl" do
+  next unless Aruba.platform.which("perl").nil?
 
   skip_this_scenario
 end
 
-Before '@requires-posix-standard-tools' do
-  next unless Aruba.platform.which('printf').nil?
+Before "@requires-ruby" do
+  next unless Aruba.platform.which("ruby").nil?
 
   skip_this_scenario
 end
 
-Before '@requires-ruby-platform-java' do
+Before "@requires-posix-standard-tools" do
+  next unless Aruba.platform.which("printf").nil?
+
+  skip_this_scenario
+end
+
+Before "@requires-ruby-platform-java" do
   skip_this_scenario unless Cucumber::JRUBY
 end
 
-Before '@unsupported-on-platform-java' do
+Before "@unsupported-on-platform-java" do
   skip_this_scenario if Cucumber::JRUBY
 end
 
-Before '@unsupported-on-platform-windows' do
+Before "@unsupported-on-platform-windows" do
   skip_this_scenario if Cucumber::WINDOWS
 end
 
-Before '@requires-readline' do
+Before "@requires-readline" do
   begin
-    require 'readline'
+    require "readline"
   rescue LoadError
     skip_this_scenario
   end
 end
 
-Before '@unsupported-on-platform-unix' do
+Before "@unsupported-on-platform-unix" do
   skip_this_scenario unless Cucumber::WINDOWS
 end
 
-Before '@unsupported-on-platform-mac' do
+Before "@unsupported-on-platform-mac" do
   skip_this_scenario if Cucumber::OS_X
 end

--- a/features/support/aruba.rb
+++ b/features/support/aruba.rb
@@ -1,4 +1,4 @@
-require 'aruba/cucumber'
+require "aruba/cucumber"
 
 Aruba.configure do |config|
   config.exit_timeout                          = 120

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,16 +1,16 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
 
 # Has to be the first file required so that all other files show coverage information
-require 'simplecov' unless RUBY_PLATFORM.include?('java')
+require "simplecov" unless RUBY_PLATFORM.include?("java")
 
 # Standard Library
-require 'fileutils'
-require 'pathname'
+require "fileutils"
+require "pathname"
 
 # Gems
-require 'aruba/cucumber'
-require 'aruba/config/jruby'
-require 'rspec/expectations'
+require "aruba/cucumber"
+require "aruba/config/jruby"
+require "rspec/expectations"
 
 Before do |scenario|
   command_name = if scenario.respond_to?(:feature) # Cucumber < 4
@@ -22,12 +22,12 @@ Before do |scenario|
   # Used in simplecov_setup so that each scenario has a different name and
   # their coverage results are merged instead of overwriting each other as
   # 'Cucumber Features'
-  ENV['SIMPLECOV_COMMAND_NAME'] = command_name.to_s
+  ENV["SIMPLECOV_COMMAND_NAME"] = command_name.to_s
 
   simplecov_setup_pathname =
-    Pathname.new(__FILE__).expand_path.parent.join('simplecov_setup')
+    Pathname.new(__FILE__).expand_path.parent.join("simplecov_setup")
 
   # set environment variable so child processes will merge their coverage data
   # with parent process's coverage data.
-  ENV['RUBYOPT'] = "-r#{simplecov_setup_pathname} #{ENV['RUBYOPT']}"
+  ENV["RUBYOPT"] = "-r#{simplecov_setup_pathname} #{ENV['RUBYOPT']}"
 end

--- a/features/support/jruby.rb
+++ b/features/support/jruby.rb
@@ -1,4 +1,4 @@
-if RUBY_PLATFORM == 'java'
+if RUBY_PLATFORM == "java"
   Before do
     @aruba_timeout_seconds = 15
   end

--- a/features/support/simplecov_setup.rb
+++ b/features/support/simplecov_setup.rb
@@ -1,9 +1,9 @@
 # @note this file is loaded in env.rb to setup simplecov using RUBYOPTs for
 # child processes and @in-process
-unless RUBY_PLATFORM.include?('java')
-  require 'simplecov'
-  root = File.expand_path('../..', __dir__)
-  SimpleCov.command_name(ENV['SIMPLECOV_COMMAND_NAME'])
+unless RUBY_PLATFORM.include?("java")
+  require "simplecov"
+  root = File.expand_path("../..", __dir__)
+  SimpleCov.command_name(ENV["SIMPLECOV_COMMAND_NAME"])
   SimpleCov.root(root)
-  load File.join(root, '.simplecov')
+  load File.join(root, ".simplecov")
 end

--- a/features/support/timing.rb
+++ b/features/support/timing.rb
@@ -20,6 +20,6 @@ at_exit do
   puts "------------- Top #{max_scenarios} slowest scenarios -------------"
   sorted_times = scenario_times.sort { |a, b| b[1] <=> a[1] }
   sorted_times[0..max_scenarios - 1].each do |key, value|
-    puts format('%.2f  %s', value, key)
+    puts format("%.2f  %s", value, key)
   end
 end

--- a/fixtures/cli-app/Gemfile
+++ b/fixtures/cli-app/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Use dependencies from gemspec
 gemspec

--- a/fixtures/cli-app/Rakefile
+++ b/fixtures/cli-app/Rakefile
@@ -1,1 +1,1 @@
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"

--- a/fixtures/cli-app/bin/aruba-test-cli
+++ b/fixtures/cli-app/bin/aruba-test-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-$LOAD_PATH << File.expand_path('../lib', __dir__)
-require 'cli/app'
+$LOAD_PATH << File.expand_path("../lib", __dir__)
+require "cli/app"
 
 exit 0

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -1,26 +1,26 @@
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'cli/app/version'
+require "cli/app/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'cli-app'
+  spec.name          = "cli-app"
   spec.version       = Cli::App::VERSION
-  spec.authors       = ['Aruba Developers']
-  spec.email         = 'cukes@googlegroups.com'
+  spec.authors       = ["Aruba Developers"]
+  spec.email         = "cukes@googlegroups.com"
 
-  spec.summary       = 'Summary'
-  spec.description   = 'Description'
-  spec.homepage      = 'http://example.com'
+  spec.summary       = "Summary"
+  spec.description   = "Description"
+  spec.homepage      = "http://example.com"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
 
-  spec.files         = Dir['lib/**/*', 'README.md']
-  spec.bindir        = 'exe'
-  spec.executables   = ['bin/aruba-test-cli']
-  spec.require_paths = ['lib']
+  spec.files         = Dir["lib/**/*", "README.md"]
+  spec.bindir        = "exe"
+  spec.executables   = ["bin/aruba-test-cli"]
+  spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'aruba'
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency "aruba"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end

--- a/fixtures/cli-app/features/support/aruba.rb
+++ b/fixtures/cli-app/features/support/aruba.rb
@@ -1,1 +1,1 @@
-require 'aruba/cucumber'
+require "aruba/cucumber"

--- a/fixtures/cli-app/features/support/env.rb
+++ b/fixtures/cli-app/features/support/env.rb
@@ -1,1 +1,1 @@
-require_relative 'aruba'
+require_relative "aruba"

--- a/fixtures/cli-app/lib/cli/app.rb
+++ b/fixtures/cli-app/lib/cli/app.rb
@@ -1,6 +1,6 @@
-require 'cli/app/version'
+require "cli/app/version"
 
-::Dir.glob(File.expand_path('**/*.rb', __dir__)).each { |f| require_relative f }
+::Dir.glob(File.expand_path("**/*.rb", __dir__)).each { |f| require_relative f }
 
 module Cli
   module App

--- a/fixtures/cli-app/lib/cli/app/suppress_simple_cov_output.rb
+++ b/fixtures/cli-app/lib/cli/app/suppress_simple_cov_output.rb
@@ -2,12 +2,12 @@ module SimpleCov
   module Formatter
     class HTMLFormatter
       def format(result)
-        Dir[File.join(File.dirname(__FILE__), '../public/*')].each do |path|
+        Dir[File.join(File.dirname(__FILE__), "../public/*")].each do |path|
           FileUtils.cp_r(path, asset_output_path)
         end
 
-        File.open(File.join(output_path, 'index.html'), 'wb') do |file|
-          file.puts template('layout').result(binding)
+        File.open(File.join(output_path, "index.html"), "wb") do |file|
+          file.puts template("layout").result(binding)
         end
       end
     end

--- a/fixtures/cli-app/lib/cli/app/version.rb
+++ b/fixtures/cli-app/lib/cli/app/version.rb
@@ -1,5 +1,5 @@
 module Cli
   module App
-    VERSION = '0.1.0'.freeze
+    VERSION = "0.1.0".freeze
   end
 end

--- a/fixtures/cli-app/script/console
+++ b/fixtures/cli-app/script/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require 'bundler/setup'
-require 'cli/app'
+require "bundler/setup"
+require "cli/app"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require 'cli/app'
 # require "pry"
 # Pry.start
 
-require 'irb'
+require "irb"
 IRB.start

--- a/fixtures/cli-app/spec/spec_helper.rb
+++ b/fixtures/cli-app/spec/spec_helper.rb
@@ -1,8 +1,8 @@
-$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 
-require 'cli/app'
+require "cli/app"
 
-require_relative 'support/aruba'
+require_relative "support/aruba"
 
-::Dir.glob(::File.expand_path('support/**/*.rb', __dir__))
+::Dir.glob(::File.expand_path("support/**/*.rb", __dir__))
      .each { |f| require_relative f }

--- a/fixtures/cli-app/spec/support/aruba.rb
+++ b/fixtures/cli-app/spec/support/aruba.rb
@@ -1,1 +1,1 @@
-require 'aruba/rspec'
+require "aruba/rspec"

--- a/fixtures/empty-app/Rakefile
+++ b/fixtures/empty-app/Rakefile
@@ -1,1 +1,1 @@
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -1,24 +1,24 @@
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'cli/app/version'
+require "cli/app/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'cli-app'
+  spec.name          = "cli-app"
   spec.version       = Cli::App::VERSION
-  spec.authors       = ['Aruba Developers']
-  spec.email         = 'cukes@googlegroups.com'
+  spec.authors       = ["Aruba Developers"]
+  spec.email         = "cukes@googlegroups.com"
 
-  spec.summary       = 'Summary'
-  spec.description   = 'Description'
-  spec.homepage      = 'http://example.com'
+  spec.summary       = "Summary"
+  spec.description   = "Description"
+  spec.homepage      = "http://example.com"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
 
-  spec.files         = Dir['lib/**/*', 'README.md']
-  spec.bindir        = 'exe'
-  spec.require_paths = ['lib']
+  spec.files         = Dir["lib/**/*", "README.md"]
+  spec.bindir        = "exe"
+  spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'bundler'
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
 end

--- a/fixtures/empty-app/lib/cli/app.rb
+++ b/fixtures/empty-app/lib/cli/app.rb
@@ -1,4 +1,4 @@
-require 'cli/app/version'
+require "cli/app/version"
 
 module Cli
   module App

--- a/fixtures/empty-app/lib/cli/app/version.rb
+++ b/fixtures/empty-app/lib/cli/app/version.rb
@@ -1,5 +1,5 @@
 module Cli
   module App
-    VERSION = '0.1.0'.freeze
+    VERSION = "0.1.0".freeze
   end
 end

--- a/fixtures/getting-started-app/Gemfile
+++ b/fixtures/getting-started-app/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'aruba', path: File.expand_path('../../..', __dir__)
-gem 'cucumber'
+gem "aruba", path: File.expand_path("../../..", __dir__)
+gem "cucumber"

--- a/fixtures/getting-started-app/features/support/env.rb
+++ b/fixtures/getting-started-app/features/support/env.rb
@@ -1,1 +1,1 @@
-require 'aruba/cucumber'
+require "aruba/cucumber"

--- a/lib/aruba.rb
+++ b/lib/aruba.rb
@@ -1,1 +1,1 @@
-require 'aruba/api'
+require "aruba/api"

--- a/lib/aruba/api.rb
+++ b/lib/aruba/api.rb
@@ -1,18 +1,18 @@
-require 'rspec/expectations'
-require 'shellwords'
+require "rspec/expectations"
+require "shellwords"
 
-require 'aruba/version'
+require "aruba/version"
 
-require 'aruba/platform'
-require 'aruba/api/core'
-require 'aruba/api/commands'
+require "aruba/platform"
+require "aruba/api/core"
+require "aruba/api/commands"
 
-require 'aruba/api/environment'
-require 'aruba/api/filesystem'
-require 'aruba/api/text'
-require 'aruba/api/bundler'
+require "aruba/api/environment"
+require "aruba/api/filesystem"
+require "aruba/api/text"
+require "aruba/api/bundler"
 
-Aruba.platform.require_matching_files('../matchers/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../matchers/**/*.rb", __FILE__)
 
 # Aruba
 module Aruba

--- a/lib/aruba/api/bundler.rb
+++ b/lib/aruba/api/bundler.rb
@@ -1,4 +1,4 @@
-require 'aruba/api/environment'
+require "aruba/api/environment"
 
 module Aruba
   module Api

--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -1,7 +1,7 @@
-require 'pathname'
+require "pathname"
 
-require 'aruba/platform'
-require 'aruba/command'
+require "aruba/platform"
+require "aruba/command"
 
 # require 'win32/file' if File::ALT_SEPARATOR
 
@@ -22,7 +22,7 @@ module Aruba
       def which(program, path = nil)
         with_environment do
           # ENV is set within this block
-          path = ENV['PATH'] if path.nil?
+          path = ENV["PATH"] if path.nil?
 
           Aruba.platform.which(program, path)
         end
@@ -35,7 +35,7 @@ module Aruba
       def pipe_in_file(file_name)
         file_name = expand_path(file_name)
 
-        File.open(file_name, 'r').each_line do |line|
+        File.open(file_name, "r").each_line do |line|
           last_command_started.write(line)
         end
       end
@@ -152,7 +152,7 @@ module Aruba
 
         unless command.interactive?
           raise NotImplementedError,
-                'Running interactively is not supported with this process launcher.'
+                "Running interactively is not supported with this process launcher."
         end
 
         start_command(command)
@@ -232,7 +232,7 @@ module Aruba
         @commands << cmd
 
         environment       = aruba.environment
-        working_directory = expand_path('.')
+        working_directory = expand_path(".")
         event_bus         = aruba.event_bus
 
         cmd = Aruba.platform.detect_ruby(cmd)

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -1,7 +1,7 @@
-require 'rspec/expectations'
-require 'aruba/runtime'
-require 'aruba/errors'
-require 'aruba/setup'
+require "rspec/expectations"
+require "aruba/runtime"
+require "aruba/errors"
+require "aruba/setup"
 
 # Aruba
 module Aruba
@@ -38,8 +38,8 @@ module Aruba
       # @yield
       #   The block which should be run in current directory
       def in_current_directory(&block)
-        create_directory '.' unless directory?('.')
-        cd('.', &block)
+        create_directory "." unless directory?(".")
+        cd(".", &block)
       end
 
       # Switch to directory
@@ -64,9 +64,9 @@ module Aruba
                     "#{expand_path(dir)} is not a directory or does not exist."
             end
 
-            old_directory = expand_path('.')
+            old_directory = expand_path(".")
             aruba.current_directory << dir
-            new_directory = expand_path('.')
+            new_directory = expand_path(".")
 
             aruba.event_bus.notify Events::ChangedWorkingDirectory.new(old: old_directory,
                                                                        new: new_directory)
@@ -78,8 +78,8 @@ module Aruba
             Aruba.platform.chdir real_new_directory
 
             result = with_environment(
-              'OLDPWD' => old_dir,
-              'PWD' => real_new_directory,
+              "OLDPWD" => old_dir,
+              "PWD" => real_new_directory,
               &block
             )
           ensure
@@ -94,9 +94,9 @@ module Aruba
           raise ArgumentError, "#{expand_path(dir)} is not a directory or does not exist."
         end
 
-        old_directory = expand_path('.')
+        old_directory = expand_path(".")
         aruba.current_directory << dir
-        new_directory = expand_path('.')
+        new_directory = expand_path(".")
 
         aruba.event_bus.notify Events::ChangedWorkingDirectory.new(old: old_directory,
                                                                    new: new_directory)
@@ -143,7 +143,7 @@ module Aruba
       def expand_path(file_name, dir_string = nil)
         unless file_name.is_a?(String) && !file_name.empty?
           message = "Filename #{file_name} needs to be a string." \
-            ' It cannot be nil or empty either. '\
+            " It cannot be nil or empty either. "\
             "Please use `expand_path('.')` if you want the current directory to be expanded."
 
           raise ArgumentError, message
@@ -152,7 +152,7 @@ module Aruba
         unless Aruba.platform.directory? File.join(aruba.config.root_directory,
                                                    aruba.config.working_directory)
           raise "Aruba's working directory does not exist." \
-            ' Maybe you forgot to run `setup_aruba` before using its API.'
+            " Maybe you forgot to run `setup_aruba` before using its API."
         end
 
         prefix = file_name[0]
@@ -162,22 +162,22 @@ module Aruba
           path = File.join(*[aruba.fixtures_directory, rest].compact)
           unless Aruba.platform.exist? path
             aruba_fixture_candidates = aruba.config.fixtures_directories
-                                            .map { |p| format('"%s"', p) }.join(', ')
+                                            .map { |p| format('"%s"', p) }.join(", ")
 
             raise ArgumentError,
                   "Fixture \"#{rest}\" does not exist" \
                   " in fixtures directory \"#{aruba.fixtures_directory}\"." \
-                  ' This was the one we found first on your system from all possible' \
+                  " This was the one we found first on your system from all possible" \
                   " candidates: #{aruba_fixture_candidates}."
           end
 
           path
-        elsif prefix == '~'
+        elsif prefix == "~"
           path = with_environment do
             File.expand_path(file_name)
           end
 
-          raise ArgumentError, 'Expanding "~/" to "/" is not allowed' if path == '/'
+          raise ArgumentError, 'Expanding "~/" to "/" is not allowed' if path == "/"
 
           unless Aruba.platform.absolute_path? path
             raise ArgumentError,
@@ -192,8 +192,8 @@ module Aruba
             aruba.logger.warn \
               "Aruba's `expand_path` method was called with an absolute path" \
               " at #{caller_file_line}, which is not recommended." \
-              ' Change the call to pass a relative path or set '\
-              '`config.allow_absolute_paths = true` to silence this warning'
+              " Change the call to pass a relative path or set "\
+              "`config.allow_absolute_paths = true` to silence this warning"
           end
           file_name
         else

--- a/lib/aruba/api/environment.rb
+++ b/lib/aruba/api/environment.rb
@@ -1,4 +1,4 @@
-require 'aruba/platform'
+require "aruba/platform"
 
 # Aruba
 module Aruba
@@ -96,7 +96,7 @@ module Aruba
 
         environment_change = { old: old_environment,
                                new: new_environment,
-                               changed: { name: name, value: '' } }
+                               changed: { name: name, value: "" } }
         aruba.event_bus.notify Events::ChangedEnvironmentVariable.new(environment_change)
 
         self

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -1,10 +1,10 @@
-require 'pathname'
+require "pathname"
 
-require 'aruba/platform'
+require "aruba/platform"
 
-Aruba.platform.require_matching_files('../matchers/file/*.rb', __FILE__)
-Aruba.platform.require_matching_files('../matchers/directory/*.rb', __FILE__)
-Aruba.platform.require_matching_files('../matchers/path/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../matchers/file/*.rb", __FILE__)
+Aruba.platform.require_matching_files("../matchers/directory/*.rb", __FILE__)
+Aruba.platform.require_matching_files("../matchers/path/*.rb", __FILE__)
 
 # Aruba
 module Aruba
@@ -67,7 +67,7 @@ module Aruba
       # @return [Array]
       #   List of files and directories
       def all_paths
-        list('.').map { |path| expand_path(path) }
+        list(".").map { |path| expand_path(path) }
       end
 
       # Return all existing files in current directory
@@ -75,7 +75,7 @@ module Aruba
       # @return [Array]
       #   List of files
       def all_files
-        list('.').select { |p| file? p }.map { |p| expand_path(p) }
+        list(".").select { |p| file? p }.map { |p| expand_path(p) }
       end
 
       # Return all existing directories in current directory
@@ -83,7 +83,7 @@ module Aruba
       # @return [Array]
       #   List of files
       def all_directories
-        list('.').select { |p| directory? p }.map { |p| expand_path(p) }
+        list(".").select { |p| directory? p }.map { |p| expand_path(p) }
       end
 
       # Create directory object
@@ -108,8 +108,8 @@ module Aruba
                 %(Only directories are supported. Path "#{name}" is not a directory.)
         end
 
-        existing_files            = Dir.glob(expand_path(File.join(name, '**', '*')))
-        current_working_directory = Pathname.new(expand_path('.'))
+        existing_files            = Dir.glob(expand_path(File.join(name, "**", "*")))
+        current_working_directory = Pathname.new(expand_path("."))
 
         existing_files.map do |d|
           Pathname.new(d).relative_path_from(current_working_directory).to_s
@@ -191,7 +191,7 @@ module Aruba
         end
 
         if source.count > 1 && exist?(destination) && !directory?(destination)
-          raise ArgumentError, 'Multiples sources can only be copied to a directory'
+          raise ArgumentError, "Multiples sources can only be copied to a directory"
         end
 
         source_paths     = source.map { |f| expand_path(f) }
@@ -240,7 +240,7 @@ module Aruba
         end
 
         if source.count > 1 && exist?(destination) && !directory?(destination)
-          raise ArgumentError, 'Multiple sources can only be copied to a directory'
+          raise ArgumentError, "Multiple sources can only be copied to a directory"
         end
 
         source_paths     = source.map { |f| expand_path(f) }
@@ -327,7 +327,7 @@ module Aruba
         file_name = expand_path(file_name)
 
         Aruba.platform.mkdir(File.dirname(file_name))
-        File.open(file_name, 'a') { |f| f << file_content }
+        File.open(file_name, "a") { |f| f << file_content }
       end
 
       # Create a directory in current directory

--- a/lib/aruba/api/text.rb
+++ b/lib/aruba/api/text.rb
@@ -30,9 +30,9 @@ module Aruba
       #   Input
       def extract_text(text)
         text
-          .gsub(/(?:\e|\033)\[\d+(?>(;\d+)*)m/, '')
-          .gsub(/\\\[|\\\]/, '')
-          .gsub(/\007|\016|\017/, '')
+          .gsub(/(?:\e|\033)\[\d+(?>(;\d+)*)m/, "")
+          .gsub(/\\\[|\\\]/, "")
+          .gsub(/\007|\016|\017/, "")
       end
 
       # Unescape special characters and remove ANSI characters
@@ -51,7 +51,7 @@ module Aruba
       # @param [#to_s] text
       #   The text to parse
       def replace_variables(text)
-        if text.include? '<pid-last-command-started>'
+        if text.include? "<pid-last-command-started>"
           text = text.gsub(/<pid-last-command-started>/, last_command_started.pid.to_s)
         end
 

--- a/lib/aruba/aruba_path.rb
+++ b/lib/aruba/aruba_path.rb
@@ -1,4 +1,4 @@
-require 'pathname'
+require "pathname"
 
 # Aruba
 module Aruba
@@ -57,7 +57,7 @@ module Aruba
     # Get path
     def to_pathname
       current_path = @obj.inject do |path, element|
-        if element.start_with?('~') ||
+        if element.start_with?("~") ||
            Aruba.platform.absolute_path?(element)
           element
         else

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -1,6 +1,6 @@
-require 'contracts'
-require 'aruba/basic_configuration/option'
-require 'aruba/in_config_wrapper'
+require "contracts"
+require "aruba/basic_configuration/option"
+require "aruba/in_config_wrapper"
 
 # Aruba
 module Aruba
@@ -26,7 +26,7 @@ module Aruba
       # @option [Object] default
       #   The default value
       def option_reader(name, type:, default: nil)
-        raise ArgumentError, 'Either use block or default value' if block_given? && default
+        raise ArgumentError, "Either use block or default value" if block_given? && default
 
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
 
@@ -46,7 +46,7 @@ module Aruba
       #   The default value
       #
       def option_accessor(name, type:, default: nil)
-        raise ArgumentError, 'Either use block or default value' if block_given? && default
+        raise ArgumentError, "Either use block or default value" if block_given? && default
 
         # Add writer
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
@@ -110,8 +110,8 @@ module Aruba
     # @yield
     #   The code block which should be run. This is a configure time only option
     def before(name, &block)
-      name = format('%s_%s', 'before_', name.to_s).to_sym
-      raise ArgumentError, 'A block is required' unless block
+      name = format("%s_%s", "before_", name.to_s).to_sym
+      raise ArgumentError, "A block is required" unless block
 
       @hooks.append(name, block)
 
@@ -129,7 +129,7 @@ module Aruba
     # @param [Array] args
     #   Arguments for the run of hook
     def run_before_hook(name, context, *args)
-      name = format('%s_%s', 'before_', name.to_s).to_sym
+      name = format("%s_%s", "before_", name.to_s).to_sym
 
       @hooks.execute(name, context, *args)
     end
@@ -142,8 +142,8 @@ module Aruba
     # @yield
     #   The code block which should be run. This is a configure time only option
     def after(name, &block)
-      name = format('%s_%s', 'after_', name.to_s).to_sym
-      raise ArgumentError, 'A block is required' unless block
+      name = format("%s_%s", "after_", name.to_s).to_sym
+      raise ArgumentError, "A block is required" unless block
 
       @hooks.append(name, block)
 
@@ -161,7 +161,7 @@ module Aruba
     # @param [Array] args
     #   Arguments for the run of hook
     def run_after_hook(name, context, *args)
-      name = format('%s_%s', 'after_', name.to_s).to_sym
+      name = format("%s_%s", "after_", name.to_s).to_sym
 
       @hooks.execute(name, context, *args)
     end

--- a/lib/aruba/cli.rb
+++ b/lib/aruba/cli.rb
@@ -1,6 +1,6 @@
-require 'thor'
-require 'aruba/console'
-require 'aruba/initializer'
+require "thor"
+require "aruba/console"
+require "aruba/initializer"
 
 # Aruba
 module Aruba
@@ -12,16 +12,16 @@ module Aruba
       true
     end
 
-    desc 'console', "Start aruba's console"
+    desc "console", "Start aruba's console"
     def console
       Aruba::Console.new.start
     end
 
-    desc 'init', 'Initialize aruba'
+    desc "init", "Initialize aruba"
     option :test_framework,
-           default: 'cucumber',
+           default: "cucumber",
            enum: %w(cucumber rspec minitest),
-           desc: 'Choose which test framework to use'
+           desc: "Choose which test framework to use"
     def init
       Aruba::Initializer.new.call(options[:test_framework])
     end

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -1,7 +1,7 @@
-require 'delegate'
-require 'aruba/processes/spawn_process'
-require 'aruba/processes/in_process'
-require 'aruba/processes/debug_process'
+require "delegate"
+require "aruba/processes/spawn_process"
+require "aruba/processes/in_process"
+require "aruba/processes/debug_process"
 
 # Aruba
 module Aruba

--- a/lib/aruba/config/jruby.rb
+++ b/lib/aruba/config/jruby.rb
@@ -1,27 +1,27 @@
-require 'rbconfig'
+require "rbconfig"
 
 # ideas taken from: http://blog.headius.com/2010/03/jruby-startup-time-tips.html
 Aruba.configure do |config|
   config.before :command do |command|
-    next unless RUBY_PLATFORM == 'java'
+    next unless RUBY_PLATFORM == "java"
 
     env = command.environment
 
-    jruby_opts = env['JRUBY_OPTS'] || ''
+    jruby_opts = env["JRUBY_OPTS"] || ""
 
     # disable JIT since these processes are so short lived
-    jruby_opts = "-X-C #{jruby_opts}" unless jruby_opts.include? '-X-C'
+    jruby_opts = "-X-C #{jruby_opts}" unless jruby_opts.include? "-X-C"
 
     # Faster startup for jruby
-    jruby_opts = "--dev #{jruby_opts}" unless jruby_opts.include? '--dev'
+    jruby_opts = "--dev #{jruby_opts}" unless jruby_opts.include? "--dev"
 
-    env['JRUBY_OPTS'] = jruby_opts
+    env["JRUBY_OPTS"] = jruby_opts
 
-    if /solaris|sunos/i.match?(RbConfig::CONFIG['host_os'])
-      java_opts = env['JAVA_OPTS'] || ''
+    if /solaris|sunos/i.match?(RbConfig::CONFIG["host_os"])
+      java_opts = env["JAVA_OPTS"] || ""
 
       # force jRuby to use client JVM for faster startup times
-      env['JAVA_OPTS'] = "-d32 #{java_opts}" unless java_opts.include?('-d32')
+      env["JAVA_OPTS"] = "-d32 #{java_opts}" unless java_opts.include?("-d32")
     end
   end
 end

--- a/lib/aruba/config_wrapper.rb
+++ b/lib/aruba/config_wrapper.rb
@@ -30,7 +30,7 @@ module Aruba
     # If one method ends with "=", e.g. ":option1=", then notify the event
     # queue, that the user changes the value of "option1"
     def method_missing(name, *args, &block)
-      notify(name, args) if name.to_s.end_with?('=')
+      notify(name, args) if name.to_s.end_with?("=")
 
       return config.send(name, *args, &block) if config.respond_to? name
 
@@ -63,7 +63,7 @@ module Aruba
       event_bus.notify(
         Events::ChangedConfiguration.new(
           changed: {
-            name: name.to_s.gsub(/=$/, ''),
+            name: name.to_s.gsub(/=$/, ""),
             value: args.first
           }
         )

--- a/lib/aruba/configuration.rb
+++ b/lib/aruba/configuration.rb
@@ -1,15 +1,15 @@
-require 'contracts'
+require "contracts"
 
-require 'aruba/version'
-require 'aruba/basic_configuration'
-require 'aruba/in_config_wrapper'
-require 'aruba/hooks'
+require "aruba/version"
+require "aruba/basic_configuration"
+require "aruba/in_config_wrapper"
+require "aruba/hooks"
 
-require 'aruba/contracts/relative_path'
-require 'aruba/contracts/absolute_path'
-require 'aruba/contracts/enum'
+require "aruba/contracts/relative_path"
+require "aruba/contracts/absolute_path"
+require "aruba/contracts/enum"
 
-require 'aruba/contracts/is_power_of_two'
+require "aruba/contracts/is_power_of_two"
 
 # Aruba
 module Aruba
@@ -21,9 +21,9 @@ module Aruba
 
     option_accessor :working_directory,
                     type: Aruba::Contracts::RelativePath,
-                    default: 'tmp/aruba'
+                    default: "tmp/aruba"
 
-    option_reader :fixtures_path_prefix, type: String, default: '%'
+    option_reader :fixtures_path_prefix, type: String, default: "%"
 
     option_accessor :exit_timeout, type: Num, default: 15
     option_accessor :stop_signal, type: Maybe[String], default: nil
@@ -36,8 +36,8 @@ module Aruba
     option_accessor :command_runtime_environment, type: Hash, default: {}
     option_accessor :command_search_paths,
                     type: ArrayOf[String] do |config|
-                      [File.join(config.root_directory.value, 'bin'),
-                       File.join(config.root_directory.value, 'exe')]
+                      [File.join(config.root_directory.value, "bin"),
+                       File.join(config.root_directory.value, "exe")]
                     end
     option_accessor :remove_ansi_escape_sequences, type: Bool, default: true
     option_accessor :command_launcher,
@@ -64,7 +64,7 @@ module Aruba
                     type: Aruba::Contracts::IsPowerOfTwo,
                     default: 512
     option_accessor :console_history_file, type: String,
-                                           default: '~/.aruba_history'
+                                           default: "~/.aruba_history"
 
     option_accessor :activate_announcer_on_command_failure,
                     type: ArrayOf[Symbol],

--- a/lib/aruba/console.rb
+++ b/lib/aruba/console.rb
@@ -1,7 +1,7 @@
-require 'irb'
+require "irb"
 
-require 'aruba/api'
-require 'aruba/console/help'
+require "aruba/api"
+require "aruba/console/help"
 
 # Aruba
 module Aruba
@@ -15,21 +15,21 @@ module Aruba
       ARGV.clear
       IRB.setup nil
 
-      IRB.conf[:IRB_NAME] = 'aruba'
+      IRB.conf[:IRB_NAME] = "aruba"
 
       IRB.conf[:PROMPT] = {}
       IRB.conf[:PROMPT][:ARUBA] = {
-        PROMPT_I: '%N:%03n:%i> ',
-        PROMPT_S: '%N:%03n:%i%l ',
-        PROMPT_C: '%N:%03n:%i* ',
+        PROMPT_I: "%N:%03n:%i> ",
+        PROMPT_S: "%N:%03n:%i%l ",
+        PROMPT_C: "%N:%03n:%i* ",
         RETURN: "# => %s\n"
       }
       IRB.conf[:PROMPT_MODE] = :ARUBA
 
       IRB.conf[:RC] = false
 
-      require 'irb/completion'
-      require 'irb/ext/save-history'
+      require "irb/completion"
+      require "irb/ext/save-history"
       IRB.conf[:READLINE] = true
       IRB.conf[:SAVE_HISTORY] = 1000
       IRB.conf[:HISTORY_FILE] = Aruba.config.console_history_file
@@ -43,14 +43,14 @@ module Aruba
         end
 
         def inspect
-          'nil'
+          "nil"
         end
       end
 
       irb = IRB::Irb.new(IRB::WorkSpace.new(context.new))
       IRB.conf[:MAIN_CONTEXT] = irb.context
 
-      trap('SIGINT') do
+      trap("SIGINT") do
         irb.signal_handle
       end
 

--- a/lib/aruba/console/help.rb
+++ b/lib/aruba/console/help.rb
@@ -1,4 +1,4 @@
-require 'aruba/api'
+require "aruba/api"
 
 # Aruba
 module Aruba
@@ -9,9 +9,9 @@ module Aruba
       # Output help information
       def aruba_help
         puts "Aruba Version: #{Aruba::VERSION}"
-        puts 'Issue Tracker: https://github.com/cucumber/aruba/issues'
-        puts 'Documentation:'
-        puts '* http://www.rubydoc.info/gems/aruba'
+        puts "Issue Tracker: https://github.com/cucumber/aruba/issues"
+        puts "Documentation:"
+        puts "* http://www.rubydoc.info/gems/aruba"
         puts
 
         nil
@@ -20,7 +20,7 @@ module Aruba
       # List available methods in aruba
       def aruba_methods
         ms = (Aruba::Api.instance_methods - Module.instance_methods)
-             .each_with_object([]) { |e, a| a << format('* %s', e) }
+             .each_with_object([]) { |e, a| a << format("* %s", e) }
              .sort
 
         puts "Available Methods:\n#{ms.join("\n")}"

--- a/lib/aruba/contracts/absolute_path.rb
+++ b/lib/aruba/contracts/absolute_path.rb
@@ -1,4 +1,4 @@
-require 'aruba/platform'
+require "aruba/platform"
 
 # Aruba
 module Aruba

--- a/lib/aruba/contracts/enum.rb
+++ b/lib/aruba/contracts/enum.rb
@@ -1,4 +1,4 @@
-require 'contracts'
+require "contracts"
 
 # Aruba
 module Aruba

--- a/lib/aruba/contracts/is_power_of_two.rb
+++ b/lib/aruba/contracts/is_power_of_two.rb
@@ -1,4 +1,4 @@
-require 'aruba/aruba_path'
+require "aruba/aruba_path"
 
 # Aruba
 module Aruba

--- a/lib/aruba/contracts/relative_path.rb
+++ b/lib/aruba/contracts/relative_path.rb
@@ -1,4 +1,4 @@
-require 'aruba/platform'
+require "aruba/platform"
 
 # Aruba
 module Aruba

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -1,8 +1,8 @@
-require 'aruba/version'
+require "aruba/version"
 
-require 'aruba/api'
-require 'aruba/cucumber/hooks'
-require 'aruba/cucumber/command'
-require 'aruba/cucumber/environment'
-require 'aruba/cucumber/file'
-require 'aruba/cucumber/testing_frameworks'
+require "aruba/api"
+require "aruba/cucumber/hooks"
+require "aruba/cucumber/command"
+require "aruba/cucumber/environment"
+require "aruba/cucumber/file"
+require "aruba/cucumber/testing_frameworks"

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -1,4 +1,4 @@
-require 'aruba/generators/script_file'
+require "aruba/generators/script_file"
 
 When(/^I run `([^`]*)`$/) do |cmd|
   cmd = sanitize_text(cmd)
@@ -14,9 +14,9 @@ end
 
 When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) \
   do |shell, commands|
-  full_path = expand_path('bin/myscript')
+  full_path = expand_path("bin/myscript")
 
-  Aruba.platform.mkdir(expand_path('bin'))
+  Aruba.platform.mkdir(expand_path("bin"))
   shell ||= Aruba.platform.default_shell
 
   Aruba::ScriptFile.new(interpreter: shell, content: commands, path: full_path).call
@@ -55,7 +55,7 @@ When(/^I (terminate|stop) the command (?:"([^"]*)"|(?:started last))$/) do |sign
           last_command_started
         end
 
-  if signal == 'terminate'
+  if signal == "terminate"
     cmd.terminate
   else
     cmd.stop
@@ -135,9 +135,9 @@ Then(
   /^(?:the )?(output|stderr|stdout) from "([^"]*)" should contain( exactly)? "([^"]*)"$/
 ) do |channel, cmd, exactly, expected|
   matcher = case channel
-            when 'output'; then :have_output
-            when 'stderr'; then :have_output_on_stderr
-            when 'stdout'; then :have_output_on_stdout
+            when "output"; then :have_output
+            when "stderr"; then :have_output_on_stderr
+            when "stdout"; then :have_output_on_stdout
             end
 
   command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
@@ -156,9 +156,9 @@ Then(
   /^(?:the )?(output|stderr|stdout) from "([^"]*)" should not contain( exactly)? "([^"]*)"$/
 ) do |channel, cmd, exactly, expected|
   matcher = case channel
-            when 'output'; then :have_output
-            when 'stderr'; then :have_output_on_stderr
-            when 'stdout'; then :have_output_on_stdout
+            when "output"; then :have_output
+            when "stderr"; then :have_output_on_stderr
+            when "stdout"; then :have_output_on_stdout
             end
 
   command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
@@ -204,9 +204,9 @@ end
 Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should not contain( exactly)?:$/) \
   do |channel, cmd, exactly, expected|
   matcher = case channel
-            when 'output'; then :have_output
-            when 'stderr'; then :have_output_on_stderr
-            when 'stdout'; then :have_output_on_stdout
+            when "output"; then :have_output
+            when "stderr"; then :have_output_on_stderr
+            when "stdout"; then :have_output_on_stdout
             end
 
   command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
@@ -224,9 +224,9 @@ end
 Then(/^(?:the )?(output|stderr|stdout) from "([^"]*)" should contain( exactly)?:$/) \
   do |channel, cmd, exactly, expected|
   matcher = case channel
-            when 'output'; then :have_output
-            when 'stderr'; then :have_output_on_stderr
-            when 'stdout'; then :have_output_on_stdout
+            when "output"; then :have_output
+            when "stderr"; then :have_output_on_stderr
+            when "stdout"; then :have_output_on_stdout
             end
 
   command = aruba.command_monitor.find(Aruba.platform.detect_ruby(cmd))
@@ -287,7 +287,7 @@ end
 Then(/^it should not (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -299,7 +299,7 @@ end
 Then(/^it should (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -311,7 +311,7 @@ end
 Then(/^it should not (pass|fail) with:$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -323,7 +323,7 @@ end
 Then(/^it should (pass|fail) with:$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -335,7 +335,7 @@ end
 Then(/^it should not (pass|fail) with exactly:$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -347,7 +347,7 @@ end
 Then(/^it should (pass|fail) with exactly:$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -359,7 +359,7 @@ end
 Then(/^it should not (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -371,7 +371,7 @@ end
 Then(/^it should (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|
   last_command_started.stop
 
-  if pass_fail == 'pass'
+  if pass_fail == "pass"
     expect(last_command_stopped).to be_successfully_executed
   else
     expect(last_command_stopped).not_to be_successfully_executed
@@ -382,9 +382,9 @@ end
 
 Then(/^(?:the )?(output|stderr|stdout) should not contain anything$/) do |channel|
   matcher = case channel
-            when 'output'; then :have_output
-            when 'stderr'; then :have_output_on_stderr
-            when 'stdout'; then :have_output_on_stdout
+            when "output"; then :have_output
+            when "stderr"; then :have_output_on_stderr
+            when "stdout"; then :have_output_on_stdout
             end
 
   expect(all_commands).to include_an_object send(matcher, be_nil.or(be_empty))
@@ -394,9 +394,9 @@ Then(/^(?:the )?(output|stdout|stderr) should( not)? contain all of these lines:
   do |channel, negated, table|
   table.raw.flatten.each do |expected|
     _matcher = case channel
-               when 'output'; then :have_output
-               when 'stderr'; then :have_output_on_stderr
-               when 'stdout'; then :have_output_on_stdout
+               when "output"; then :have_output
+               when "stderr"; then :have_output_on_stderr
+               when "stdout"; then :have_output_on_stdout
                end
 
     # TODO: This isn't actually using the above. It's hardcoded to use have_output only
@@ -440,5 +440,5 @@ When(/^I send the signal "([^"]*)" to the command (?:"([^"]*)"|(?:started last))
 end
 
 Given(/^I look for executables in "(.*)" within the current directory$/) do |directory|
-  prepend_environment_variable 'PATH', expand_path(directory) + File::PATH_SEPARATOR
+  prepend_environment_variable "PATH", expand_path(directory) + File::PATH_SEPARATOR
 end

--- a/lib/aruba/cucumber/environment.rb
+++ b/lib/aruba/cucumber/environment.rb
@@ -1,5 +1,5 @@
 Given(/^a mocked home directory$/) do
-  set_environment_variable 'HOME', expand_path('.')
+  set_environment_variable "HOME", expand_path(".")
 end
 
 Given(/^I set the environment variable "(.*)" to "(.*)"/) do |variable, value|
@@ -16,8 +16,8 @@ end
 
 Given(/^I set the environment variables? to:/) do |table|
   table.hashes.each do |row|
-    variable = row['variable'].to_s
-    value = row['value'].to_s
+    variable = row["variable"].to_s
+    value = row["value"].to_s
 
     set_environment_variable(variable, value)
   end
@@ -25,8 +25,8 @@ end
 
 Given(/^I append the values? to the environment variables?:/) do |table|
   table.hashes.each do |row|
-    variable = row['variable'].to_s
-    value = row['value'].to_s
+    variable = row["variable"].to_s
+    value = row["value"].to_s
 
     append_environment_variable(variable, value)
   end
@@ -34,8 +34,8 @@ end
 
 Given(/^I prepend the values? to the environment variables?:/) do |table|
   table.hashes.each do |row|
-    variable = row['variable'].to_s
-    value = row['value'].to_s
+    variable = row["variable"].to_s
+    value = row["value"].to_s
 
     prepend_environment_variable(variable, value)
   end

--- a/lib/aruba/cucumber/file.rb
+++ b/lib/aruba/cucumber/file.rb
@@ -46,12 +46,12 @@ Given(/^(?:a|the) (\d+) byte file(?: named)? "([^"]*)"$/) do |file_size, file_na
 end
 
 Given(/^(?:an|the) empty file(?: named)? "([^"]*)"$/) do |file_name|
-  write_file(file_name, '')
+  write_file(file_name, "")
 end
 
 Given(/^(?:an|the) empty file(?: named)? "([^"]*)" with mode "([^"]*)"$/) \
   do |file_name, file_mode|
-  write_file(file_name, '')
+  write_file(file_name, "")
   chmod(file_mode, file_name)
 end
 

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -1,6 +1,6 @@
-require 'aruba/aruba_path'
-require 'aruba/api'
-require 'aruba/platform'
+require "aruba/aruba_path"
+require "aruba/api"
+require "aruba/platform"
 World(Aruba::Api)
 
 Around do |_, block|
@@ -10,10 +10,10 @@ end
 Before do
   # ... so every change needs to be done later
   prepend_environment_variable(
-    'PATH',
+    "PATH",
     aruba.config.command_search_paths.join(File::PATH_SEPARATOR) + File::PATH_SEPARATOR
   )
-  set_environment_variable 'HOME', aruba.config.home_directory
+  set_environment_variable "HOME", aruba.config.home_directory
 end
 
 After do
@@ -21,68 +21,68 @@ After do
   aruba.command_monitor.clear
 end
 
-Before('@no-clobber') do
+Before("@no-clobber") do
   setup_aruba(false)
 end
 
-Before('~@no-clobber') do
+Before("~@no-clobber") do
   setup_aruba
 end
 
-Before('@puts') do
+Before("@puts") do
   aruba.announcer.mode = :puts
 end
 
-Before('@announce-command') do
+Before("@announce-command") do
   aruba.announcer.activate :command
 end
 
-Before('@announce-command-content') do
+Before("@announce-command-content") do
   aruba.announcer.activate :command_content
 end
 
-Before('@announce-command-filesystem-status') do
+Before("@announce-command-filesystem-status") do
   aruba.announcer.activate :command_filesystem_status
 end
 
-Before('@announce-output') do
+Before("@announce-output") do
   aruba.announcer.activate :stdout
   aruba.announcer.activate :stderr
 end
 
-Before('@announce-stdout') do
+Before("@announce-stdout") do
   aruba.announcer.activate :stdout
 end
 
-Before('@announce-stderr') do
+Before("@announce-stderr") do
   aruba.announcer.activate :stderr
 end
 
-Before('@announce-directory') do
+Before("@announce-directory") do
   aruba.announcer.activate :directory
 end
 
-Before('@announce-stop-signal') do
+Before("@announce-stop-signal") do
   aruba.announcer.activate :stop_signal
 end
 
-Before('@announce-full-environment') do
+Before("@announce-full-environment") do
   aruba.announcer.activate :full_environment
 end
 
-Before('@announce-changed-environment') do
+Before("@announce-changed-environment") do
   aruba.announcer.activate :changed_environment
 end
 
-Before('@announce-timeout') do
+Before("@announce-timeout") do
   aruba.announcer.activate :timeout
 end
 
-Before('@announce-wait-time') do
+Before("@announce-wait-time") do
   aruba.announcer.activate :wait_time
 end
 
-Before('@announce') do
+Before("@announce") do
   aruba.announcer.activate :changed_environment
   aruba.announcer.activate :command
   aruba.announcer.activate :directory
@@ -98,30 +98,30 @@ Before('@announce') do
   aruba.announcer.activate :command_filesystem_status
 end
 
-Before('@keep-ansi-escape-sequences') do
+Before("@keep-ansi-escape-sequences") do
   aruba.config.remove_ansi_escape_sequences = false
 end
 
-Before '@mocked-home-directory' do
-  set_environment_variable 'HOME', expand_path('.')
+Before "@mocked-home-directory" do
+  set_environment_variable "HOME", expand_path(".")
 end
 
-Before('@disable-bundler') do
+Before("@disable-bundler") do
   unset_bundler_env_vars
 end
 
-Before('@debug') do
+Before("@debug") do
   aruba.config.command_launcher = :debug
 end
 
-Before('@command-launcher-spawn') do
+Before("@command-launcher-spawn") do
   aruba.config.command_launcher = :spawn
 end
 
-Before('@command-launcher-in-process') do
+Before("@command-launcher-in-process") do
   aruba.config.command_launcher = :in_process
 end
 
-Before('@command-launcher-debug') do
+Before("@command-launcher-debug") do
   aruba.config.command_launcher = :debug
 end

--- a/lib/aruba/cucumber/testing_frameworks.rb
+++ b/lib/aruba/cucumber/testing_frameworks.rb
@@ -1,25 +1,25 @@
 # Cucumber
 Then(/^the feature(?:s)? should not(?: all)? pass$/) do
   step 'the output should contain " failed)"'
-  step 'the exit status should be 1'
+  step "the exit status should be 1"
 end
 
 # Cucumber
 Then(/^the feature(?:s)? should(?: all)? pass$/) do
   step 'the output should not contain " failed)"'
   step 'the output should not contain " undefined)"'
-  step 'the exit status should be 0'
+  step "the exit status should be 0"
 end
 
 # Cucumber
 Then(/^the feature(?:s)? should not(?: all)? pass with( regex)?:$/) do |regex, string|
   step 'the output should contain " failed)"'
-  step 'the exit status should be 1'
+  step "the exit status should be 1"
 
   if regex
     step "the output should match %r<#{string}>"
   else
-    step 'the output should contain:', string
+    step "the output should contain:", string
   end
 end
 
@@ -27,12 +27,12 @@ end
 Then(/^the feature(?:s)? should(?: all)? pass with( regex)?:$/) do |regex, string|
   step 'the output should not contain " failed)"'
   step 'the output should not contain " undefined)"'
-  step 'the exit status should be 0'
+  step "the exit status should be 0"
 
   if regex
     step "the output should match %r<#{string}>"
   else
-    step 'the output should contain:', string
+    step "the output should contain:", string
   end
 end
 
@@ -45,36 +45,36 @@ Then(/^the spec(?:s)? should not(?: all)? pass(?: with (\d+) failures?)?$/) \
     step %(the output should contain "#{count_failures} failures")
   end
 
-  step 'the exit status should be 1'
+  step "the exit status should be 1"
 end
 
 # RSpec
 Then(/^the spec(?:s)? should all pass$/) do
   step 'the output should contain "0 failures"'
-  step 'the exit status should be 0'
+  step "the exit status should be 0"
 end
 
 # RSpec
 Then(/^the spec(?:s)? should not(?: all)? pass with( regex)?:$/) do |regex, string|
   step 'the output should not contain "0 failures"'
-  step 'the exit status should be 1'
+  step "the exit status should be 1"
 
   if regex
     step "the output should match %r<#{string}>"
   else
-    step 'the output should contain:', string
+    step "the output should contain:", string
   end
 end
 
 # RSpec
 Then(/^the spec(?:s)? should(?: all)? pass with( regex)?:$/) do |regex, string|
   step 'the output should contain "0 failures"'
-  step 'the exit status should be 0'
+  step "the exit status should be 0"
 
   if regex
     step "the output should match %r<#{string}>"
   else
-    step 'the output should contain:', string
+    step "the output should contain:", string
   end
 end
 
@@ -87,35 +87,35 @@ Then(/^the tests(?:s)? should not(?: all)? pass(?: with (\d+) failures?)?$/) \
     step %(the output should contain "#{count_failures} errors")
   end
 
-  step 'the exit status should be 1'
+  step "the exit status should be 1"
 end
 
 # Minitest
 Then(/^the tests(?:s)? should all pass$/) do
   step 'the output should contain "0 errors"'
-  step 'the exit status should be 0'
+  step "the exit status should be 0"
 end
 
 # Minitest
 Then(/^the test(?:s)? should not(?: all)? pass with( regex)?:$/) do |regex, string|
   step 'the output should contain "0 errors"'
-  step 'the exit status should be 1'
+  step "the exit status should be 1"
 
   if regex
     step "the output should match %r<#{string}>"
   else
-    step 'the output should contain:', string
+    step "the output should contain:", string
   end
 end
 
 # Minitest
 Then(/^the test(?:s)? should(?: all)? pass with( regex)?:$/) do |regex, string|
   step 'the output should not contain "0 errors"'
-  step 'the exit status should be 0'
+  step "the exit status should be 0"
 
   if regex
     step "the output should match %r<#{string}>"
   else
-    step 'the output should contain:', string
+    step "the output should contain:", string
   end
 end

--- a/lib/aruba/event_bus.rb
+++ b/lib/aruba/event_bus.rb
@@ -1,5 +1,5 @@
-require 'aruba/event_bus/name_resolver'
-require 'aruba/errors'
+require "aruba/event_bus/name_resolver"
+require "aruba/errors"
 
 module Aruba
   # Event bus
@@ -34,7 +34,7 @@ module Aruba
       handler = handler_proc || handler_object
 
       if handler.nil? || !handler.respond_to?(:call)
-        raise ArgumentError, 'Please pass either an object#call or a handler block'
+        raise ArgumentError, "Please pass either an object#call or a handler block"
       end
 
       Array(event_ids).flatten.each do |id|
@@ -53,7 +53,7 @@ module Aruba
     #   handler.
     #
     def notify(event)
-      raise NoEventError, 'Please pass an event object, not a class' if event.is_a?(Class)
+      raise NoEventError, "Please pass an event object, not a class" if event.is_a?(Class)
 
       @handlers[event.class.to_s].each { |handler| handler.call(event) }
     end

--- a/lib/aruba/event_bus/name_resolver.rb
+++ b/lib/aruba/event_bus/name_resolver.rb
@@ -1,4 +1,4 @@
-require 'aruba/errors'
+require "aruba/errors"
 
 # Event notification library
 module Aruba
@@ -10,13 +10,13 @@ module Aruba
       # Helpers for Resolvers
       module ResolveHelpers
         def camel_case(underscored_name)
-          underscored_name.to_s.split('_').map { |word| word.upcase[0] + word[1..-1] }.join
+          underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..-1] }.join
         end
 
         # Thanks ActiveSupport
         # (Only needed to support Ruby 1.9.3 and JRuby)
         def constantize(camel_cased_word)
-          names = camel_cased_word.split('::')
+          names = camel_cased_word.split("::")
 
           # Trigger a built-in NameError exception including the ill-formed
           # constant in the message.
@@ -148,7 +148,7 @@ module Aruba
       def transform(event_id)
         resolvers.find { |r| r.match? event_id }.new.transform(default_namespace, event_id)
       rescue StandardError => e
-        types = @resolvers.map(&:supports).flatten.join(', ')
+        types = @resolvers.map(&:supports).flatten.join(", ")
         message = "Transforming \"#{event_id}\" into an event class failed." \
           " Supported types are: #{types}. #{e.message}."
         raise EventNameResolveError, message, cause: e

--- a/lib/aruba/file_size.rb
+++ b/lib/aruba/file_size.rb
@@ -1,4 +1,4 @@
-require 'delegate'
+require "delegate"
 
 # Aruba
 module Aruba

--- a/lib/aruba/generators/script_file.rb
+++ b/lib/aruba/generators/script_file.rb
@@ -23,7 +23,7 @@ module Aruba
 
     def header
       if script_starts_with_shebang?
-        ''
+        ""
       elsif interpreter_is_absolute_path?
         format("#!%s\n", interpreter)
       elsif interpreter_is_just_the_name_of_shell?
@@ -40,7 +40,7 @@ module Aruba
     end
 
     def script_starts_with_shebang?
-      content.start_with? '#!'
+      content.start_with? "#!"
     end
   end
 end

--- a/lib/aruba/in_config_wrapper.rb
+++ b/lib/aruba/in_config_wrapper.rb
@@ -16,7 +16,7 @@ module Aruba
 
     def method_missing(name, *args)
       if config.key? name
-        raise ArgumentError, 'Options take no argument' if args.any?
+        raise ArgumentError, "Options take no argument" if args.any?
 
         config[name]
       else

--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -1,5 +1,5 @@
-require 'thor/group'
-require 'thor/actions'
+require "thor/group"
+require "thor/actions"
 
 # Aruba
 module Aruba
@@ -15,7 +15,7 @@ module Aruba
 
       # Add gem to gemfile
       def add_gem
-        file = 'Gemfile'
+        file = "Gemfile"
         creator = if File.exist? file
                     :append_to_file
                   else
@@ -24,9 +24,9 @@ module Aruba
 
         content = if File.exist? file
                     file_ends_with_carriage_return =
-                      File.open(file, 'r').readlines.last.match(/.*\n$/)
+                      File.open(file, "r").readlines.last.match(/.*\n$/)
 
-                    prefix = file_ends_with_carriage_return ? '' : "\n"
+                    prefix = file_ends_with_carriage_return ? "" : "\n"
 
                     %(#{prefix}gem 'aruba', '~> #{Aruba::VERSION}')
                   else
@@ -79,7 +79,7 @@ module Aruba
       end
 
       def create_helper
-        file = 'spec/spec_helper.rb'
+        file = "spec/spec_helper.rb"
         creator = if File.exist? file
                     :append_to_file
                   else
@@ -95,7 +95,7 @@ module Aruba
       end
 
       def create_support_file
-        create_file 'spec/support/aruba.rb', <<~EOS
+        create_file "spec/support/aruba.rb", <<~EOS
           require 'aruba/rspec'
         EOS
       end
@@ -120,7 +120,7 @@ module Aruba
       end
 
       def create_support_file
-        create_file 'features/support/aruba.rb', <<~EOS
+        create_file "features/support/aruba.rb", <<~EOS
           require 'aruba/cucumber'
         EOS
       end
@@ -145,7 +145,7 @@ module Aruba
       end
 
       def create_helper
-        file =  'test/test_helper.rb'
+        file =  "test/test_helper.rb"
         creator = if File.exist? file
                     :append_to_file
                   else
@@ -161,7 +161,7 @@ module Aruba
       end
 
       def create_example
-        create_file 'test/use_aruba_with_minitest.rb', <<~EOS
+        create_file "test/use_aruba_with_minitest.rb", <<~EOS
           $LOAD_PATH.unshift File.expand_path('../test', __FILE__)
 
           require 'test_helper'

--- a/lib/aruba/matchers/base/base_matcher.rb
+++ b/lib/aruba/matchers/base/base_matcher.rb
@@ -1,4 +1,4 @@
-require 'aruba/matchers/base/object_formatter'
+require "aruba/matchers/base/object_formatter"
 
 # Aruba
 module Aruba

--- a/lib/aruba/matchers/base/message_indenter.rb
+++ b/lib/aruba/matchers/base/message_indenter.rb
@@ -8,7 +8,7 @@ module Aruba
         module_function
 
         def indent_multiline_message(message)
-          message = message.sub(/\n+\z/, '')
+          message = message.sub(/\n+\z/, "")
           message.lines.map do |line|
             /\S/.match?(line) ? "   #{line}" : line
           end.join

--- a/lib/aruba/matchers/base/object_formatter.rb
+++ b/lib/aruba/matchers/base/object_formatter.rb
@@ -52,7 +52,7 @@ module Aruba
         end
       end
 
-      TIME_FORMAT = '%Y-%m-%d %H:%M:%S'.freeze
+      TIME_FORMAT = "%Y-%m-%d %H:%M:%S".freeze
 
       if Time.method_defined?(:nsec)
         # @private
@@ -61,7 +61,7 @@ module Aruba
         end
       end
 
-      DATE_TIME_FORMAT = '%a, %d %b %Y %H:%M:%S.%N %z'.freeze
+      DATE_TIME_FORMAT = "%a, %d %b %Y %H:%M:%S.%N %z".freeze
 
       # ActiveSupport sometimes overrides inspect. If `ActiveSupport` is
       # defined use a custom format string that includes more time precision.

--- a/lib/aruba/matchers/collection.rb
+++ b/lib/aruba/matchers/collection.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../collection/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../collection/**/*.rb", __FILE__)

--- a/lib/aruba/matchers/collection/all.rb
+++ b/lib/aruba/matchers/collection/all.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations'
+require "rspec/expectations"
 
 # Aruba
 module Aruba

--- a/lib/aruba/matchers/collection/include_an_object.rb
+++ b/lib/aruba/matchers/collection/include_an_object.rb
@@ -1,5 +1,5 @@
-require 'aruba/matchers/base/base_matcher'
-require 'aruba/matchers/base/message_indenter'
+require "aruba/matchers/base/base_matcher"
+require "aruba/matchers/base/message_indenter"
 
 # Aruba
 module Aruba

--- a/lib/aruba/matchers/command.rb
+++ b/lib/aruba/matchers/command.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../command/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../command/**/*.rb", __FILE__)

--- a/lib/aruba/matchers/command/be_successfully_executed.rb
+++ b/lib/aruba/matchers/command/be_successfully_executed.rb
@@ -1,7 +1,7 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
-require 'aruba/matchers/command/have_exit_status'
-require 'aruba/matchers/command/have_finished_in_time'
+require "aruba/matchers/command/have_exit_status"
+require "aruba/matchers/command/have_finished_in_time"
 
 # @!method be_successfuly_executed
 #   This matchers checks if execution of <command> was successful
@@ -30,7 +30,7 @@ RSpec::Matchers.define :be_successfully_executed do
 
   failure_message do |_actual|
     "Expected `#{@actual}` to succeed" \
-      ' but got non-zero exit status and the following output:' \
+      " but got non-zero exit status and the following output:" \
       "\n\n#{@old_actual.output}\n"
   end
 end

--- a/lib/aruba/matchers/command/have_finished_in_time.rb
+++ b/lib/aruba/matchers/command/have_finished_in_time.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method run_too_long
 #   This matchers checks if <command> run too long. Say the timeout is 10

--- a/lib/aruba/matchers/command/have_output.rb
+++ b/lib/aruba/matchers/command/have_output.rb
@@ -1,4 +1,4 @@
-require 'aruba/matchers/base/message_indenter'
+require "aruba/matchers/base/message_indenter"
 
 # @!method have_output
 #   This matchers checks if <command> has created output

--- a/lib/aruba/matchers/directory.rb
+++ b/lib/aruba/matchers/directory.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../directory/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../directory/**/*.rb", __FILE__)

--- a/lib/aruba/matchers/directory/be_an_existing_directory.rb
+++ b/lib/aruba/matchers/directory/be_an_existing_directory.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method be_an_existing_directory
 #   This matchers checks if <directory> exists in filesystem
@@ -19,7 +19,7 @@ RSpec::Matchers.define :be_an_existing_directory do |_|
   match do |actual|
     stop_all_commands
 
-    raise 'String expected' unless actual.is_a? String
+    raise "String expected" unless actual.is_a? String
 
     directory?(actual)
   end

--- a/lib/aruba/matchers/directory/have_sub_directory.rb
+++ b/lib/aruba/matchers/directory/have_sub_directory.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method have_sub_directory(sub_directory)
 #   This matchers checks if <directory> has given sub-directory
@@ -42,13 +42,13 @@ RSpec::Matchers.define :have_sub_directory do |expected|
 
   failure_message do |actual|
     format('expected that directory "%s" has the following sub-directories: %s.',
-           actual.join(', '),
+           actual.join(", "),
            expected)
   end
 
   failure_message_when_negated do |actual|
     format('expected that directory "%s" does not have the following sub-directories: %s.',
-           actual.join(', '),
+           actual.join(", "),
            expected)
   end
 end

--- a/lib/aruba/matchers/environment.rb
+++ b/lib/aruba/matchers/environment.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../matchers/environment/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../matchers/environment/*.rb", __FILE__)

--- a/lib/aruba/matchers/file.rb
+++ b/lib/aruba/matchers/file.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../file/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../file/**/*.rb", __FILE__)

--- a/lib/aruba/matchers/file/be_a_command_found_in_path.rb
+++ b/lib/aruba/matchers/file/be_a_command_found_in_path.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method be_a_command_found_in_path
 #   This matchers checks if <command> can be found in path

--- a/lib/aruba/matchers/file/be_an_existing_executable.rb
+++ b/lib/aruba/matchers/file/be_an_existing_executable.rb
@@ -1,5 +1,5 @@
-require 'rspec/expectations/version'
-require 'shellwords'
+require "rspec/expectations/version"
+require "shellwords"
 
 # @!method be_an_existing_executable
 #   This matchers checks if <file> exists in filesystem

--- a/lib/aruba/matchers/file/be_an_existing_file.rb
+++ b/lib/aruba/matchers/file/be_an_existing_file.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method be_an_existing_file
 #   This matchers checks if <file> exists in filesystem
@@ -19,7 +19,7 @@ RSpec::Matchers.define :be_an_existing_file do |_|
   match do |actual|
     stop_all_commands
 
-    raise 'String expected' unless actual.is_a? String
+    raise "String expected" unless actual.is_a? String
 
     file?(actual)
   end

--- a/lib/aruba/matchers/file/have_file_content.rb
+++ b/lib/aruba/matchers/file/have_file_content.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method have_file_content(content)
 #   This matchers checks if <file> has content. `content` can be a string,

--- a/lib/aruba/matchers/file/have_file_size.rb
+++ b/lib/aruba/matchers/file/have_file_size.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method have_file_size(size)
 #   This matchers checks if path has file size

--- a/lib/aruba/matchers/file/have_same_file_content.rb
+++ b/lib/aruba/matchers/file/have_same_file_content.rb
@@ -1,5 +1,5 @@
-require 'rspec/expectations/version'
-require 'fileutils'
+require "rspec/expectations/version"
+require "fileutils"
 
 # @!method have_same_file_content_as(file_name)
 #   This matchers checks if <file1> has the same content like <file2>

--- a/lib/aruba/matchers/path.rb
+++ b/lib/aruba/matchers/path.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../path/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../path/**/*.rb", __FILE__)

--- a/lib/aruba/matchers/path/a_path_matching_pattern.rb
+++ b/lib/aruba/matchers/path/a_path_matching_pattern.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method a_path_matching_pattern(/pattern/)
 #   This matchers checks if <path> matches pattern. `pattern` can be a string,

--- a/lib/aruba/matchers/path/be_an_absolute_path.rb
+++ b/lib/aruba/matchers/path/be_an_absolute_path.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method be_an_absolute_path
 #   This matchers checks if <path> exists in filesystem

--- a/lib/aruba/matchers/path/be_an_existing_path.rb
+++ b/lib/aruba/matchers/path/be_an_existing_path.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method be_an_existing_path
 #   This matchers checks if <path> exists in filesystem

--- a/lib/aruba/matchers/path/have_permissions.rb
+++ b/lib/aruba/matchers/path/have_permissions.rb
@@ -1,4 +1,4 @@
-require 'rspec/expectations/version'
+require "rspec/expectations/version"
 
 # @!method have_permissions(permissions)
 #   This matchers checks if <file> or <directory> has <perm> permissions
@@ -43,7 +43,7 @@ RSpec::Matchers.define :have_permissions do |expected|
                 when Integer
                   expected.to_s(8)
                 when String
-                  expected.gsub(/^0*/, '')
+                  expected.gsub(/^0*/, "")
                 else
                   expected
                 end

--- a/lib/aruba/matchers/string.rb
+++ b/lib/aruba/matchers/string.rb
@@ -1,1 +1,1 @@
-Aruba.platform.require_matching_files('../string/**/*.rb', __FILE__)
+Aruba.platform.require_matching_files("../string/**/*.rb", __FILE__)

--- a/lib/aruba/matchers/string/include_output_string.rb
+++ b/lib/aruba/matchers/string/include_output_string.rb
@@ -18,7 +18,7 @@
 #     end
 RSpec::Matchers.define :include_output_string do |expected|
   match do |actual|
-    actual.force_encoding('UTF-8')
+    actual.force_encoding("UTF-8")
     @expected = Regexp.new(Regexp.escape(sanitize_text(expected.to_s)), Regexp::MULTILINE)
     @actual   = sanitize_text(actual)
 

--- a/lib/aruba/matchers/string/match_output_string.rb
+++ b/lib/aruba/matchers/string/match_output_string.rb
@@ -18,7 +18,7 @@
 #     end
 RSpec::Matchers.define :match_output_string do |expected|
   match do |actual|
-    actual.force_encoding('UTF-8')
+    actual.force_encoding("UTF-8")
     @expected = Regexp.new(unescape_text(expected), Regexp::MULTILINE)
     @actual   = sanitize_text(actual)
 

--- a/lib/aruba/matchers/string/output_string_eq.rb
+++ b/lib/aruba/matchers/string/output_string_eq.rb
@@ -18,7 +18,7 @@
 #     end
 RSpec::Matchers.define :output_string_eq do |expected|
   match do |actual|
-    actual.force_encoding('UTF-8')
+    actual.force_encoding("UTF-8")
     @expected = sanitize_text(expected.to_s)
     @actual   = sanitize_text(actual.to_s)
 

--- a/lib/aruba/platform.rb
+++ b/lib/aruba/platform.rb
@@ -1,5 +1,5 @@
-require 'aruba/platforms/unix_platform'
-require 'aruba/platforms/windows_platform'
+require "aruba/platforms/unix_platform"
+require "aruba/platforms/windows_platform"
 
 # Aruba
 module Aruba

--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -1,7 +1,7 @@
-require 'shellwords'
-require 'aruba/colorizer'
+require "shellwords"
+require "aruba/colorizer"
 
-Aruba::Colorizer.coloring = false if !$stdout.tty? && !ENV.key?('AUTOTEST')
+Aruba::Colorizer.coloring = false if !$stdout.tty? && !ENV.key?("AUTOTEST")
 
 # Aruba
 module Aruba
@@ -81,29 +81,29 @@ module Aruba
       private
 
       def after_init
-        output_format :changed_configuration, proc { |n, v| format('# %s = %s', n, v) }
+        output_format :changed_configuration, proc { |n, v| format("# %s = %s", n, v) }
         output_format :changed_environment,
-                      proc { |n, v| format('$ export %s=%s', n, Shellwords.escape(v)) }
-        output_format :command, '$ %s'
-        output_format :directory, '$ cd %s'
+                      proc { |n, v| format("$ export %s=%s", n, Shellwords.escape(v)) }
+        output_format :command, "$ %s"
+        output_format :directory, "$ cd %s"
         output_format :environment,
-                      proc { |n, v| format('$ export %s=%s', n, Shellwords.escape(v)) }
+                      proc { |n, v| format("$ export %s=%s", n, Shellwords.escape(v)) }
         output_format :full_environment,
                       proc { |h|
                         format("<<-ENVIRONMENT\n%s\nENVIRONMENT",
                                Aruba.platform.simple_table(h))
                       }
         output_format :modified_environment,
-                      proc { |n, v| format('$ export %s=%s', n, Shellwords.escape(v)) }
+                      proc { |n, v| format("$ export %s=%s", n, Shellwords.escape(v)) }
         output_format :stderr, "<<-STDERR\n%s\nSTDERR"
         output_format :stdout, "<<-STDOUT\n%s\nSTDOUT"
         output_format :command_content, "<<-COMMAND\n%s\nCOMMAND"
         output_format :stop_signal,
                       proc { |p, s|
-                        format('Command will be stopped with `kill -%s %s`', s, p)
+                        format("Command will be stopped with `kill -%s %s`", s, p)
                       }
-        output_format :timeout, '# %s-timeout: %s seconds'
-        output_format :wait_time, '# %s: %s seconds'
+        output_format :timeout, "# %s-timeout: %s seconds"
+        output_format :wait_time, "# %s: %s seconds"
         output_format :command_filesystem_status,
                       proc { |status|
                         format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS",
@@ -111,7 +111,7 @@ module Aruba
                       }
       end
 
-      def output_format(channel, string = '%s', &block)
+      def output_format(channel, string = "%s", &block)
         output_formats[channel.to_sym] = if block
                                            block
                                          elsif string.is_a?(Proc)
@@ -180,7 +180,7 @@ module Aruba
         the_output_format = if output_formats.key? channel
                               output_formats[channel]
                             else
-                              proc { |v| format('%s', v) }
+                              proc { |v| format("%s", v) }
                             end
 
         return unless activated?(channel)

--- a/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
+++ b/lib/aruba/platforms/aruba_fixed_size_file_creator.rb
@@ -28,7 +28,7 @@ module Aruba
 
         Aruba.platform.mkdir(File.dirname(path))
 
-        File.open(path, 'wb') do |f|
+        File.open(path, "wb") do |f|
           f.seek(size - 1)
           f.write("\0")
         end

--- a/lib/aruba/platforms/aruba_logger.rb
+++ b/lib/aruba/platforms/aruba_logger.rb
@@ -1,4 +1,4 @@
-require 'logger'
+require "logger"
 
 # Aruba
 module Aruba

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -1,4 +1,4 @@
-require 'aruba/errors'
+require "aruba/errors"
 
 # Aruba
 module Aruba
@@ -20,7 +20,7 @@ module Aruba
       end
 
       def method_missing(*)
-        raise NoCommandHasBeenStoppedError, 'No last command stopped available'
+        raise NoCommandHasBeenStoppedError, "No last command stopped available"
       end
 
       def respond_to_missing?(*)
@@ -34,7 +34,7 @@ module Aruba
       end
 
       def method_missing(*)
-        raise NoCommandHasBeenStartedError, 'No last command started available'
+        raise NoCommandHasBeenStartedError, "No last command started available"
       end
 
       def respond_to_missing?(*)
@@ -96,7 +96,7 @@ module Aruba
     def all_stdout
       registered_commands.each(&:stop)
 
-      registered_commands.each_with_object('') { |e, a| a << e.stdout }
+      registered_commands.each_with_object("") { |e, a| a << e.stdout }
     end
 
     # Get stderr of all commands
@@ -106,7 +106,7 @@ module Aruba
     def all_stderr
       registered_commands.each(&:stop)
 
-      registered_commands.each_with_object('') { |e, a| a << e.stderr }
+      registered_commands.each_with_object("") { |e, a| a << e.stderr }
     end
 
     # Get stderr and stdout of all commands

--- a/lib/aruba/platforms/determine_disk_usage.rb
+++ b/lib/aruba/platforms/determine_disk_usage.rb
@@ -1,4 +1,4 @@
-require 'aruba/file_size'
+require "aruba/file_size"
 
 module Aruba
   module Platforms

--- a/lib/aruba/platforms/filesystem_status.rb
+++ b/lib/aruba/platforms/filesystem_status.rb
@@ -36,7 +36,7 @@ module Aruba
 
       # Return permissions
       def mode
-        format('%o', status.mode)[-4, 4].gsub(/^0*/, '')
+        format("%o", status.mode)[-4, 4].gsub(/^0*/, "")
       end
 
       # Return owner

--- a/lib/aruba/platforms/simple_table.rb
+++ b/lib/aruba/platforms/simple_table.rb
@@ -27,7 +27,7 @@ module Aruba
       #   The table
       def to_s
         longest_key = hash.keys.map(&:to_s).max_by(&:length)
-        return '' if longest_key.nil?
+        return "" if longest_key.nil?
 
         name_size = longest_key.length
 

--- a/lib/aruba/platforms/unix_command_string.rb
+++ b/lib/aruba/platforms/unix_command_string.rb
@@ -1,5 +1,5 @@
-require 'delegate'
-require 'shellwords'
+require "delegate"
+require "shellwords"
 
 # Aruba
 module Aruba

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -1,20 +1,20 @@
-require 'rbconfig'
-require 'pathname'
+require "rbconfig"
+require "pathname"
 
-require 'aruba/aruba_path'
+require "aruba/aruba_path"
 
-require 'aruba/platforms/simple_table'
-require 'aruba/platforms/unix_command_string'
-require 'aruba/platforms/unix_which'
-require 'aruba/platforms/determine_file_size'
-require 'aruba/platforms/determine_disk_usage'
-require 'aruba/platforms/aruba_file_creator'
-require 'aruba/platforms/aruba_fixed_size_file_creator'
-require 'aruba/platforms/local_environment'
-require 'aruba/platforms/aruba_logger'
-require 'aruba/platforms/announcer'
-require 'aruba/platforms/command_monitor'
-require 'aruba/platforms/filesystem_status'
+require "aruba/platforms/simple_table"
+require "aruba/platforms/unix_command_string"
+require "aruba/platforms/unix_which"
+require "aruba/platforms/determine_file_size"
+require "aruba/platforms/determine_disk_usage"
+require "aruba/platforms/aruba_file_creator"
+require "aruba/platforms/aruba_fixed_size_file_creator"
+require "aruba/platforms/local_environment"
+require "aruba/platforms/aruba_logger"
+require "aruba/platforms/announcer"
+require "aruba/platforms/command_monitor"
+require "aruba/platforms/filesystem_status"
 
 # Aruba
 module Aruba
@@ -79,7 +79,7 @@ module Aruba
       end
 
       def default_shell
-        'bash'
+        "bash"
       end
 
       def detect_ruby(cmd)
@@ -91,11 +91,11 @@ module Aruba
       end
 
       def deprecated(msg)
-        warn(format('%s. Called by %s', msg, caller[1]))
+        warn(format("%s. Called by %s", msg, caller[1]))
       end
 
       def current_ruby
-        ::File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+        ::File.join(RbConfig::CONFIG["bindir"], RbConfig::CONFIG["ruby_install_name"])
       end
 
       def require_matching_files(pattern, base)
@@ -125,7 +125,7 @@ module Aruba
       def chdir(dir_name, &block)
         dir_name = ::File.expand_path(dir_name.to_s)
 
-        with_environment 'OLDPWD' => getwd, 'PWD' => dir_name do
+        with_environment "OLDPWD" => getwd, "PWD" => dir_name do
           ::Dir.chdir(dir_name, &block)
         end
       end
@@ -233,7 +233,7 @@ module Aruba
       # @param [String] path
       #   The PATH, a string concatenated with ":", e.g. /usr/bin/:/bin on a
       #   UNIX-system
-      def which(program, path = ENV['PATH'])
+      def which(program, path = ENV["PATH"])
         UnixWhich.new.call(program, path)
       end
 

--- a/lib/aruba/platforms/unix_which.rb
+++ b/lib/aruba/platforms/unix_which.rb
@@ -70,7 +70,7 @@ module Aruba
       #
       # @param [String] path
       #   ENV['PATH']
-      def call(program, path = ENV['PATH'])
+      def call(program, path = ENV["PATH"])
         raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
 
         program = program.to_s

--- a/lib/aruba/platforms/windows_command_string.rb
+++ b/lib/aruba/platforms/windows_command_string.rb
@@ -15,7 +15,7 @@ module Aruba
 
       # Convert to array
       def to_a
-        [cmd_path, '/c', [escaped_command, *escaped_arguments].join(' ')]
+        [cmd_path, "/c", [escaped_command, *escaped_arguments].join(" ")]
       end
 
       private
@@ -30,7 +30,7 @@ module Aruba
       end
 
       def cmd_path
-        Aruba.platform.which('cmd.exe')
+        Aruba.platform.which("cmd.exe")
       end
     end
   end

--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -1,4 +1,4 @@
-require 'aruba/platforms/unix_environment_variables'
+require "aruba/platforms/unix_environment_variables"
 
 # Aruba
 module Aruba

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -1,9 +1,9 @@
-require 'cucumber/platform'
+require "cucumber/platform"
 
-require 'aruba/platforms/unix_platform'
-require 'aruba/platforms/windows_command_string'
-require 'aruba/platforms/windows_environment_variables'
-require 'aruba/platforms/windows_which'
+require "aruba/platforms/unix_platform"
+require "aruba/platforms/windows_command_string"
+require "aruba/platforms/windows_environment_variables"
+require "aruba/platforms/windows_which"
 
 # Aruba
 module Aruba
@@ -34,7 +34,7 @@ module Aruba
       end
 
       # @see UnixPlatform#which
-      def which(program, path = ENV['PATH'])
+      def which(program, path = ENV["PATH"])
         WindowsWhich.new.call(program, path)
       end
 

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -49,7 +49,7 @@ module Aruba
             file = File.join(dir, program)
             # Dir[] doesn't handle backslashes properly, so convert them. Also, if
             # the program name doesn't have an extension, try them all.
-            file = file.tr('\\', '/')
+            file = file.tr('\\', "/")
 
             found = Dir[file].first
 
@@ -84,7 +84,7 @@ module Aruba
       #
       # @param [String] path
       #   ENV['PATH']
-      def call(program, path = ENV['PATH'])
+      def call(program, path = ENV["PATH"])
         raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
 
         program = program.to_s
@@ -96,10 +96,10 @@ module Aruba
       private
 
       def windows_executable_extentions
-        if ENV['PATHEXT']
-          format('.{%s}', ENV['PATHEXT'].tr(';', ',').tr('.', '')).downcase
+        if ENV["PATHEXT"]
+          format(".{%s}", ENV["PATHEXT"].tr(";", ",").tr(".", "")).downcase
         else
-          '.{exe,com,bat}'
+          ".{exe,com,bat}"
         end
       end
     end

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -1,5 +1,5 @@
-require 'aruba/platform'
-require 'shellwords'
+require "aruba/platform"
+require "shellwords"
 
 # Aruba
 module Aruba

--- a/lib/aruba/processes/debug_process.rb
+++ b/lib/aruba/processes/debug_process.rb
@@ -1,4 +1,4 @@
-require 'aruba/processes/spawn_process'
+require "aruba/processes/spawn_process"
 
 # Aruba
 module Aruba
@@ -41,8 +41,8 @@ module Aruba
       # @return [String]
       #   A predefined string to make users aware they are using the DebugProcess
       def stdout(*)
-        'This is the debug launcher on STDOUT.' \
-          ' If this output is unexpected, please check your setup.'
+        "This is the debug launcher on STDOUT." \
+          " If this output is unexpected, please check your setup."
       end
 
       # Return stderr
@@ -50,8 +50,8 @@ module Aruba
       # @return [String]
       #   A predefined string to make users aware they are using the DebugProcess
       def stderr(*)
-        'This is the debug launcher on STDERR.' \
-          ' If this output is unexpected, please check your setup.'
+        "This is the debug launcher on STDERR." \
+          " If this output is unexpected, please check your setup."
       end
 
       # Write to nothing

--- a/lib/aruba/processes/in_process.rb
+++ b/lib/aruba/processes/in_process.rb
@@ -1,7 +1,7 @@
-require 'shellwords'
-require 'stringio'
-require 'aruba/processes/basic_process'
-require 'aruba/platform'
+require "shellwords"
+require "stringio"
+require "aruba/processes/basic_process"
+require "aruba/platform"
 
 # Aruba
 module Aruba
@@ -61,14 +61,14 @@ module Aruba
 
       # Start command
       def start
-        raise 'You need to call aruba.config.main_class = YourMainClass' unless main_class
+        raise "You need to call aruba.config.main_class = YourMainClass" unless main_class
 
         @started = true
 
         Dir.chdir @working_directory do
           before_run
 
-          Aruba.platform.with_environment environment.merge('PWD' => @working_directory) do
+          Aruba.platform.with_environment environment.merge("PWD" => @working_directory) do
             main_class.new(@argv, @stdin, @stdout, @stderr, @kernel).execute!
           end
 
@@ -110,7 +110,7 @@ module Aruba
       # Close io
       def close_io(name)
         unless [:stdin, :stdout, :stderr].include? name
-          raise ArgumentError, 'Only stdin stdout and stderr are allowed to close'
+          raise ArgumentError, "Only stdin stdout and stderr are allowed to close"
         end
 
         get_instance_variable(name.to_sym).close

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -1,10 +1,10 @@
-require 'childprocess'
-require 'tempfile'
-require 'shellwords'
+require "childprocess"
+require "tempfile"
+require "shellwords"
 
-require 'aruba/errors'
-require 'aruba/processes/basic_process'
-require 'aruba/platform'
+require "aruba/errors"
+require "aruba/processes/basic_process"
+require "aruba/platform"
 
 # Aruba
 module Aruba
@@ -67,23 +67,23 @@ module Aruba
         if started?
           error_message =
             "Command \"#{commandline}\" has already been started." \
-            ' Please `#stop` the command first and `#start` it again.' \
-            ' Alternatively use `#restart`.'
+            " Please `#stop` the command first and `#start` it again." \
+            " Alternatively use `#restart`."
           raise CommandAlreadyStartedError, error_message
         end
 
         @started = true
 
         @process = ChildProcess.build(*command_string.to_a)
-        @stdout_file = Tempfile.new('aruba-stdout-')
-        @stderr_file = Tempfile.new('aruba-stderr-')
+        @stdout_file = Tempfile.new("aruba-stdout-")
+        @stderr_file = Tempfile.new("aruba-stderr-")
 
         @stdout_file.sync = true
         @stderr_file.sync = true
 
-        if RUBY_VERSION >= '1.9'
-          @stdout_file.set_encoding('ASCII-8BIT')
-          @stderr_file.set_encoding('ASCII-8BIT')
+        if RUBY_VERSION >= "1.9"
+          @stdout_file.set_encoding("ASCII-8BIT")
+          @stderr_file.set_encoding("ASCII-8BIT")
         end
 
         @exit_status = nil
@@ -279,7 +279,7 @@ module Aruba
             if Aruba.platform.builtin_shell_commands.include?(command)
               command
             else
-              Aruba.platform.which(command, environment['PATH'])
+              Aruba.platform.which(command, environment["PATH"])
             end
           end
       end
@@ -295,7 +295,7 @@ module Aruba
         data = file.read
         file.close
 
-        data.force_encoding('UTF-8')
+        data.force_encoding("UTF-8")
       end
     end
   end

--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -1,8 +1,8 @@
-require 'rspec/core'
+require "rspec/core"
 
-require 'aruba'
-require 'aruba/api'
-require 'aruba/version'
+require "aruba"
+require "aruba/api"
+require "aruba/version"
 
 RSpec.configure do |config|
   config.include Aruba::Api, type: :aruba
@@ -14,12 +14,12 @@ RSpec.configure do |config|
 
       # Modify PATH to include project/bin
       prepend_environment_variable(
-        'PATH',
+        "PATH",
         aruba.config.command_search_paths.join(File::PATH_SEPARATOR) + File::PATH_SEPARATOR
       )
 
       # Use configured home directory as HOME
-      set_environment_variable 'HOME', aruba.config.home_directory
+      set_environment_variable "HOME", aruba.config.home_directory
     end
 
     example.run

--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -1,8 +1,8 @@
-require 'aruba/configuration'
-require 'aruba/aruba_path'
-require 'aruba/config_wrapper'
-require 'aruba/events'
-require 'aruba/event_bus'
+require "aruba/configuration"
+require "aruba/aruba_path"
+require "aruba/config_wrapper"
+require "aruba/events"
+require "aruba/event_bus"
 
 module Aruba
   # Runtime of aruba
@@ -84,7 +84,7 @@ module Aruba
         directory = candidates.find { |d| Aruba.platform.directory? d }
 
         unless directory
-          canditates_display = candidates.map { |d| format('"%s"', d) }.join(', ')
+          canditates_display = candidates.map { |d| format('"%s"', d) }.join(", ")
           raise "No existing fixtures directory found in #{canditates_display}."
         end
 

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -39,10 +39,10 @@ module Aruba
         :command_started,
         proc do |event|
           runtime.announcer.announce(:command) { event.entity.commandline }
-          runtime.announcer.announce(:timeout, 'exit') { event.entity.exit_timeout }
-          runtime.announcer.announce(:timeout, 'io wait') { event.entity.io_wait_timeout }
+          runtime.announcer.announce(:timeout, "exit") { event.entity.exit_timeout }
+          runtime.announcer.announce(:timeout, "io wait") { event.entity.io_wait_timeout }
           runtime.announcer
-            .announce(:wait_time, 'startup wait time') { event.entity.startup_wait_time }
+            .announce(:wait_time, "startup wait time") { event.entity.startup_wait_time }
           runtime.announcer.announce(:full_environment) { event.entity.environment }
         end
       )

--- a/lib/aruba/tasks/docker_helpers.rb
+++ b/lib/aruba/tasks/docker_helpers.rb
@@ -1,4 +1,4 @@
-require 'psych'
+require "psych"
 
 module Aruba
   class DockerRunInstance
@@ -43,15 +43,15 @@ module Aruba
       docker_image        = run_instance.image
 
       cmdline = []
-      cmdline << 'docker'
-      cmdline << 'build'
-      cmdline << '--no-cache=true' if cache == 'false'
+      cmdline << "docker"
+      cmdline << "build"
+      cmdline << "--no-cache=true" if cache == "false"
 
       %w(http_proxy https_proxy HTTP_PROXY HTTPS_PROXY).each do |var|
         next unless ENV.key? var
 
         proxy_uri = URI(ENV[var])
-        proxy_uri.host = '172.17.0.1'
+        proxy_uri.host = "172.17.0.1"
         cmdline << "--build-arg #{var}=#{proxy_uri}"
       end
 
@@ -59,7 +59,7 @@ module Aruba
       cmdline << "-f #{docker_file}"
       cmdline << File.dirname(docker_file)
 
-      cmdline.join(' ')
+      cmdline.join(" ")
     end
   end
 
@@ -81,10 +81,10 @@ module Aruba
       command = opts[:command]
 
       cmdline = []
-      cmdline << 'docker'
-      cmdline << 'run'
-      cmdline << '-it'
-      cmdline << '--rm'
+      cmdline << "docker"
+      cmdline << "run"
+      cmdline << "-it"
+      cmdline << "--rm"
       cmdline << "--name #{run_instance.container_name}"
 
       volumes.each do |v|
@@ -94,13 +94,13 @@ module Aruba
       cmdline << image
       cmdline << command if command
 
-      cmdline.join(' ')
+      cmdline.join(" ")
     end
 
     private
 
     def expand_volume_paths(volume_paths)
-      volume_paths.split(':').map { |path| File.expand_path(path) }.join(':')
+      volume_paths.split(":").map { |path| File.expand_path(path) }.join(":")
     end
   end
 
@@ -112,39 +112,39 @@ module Aruba
     public
 
     def initialize(path)
-      @data = Psych.load_file(path)['services']
+      @data = Psych.load_file(path)["services"]
     end
 
     def volumes(instance)
-      fetch(instance)['volumes']
+      fetch(instance)["volumes"]
     end
 
     def build_context(instance)
-      fetch(instance).fetch('build', {})['context']
+      fetch(instance).fetch("build", {})["context"]
     end
 
     def build_arguments(instance)
-      fetch(instance).fetch('build', {})['args']
+      fetch(instance).fetch("build", {})["args"]
     end
 
     def docker_file(instance)
-      fetch(instance).fetch('build', {})['dockerfile']
+      fetch(instance).fetch("build", {})["dockerfile"]
     end
 
     def image(instance)
-      fetch(instance)['image']
+      fetch(instance)["image"]
     end
 
     def container_name(instance)
-      fetch(instance)['container_name']
+      fetch(instance)["container_name"]
     end
 
     def command(instance)
-      fetch(instance)['command']
+      fetch(instance)["command"]
     end
 
     def working_directory(instance)
-      fetch(instance)['working_dir']
+      fetch(instance)["working_dir"]
     end
 
     private

--- a/lib/aruba/version.rb
+++ b/lib/aruba/version.rb
@@ -1,3 +1,3 @@
 module Aruba
-  VERSION = '1.0.4'.freeze
+  VERSION = "1.0.4".freeze
 end

--- a/spec/aruba/api/bundler_spec.rb
+++ b/spec/aruba/api/bundler_spec.rb
@@ -1,15 +1,15 @@
-require 'spec_helper'
-require 'aruba/api'
+require "spec_helper"
+require "aruba/api"
 
 RSpec.describe Aruba::Api::Bundler do
-  include_context 'uses aruba API'
+  include_context "uses aruba API"
 
-  describe '#unset_bundler_env_vars' do
+  describe "#unset_bundler_env_vars" do
     it "sets up Aruba's environment to clear Bundler's variables" do
       @aruba.unset_bundler_env_vars
 
-      expect(@aruba.aruba.environment['BUNDLE_PATH']).to be_nil
-      expect(@aruba.aruba.environment['BUNDLE_GEMFILE']).to be_nil
+      expect(@aruba.aruba.environment["BUNDLE_PATH"]).to be_nil
+      expect(@aruba.aruba.environment["BUNDLE_GEMFILE"]).to be_nil
     end
   end
 end

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -1,29 +1,29 @@
-require 'spec_helper'
-require 'aruba/api'
-require 'fileutils'
+require "spec_helper"
+require "aruba/api"
+require "fileutils"
 
 RSpec.describe Aruba::Api::Commands do
-  include_context 'uses aruba API'
+  include_context "uses aruba API"
 
-  describe '#run_command' do
-    context 'when succesfully running a command' do
-      before { @aruba.run_command 'cat' }
+  describe "#run_command" do
+    context "when succesfully running a command" do
+      before { @aruba.run_command "cat" }
 
       after { @aruba.all_commands.each(&:stop) }
 
-      it 'respond to input' do
-        @aruba.type 'Hello'
+      it "respond to input" do
+        @aruba.type "Hello"
         @aruba.type "\u0004"
-        expect(@aruba.last_command_started).to have_output 'Hello'
+        expect(@aruba.last_command_started).to have_output "Hello"
       end
 
-      it 'respond to close_input' do
-        @aruba.type 'Hello'
+      it "respond to close_input" do
+        @aruba.type "Hello"
         @aruba.close_input
-        expect(@aruba.last_command_started).to have_output 'Hello'
+        expect(@aruba.last_command_started).to have_output "Hello"
       end
 
-      it 'pipes data' do
+      it "pipes data" do
         @aruba.write_file(@file_name, "Hello\nWorld!")
         @aruba.pipe_in_file(@file_name)
         @aruba.close_input
@@ -31,7 +31,7 @@ RSpec.describe Aruba::Api::Commands do
       end
     end
 
-    context 'when mode is :in_process' do
+    context "when mode is :in_process" do
       before do
         @aruba.aruba.config.command_launcher = :in_process
       end
@@ -40,13 +40,13 @@ RSpec.describe Aruba::Api::Commands do
         @aruba.aruba.config.command_launcher = :spawn
       end
 
-      it 'raises an error' do
-        expect { @aruba.run_command 'cat' }.to raise_error NotImplementedError
+      it "raises an error" do
+        expect { @aruba.run_command "cat" }.to raise_error NotImplementedError
       end
     end
 
-    context 'when running a relative command' do
-      let(:cmd) { Cucumber::WINDOWS ? 'bin/testcmd.bat' : 'bin/testcmd' }
+    context "when running a relative command" do
+      let(:cmd) { Cucumber::WINDOWS ? "bin/testcmd.bat" : "bin/testcmd" }
 
       before do
         if Cucumber::WINDOWS
@@ -62,7 +62,7 @@ RSpec.describe Aruba::Api::Commands do
         end
       end
 
-      it 'finds the command from the test directory' do
+      it "finds the command from the test directory" do
         run_command(cmd)
         expect(last_command_started).to be_successfully_executed
       end

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -1,18 +1,18 @@
-require 'spec_helper'
-require 'aruba/api'
-require 'fileutils'
+require "spec_helper"
+require "aruba/api"
+require "fileutils"
 
 RSpec.describe Aruba::Api::Core do
-  include_context 'uses aruba API'
+  include_context "uses aruba API"
 
-  describe '#cd' do
+  describe "#cd" do
     before do
-      @directory_name = 'test_dir'
+      @directory_name = "test_dir"
       @directory_path = File.join(@aruba.aruba.current_directory, @directory_name)
     end
 
-    context 'with a block given' do
-      it 'runs the passed block in the given directory' do
+    context "with a block given" do
+      it "runs the passed block in the given directory" do
         @aruba.create_directory @directory_name
         full_path = File.expand_path(@directory_path)
         @aruba.cd @directory_name do
@@ -21,25 +21,25 @@ RSpec.describe Aruba::Api::Core do
         expect(Dir.pwd).not_to eq full_path
       end
 
-      it 'sets directory environment in the passed block' do
+      it "sets directory environment in the passed block" do
         @aruba.create_directory @directory_name
         old_pwd = Dir.pwd
         full_path = File.expand_path(@directory_path)
         @aruba.cd @directory_name do
-          expect(ENV['PWD']).to eq full_path
-          expect(ENV['OLDPWD']).to eq old_pwd
+          expect(ENV["PWD"]).to eq full_path
+          expect(ENV["OLDPWD"]).to eq old_pwd
         end
       end
 
-      it 'sets aruba environment in the passed block' do
+      it "sets aruba environment in the passed block" do
         @aruba.create_directory @directory_name
-        @aruba.set_environment_variable('FOO', 'bar')
+        @aruba.set_environment_variable("FOO", "bar")
         @aruba.cd @directory_name do
-          expect(ENV['FOO']).to eq 'bar'
+          expect(ENV["FOO"]).to eq "bar"
         end
       end
 
-      it 'does not touch other environment variables in the passed block' do
+      it "does not touch other environment variables in the passed block" do
         keys = ENV.keys - %w(PWD OLDPWD)
         old_values = ENV.values_at(*keys)
         @aruba.create_directory @directory_name
@@ -50,14 +50,14 @@ RSpec.describe Aruba::Api::Core do
 
       it 'expands "~" to the aruba home directory' do
         full_path = aruba.config.home_directory
-        @aruba.cd '~' do
+        @aruba.cd "~" do
           expect(Dir.pwd).to eq full_path
         end
         expect(Dir.pwd).not_to eq full_path
       end
     end
 
-    context 'with no block given' do
+    context "with no block given" do
       it "sets aruba's current directory to the given directory" do
         @aruba.create_directory @directory_name
         full_path = File.expand_path(@directory_path)
@@ -67,18 +67,18 @@ RSpec.describe Aruba::Api::Core do
 
       it 'expands "~" to the aruba home directory' do
         full_path = aruba.config.home_directory
-        @aruba.cd '~'
+        @aruba.cd "~"
         expect(File.expand_path(@aruba.aruba.current_directory)).to eq full_path
       end
     end
   end
 
-  describe '#expand_path' do
-    context 'when file_name is given' do
+  describe "#expand_path" do
+    context "when file_name is given" do
       it { expect(@aruba.expand_path(@file_name)).to eq File.expand_path(@file_path) }
     end
 
-    context 'when an absolute file_path is given' do
+    context "when an absolute file_path is given" do
       let(:logger) { @aruba.aruba.logger }
 
       before do
@@ -87,13 +87,13 @@ RSpec.describe Aruba::Api::Core do
 
       it { expect(@aruba.expand_path(@file_path)).to eq @file_path }
 
-      it 'warns about it' do
+      it "warns about it" do
         @aruba.expand_path(@file_path)
         expect(logger).to have_received(:warn)
           .with(/Aruba's `expand_path` method was called with an absolute path/)
       end
 
-      it 'does not warn about it if told not to' do
+      it "does not warn about it if told not to" do
         @aruba.aruba.config.allow_absolute_paths = true
         @aruba.expand_path(@file_path)
         expect(logger).not_to have_received(:warn)
@@ -101,67 +101,67 @@ RSpec.describe Aruba::Api::Core do
     end
 
     context 'when path contains "."' do
-      it { expect(@aruba.expand_path('.')).to eq File.expand_path(aruba.current_directory) }
+      it { expect(@aruba.expand_path(".")).to eq File.expand_path(aruba.current_directory) }
     end
 
     context 'when path contains ".."' do
       it {
-        expect(@aruba.expand_path('path/..'))
+        expect(@aruba.expand_path("path/.."))
           .to eq File.expand_path(File.join(aruba.current_directory))
       }
     end
 
-    context 'when path is nil' do
+    context "when path is nil" do
       it { expect { @aruba.expand_path(nil) }.to raise_error ArgumentError }
     end
 
-    context 'when path is empty' do
-      it { expect { @aruba.expand_path('') }.to raise_error ArgumentError }
+    context "when path is empty" do
+      it { expect { @aruba.expand_path("") }.to raise_error ArgumentError }
     end
 
-    context 'when second argument is given' do
-      it 'behaves similar to File.expand_path' do
-        expect(@aruba.expand_path(@file_name, 'path'))
-          .to eq File.expand_path(File.join(aruba.current_directory, 'path', @file_name))
+    context "when second argument is given" do
+      it "behaves similar to File.expand_path" do
+        expect(@aruba.expand_path(@file_name, "path"))
+          .to eq File.expand_path(File.join(aruba.current_directory, "path", @file_name))
       end
     end
 
     context 'when file_name contains fixtures "%" string' do
-      it 'finds files in the fixtures directory' do
-        expect(@aruba.expand_path('%/cli-app'))
-          .to eq File.expand_path('cli-app', File.join(aruba.fixtures_directory))
+      it "finds files in the fixtures directory" do
+        expect(@aruba.expand_path("%/cli-app"))
+          .to eq File.expand_path("cli-app", File.join(aruba.fixtures_directory))
       end
     end
   end
 
-  describe '#in_current_directory' do
+  describe "#in_current_directory" do
     let(:directory_path) { @aruba.aruba.current_directory }
     let!(:full_path) { File.expand_path(directory_path) }
 
-    context 'with a block given' do
-      it 'runs the passed block in the given directory' do
+    context "with a block given" do
+      it "runs the passed block in the given directory" do
         @aruba.in_current_directory do
           expect(Dir.pwd).to eq full_path
         end
         expect(Dir.pwd).not_to eq full_path
       end
 
-      it 'sets directory environment in the passed block' do
+      it "sets directory environment in the passed block" do
         old_pwd = Dir.pwd
         @aruba.in_current_directory do
-          expect(ENV['PWD']).to eq full_path
-          expect(ENV['OLDPWD']).to eq old_pwd
+          expect(ENV["PWD"]).to eq full_path
+          expect(ENV["OLDPWD"]).to eq old_pwd
         end
       end
 
-      it 'sets aruba environment in the passed block' do
-        @aruba.set_environment_variable('FOO', 'bar')
+      it "sets aruba environment in the passed block" do
+        @aruba.set_environment_variable("FOO", "bar")
         @aruba.in_current_directory do
-          expect(ENV['FOO']).to eq 'bar'
+          expect(ENV["FOO"]).to eq "bar"
         end
       end
 
-      it 'does not touch other environment variables in the passed block' do
+      it "does not touch other environment variables in the passed block" do
         keys = ENV.keys - %w(PWD OLDPWD)
         old_values = ENV.values_at(*keys)
         @aruba.in_current_directory do
@@ -171,88 +171,88 @@ RSpec.describe Aruba::Api::Core do
     end
   end
 
-  describe '#with_environment' do
-    it 'modifies env for block' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      ENV[variable] = '1'
+  describe "#with_environment" do
+    it "modifies env for block" do
+      variable = "THIS_IS_A_ENV_VAR"
+      ENV[variable] = "1"
 
-      @aruba.with_environment variable => '0' do
-        expect(ENV[variable]).to eq '0'
+      @aruba.with_environment variable => "0" do
+        expect(ENV[variable]).to eq "0"
       end
 
-      expect(ENV[variable]).to eq '1'
+      expect(ENV[variable]).to eq "1"
     end
 
-    it 'modifies env for recursive calls block' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      ENV[variable] = '1'
+    it "modifies env for recursive calls block" do
+      variable = "THIS_IS_A_ENV_VAR"
+      ENV[variable] = "1"
 
-      @aruba.with_environment variable => '0' do
+      @aruba.with_environment variable => "0" do
         @aruba.with_environment do
-          expect(ENV[variable]).to eq '0'
+          expect(ENV[variable]).to eq "0"
         end
       end
 
-      expect(ENV[variable]).to eq '1'
+      expect(ENV[variable]).to eq "1"
     end
 
-    it 'works together with #set_environment_variable' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      @aruba.set_environment_variable variable, '1'
+    it "works together with #set_environment_variable" do
+      variable = "THIS_IS_A_ENV_VAR"
+      @aruba.set_environment_variable variable, "1"
 
       @aruba.with_environment do
-        expect(ENV[variable]).to eq '1'
-        @aruba.set_environment_variable variable, '0'
+        expect(ENV[variable]).to eq "1"
+        @aruba.set_environment_variable variable, "0"
         @aruba.with_environment do
-          expect(ENV[variable]).to eq '0'
+          expect(ENV[variable]).to eq "0"
         end
-        expect(ENV[variable]).to eq '1'
+        expect(ENV[variable]).to eq "1"
       end
     end
 
-    it 'works with a mix of ENV and #set_environment_variable' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      @aruba.set_environment_variable variable, '1'
-      ENV[variable] = '2'
-      expect(ENV[variable]).to eq '2'
+    it "works with a mix of ENV and #set_environment_variable" do
+      variable = "THIS_IS_A_ENV_VAR"
+      @aruba.set_environment_variable variable, "1"
+      ENV[variable] = "2"
+      expect(ENV[variable]).to eq "2"
 
       @aruba.with_environment do
-        expect(ENV[variable]).to eq '1'
-        @aruba.set_environment_variable variable, '0'
+        expect(ENV[variable]).to eq "1"
+        @aruba.set_environment_variable variable, "0"
         @aruba.with_environment do
-          expect(ENV[variable]).to eq '0'
+          expect(ENV[variable]).to eq "0"
         end
-        expect(ENV[variable]).to eq '1'
+        expect(ENV[variable]).to eq "1"
       end
-      expect(ENV[variable]).to eq '2'
+      expect(ENV[variable]).to eq "2"
     end
 
-    it 'works with a mix of argument and #set_environment_variable' do
-      variable = 'THIS_IS_A_ENV_VAR'
+    it "works with a mix of argument and #set_environment_variable" do
+      variable = "THIS_IS_A_ENV_VAR"
 
-      @aruba.set_environment_variable variable, '1'
-      @aruba.with_environment variable => '2' do
-        expect(ENV[variable]).to eq '2'
+      @aruba.set_environment_variable variable, "1"
+      @aruba.with_environment variable => "2" do
+        expect(ENV[variable]).to eq "2"
         @aruba.with_environment do
-          expect(ENV[variable]).to eq '2'
+          expect(ENV[variable]).to eq "2"
         end
       end
     end
 
-    it 'works together with #delete_environment_variable' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      ENV[variable] = '2'
+    it "works together with #delete_environment_variable" do
+      variable = "THIS_IS_A_ENV_VAR"
+      ENV[variable] = "2"
       @aruba.delete_environment_variable variable
 
       @aruba.with_environment do
         expect(ENV[variable]).to be_nil
       end
-      expect(ENV[variable]).to eq '2'
+      expect(ENV[variable]).to eq "2"
     end
 
-    it 'works with #delete_environment_variable when called several times' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      ENV[variable] = '2'
+    it "works with #delete_environment_variable when called several times" do
+      variable = "THIS_IS_A_ENV_VAR"
+      ENV[variable] = "2"
       @aruba.delete_environment_variable variable
 
       @aruba.with_environment do
@@ -262,14 +262,14 @@ RSpec.describe Aruba::Api::Core do
       @aruba.with_environment do
         expect(ENV[variable]).to be_nil
       end
-      expect(ENV[variable]).to eq '2'
+      expect(ENV[variable]).to eq "2"
     end
 
-    it 'forgets passed argument when called again' do
-      variable = 'THIS_IS_A_ENV_VAR'
+    it "forgets passed argument when called again" do
+      variable = "THIS_IS_A_ENV_VAR"
 
       @aruba.with_environment variable => 2 do
-        expect(ENV[variable]).to eq '2'
+        expect(ENV[variable]).to eq "2"
       end
 
       @aruba.with_environment do
@@ -277,15 +277,15 @@ RSpec.describe Aruba::Api::Core do
       end
     end
 
-    it 'keeps values not set in argument' do
-      variable = 'THIS_IS_A_ENV_VAR'
-      ENV[variable] = '2'
-      expect(ENV[variable]).to eq '2'
+    it "keeps values not set in argument" do
+      variable = "THIS_IS_A_ENV_VAR"
+      ENV[variable] = "2"
+      expect(ENV[variable]).to eq "2"
 
       @aruba.with_environment do
-        expect(ENV[variable]).to eq '2'
+        expect(ENV[variable]).to eq "2"
       end
-      expect(ENV[variable]).to eq '2'
+      expect(ENV[variable]).to eq "2"
     end
   end
 end

--- a/spec/aruba/api/filesystem_spec.rb
+++ b/spec/aruba/api/filesystem_spec.rb
@@ -1,23 +1,23 @@
-require 'spec_helper'
-require 'aruba/api'
+require "spec_helper"
+require "aruba/api"
 
 RSpec.describe Aruba::Api::Filesystem do
-  include_context 'uses aruba API'
+  include_context "uses aruba API"
 
-  describe '#all_paths' do
+  describe "#all_paths" do
     let(:name) { @file_name }
     let(:path) { @file_path }
 
-    context 'when file exists' do
+    context "when file exists" do
       before do
-        Aruba.platform.write_file(path, '')
+        Aruba.platform.write_file(path, "")
       end
 
       it { expect(all_paths).to include expand_path(name) }
     end
 
-    context 'when directory exists' do
-      let(:name) { 'test_dir' }
+    context "when directory exists" do
+      let(:name) { "test_dir" }
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
       before do
@@ -27,25 +27,25 @@ RSpec.describe Aruba::Api::Filesystem do
       it { expect(all_paths).to include expand_path(name) }
     end
 
-    context 'when nothing exists' do
+    context "when nothing exists" do
       it { expect(all_paths).to eq [] }
     end
   end
 
-  describe '#all_files' do
+  describe "#all_files" do
     let(:name) { @file_name }
     let(:path) { @file_path }
 
-    context 'when file exists' do
+    context "when file exists" do
       before do
-        Aruba.platform.write_file(path, '')
+        Aruba.platform.write_file(path, "")
       end
 
       it { expect(all_files).to include expand_path(name) }
     end
 
-    context 'when directory exists' do
-      let(:name) { 'test_dir' }
+    context "when directory exists" do
+      let(:name) { "test_dir" }
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
       before do
@@ -55,25 +55,25 @@ RSpec.describe Aruba::Api::Filesystem do
       it { expect(all_files).to eq [] }
     end
 
-    context 'when nothing exists' do
+    context "when nothing exists" do
       it { expect(all_files).to eq [] }
     end
   end
 
-  describe '#all_directories' do
+  describe "#all_directories" do
     let(:name) { @file_name }
     let(:path) { @file_path }
 
-    context 'when file exists' do
+    context "when file exists" do
       before do
-        Aruba.platform.write_file(path, '')
+        Aruba.platform.write_file(path, "")
       end
 
       it { expect(all_directories).to eq [] }
     end
 
-    context 'when directory exists' do
-      let(:name) { 'test_dir' }
+    context "when directory exists" do
+      let(:name) { "test_dir" }
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
       before do
@@ -83,85 +83,85 @@ RSpec.describe Aruba::Api::Filesystem do
       it { expect(all_directories).to include expand_path(name) }
     end
 
-    context 'when nothing exists' do
+    context "when nothing exists" do
       it { expect(all_directories).to eq [] }
     end
   end
 
-  describe '#file_size' do
+  describe "#file_size" do
     let(:name) { @file_name }
     let(:path) { @file_path }
     let(:size) { file_size(name) }
 
-    context 'when file exists' do
+    context "when file exists" do
       before do
-        File.open(path, 'w') { |f| f.print 'a' }
+        File.open(path, "w") { |f| f.print "a" }
       end
 
       it { expect(size).to eq 1 }
     end
 
-    context 'when file does not exist' do
-      let(:name) { 'non_existing_file' }
+    context "when file does not exist" do
+      let(:name) { "non_existing_file" }
 
       it { expect { size }.to raise_error RSpec::Expectations::ExpectationNotMetError }
     end
   end
 
-  describe '#touch' do
+  describe "#touch" do
     let(:name) { @file_name }
     let(:path) { @file_path }
     let(:options) { {} }
 
     before do
-      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
+      @aruba.set_environment_variable "HOME", File.expand_path(@aruba.aruba.current_directory)
     end
 
-    context 'when touching a file that does not exist' do
+    context "when touching a file that does not exist" do
       before do
         @aruba.touch(name, options)
       end
 
-      context 'and should be created in an existing directory' do
+      context "and should be created in an existing directory" do
         it { expect(File.size(path)).to eq 0 }
 
-        it_behaves_like 'an existing file'
+        it_behaves_like "an existing file"
       end
 
-      context 'and should be created in a non-existing directory' do
-        let(:name) { 'directory/test' }
-        let(:path) { File.join(@aruba.aruba.current_directory, 'directory/test') }
+      context "and should be created in a non-existing directory" do
+        let(:name) { "directory/test" }
+        let(:path) { File.join(@aruba.aruba.current_directory, "directory/test") }
 
-        it_behaves_like 'an existing file'
+        it_behaves_like "an existing file"
       end
 
-      context 'and path includes ~' do
+      context "and path includes ~" do
         let(:string) { random_string }
-        let(:name) { File.join('~', string) }
+        let(:name) { File.join("~", string) }
         let(:path) { File.join(@aruba.aruba.current_directory, string) }
 
-        it_behaves_like 'an existing file'
+        it_behaves_like "an existing file"
       end
 
-      context 'and the mtime should be set statically' do
-        let(:time) { Time.parse('2014-01-01 10:00:00') }
-        let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
+      context "and the mtime should be set statically" do
+        let(:time) { Time.parse("2014-01-01 10:00:00") }
+        let(:options) { { mtime: Time.parse("2014-01-01 10:00:00") } }
 
-        it_behaves_like 'an existing file'
+        it_behaves_like "an existing file"
         it { expect(File.mtime(path)).to eq time }
       end
 
-      context 'and multiple file names are given' do
+      context "and multiple file names are given" do
         let(:name) { %w(file1 file2 file3) }
         let(:path) do
           %w(file1 file2 file3).map { |p| File.join(@aruba.aruba.current_directory, p) }
         end
 
-        it_behaves_like 'an existing file'
+        it_behaves_like "an existing file"
       end
     end
 
-    context 'when touching an existing directory' do
+    context "when touching an existing directory" do
       let(:name) { %w(directory1) }
       let(:path) { Array(name).map { |p| File.join(@aruba.aruba.current_directory, p) } }
 
@@ -170,65 +170,65 @@ RSpec.describe Aruba::Api::Filesystem do
         @aruba.touch(name, options)
       end
 
-      context 'and the mtime should be set statically' do
-        let(:time) { Time.parse('2014-01-01 10:00:00') }
-        let(:options) { { mtime: Time.parse('2014-01-01 10:00:00') } }
+      context "and the mtime should be set statically" do
+        let(:time) { Time.parse("2014-01-01 10:00:00") }
+        let(:options) { { mtime: Time.parse("2014-01-01 10:00:00") } }
 
-        it_behaves_like 'an existing directory'
+        it_behaves_like "an existing directory"
         it { Array(path).each { |p| expect(File.mtime(p)).to eq time } }
       end
     end
   end
 
-  describe '#absolute?' do
+  describe "#absolute?" do
     let(:name) { @file_name }
     let(:path) { File.expand_path(File.join(@aruba.aruba.current_directory, name)) }
 
-    context 'when is absolute path' do
+    context "when is absolute path" do
       it { expect(@aruba).to be_absolute(path) }
     end
 
-    context 'when is relative path' do
+    context "when is relative path" do
       it { expect(@aruba).not_to be_absolute(name) }
     end
   end
 
-  describe '#relative?' do
+  describe "#relative?" do
     let(:name) { @file_name }
     let(:path) { File.expand_path(File.join(@aruba.aruba.current_directory, name)) }
 
-    context 'when given an absolute path' do
+    context "when given an absolute path" do
       it { expect(@aruba).not_to be_relative(path) }
     end
 
-    context 'when given a relative path' do
+    context "when given a relative path" do
       it { expect(@aruba).to be_relative(name) }
     end
   end
 
-  describe '#exist?' do
-    context 'when given a file' do
+  describe "#exist?" do
+    context "when given a file" do
       let(:name) { @file_name }
       let(:path) { @file_path }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
-          Aruba.platform.write_file(path, '')
+          Aruba.platform.write_file(path, "")
         end
 
         it { expect(@aruba).to be_exist(name) }
       end
 
-      context 'when it does not exist' do
+      context "when it does not exist" do
         it { expect(@aruba).not_to be_exist(name) }
       end
     end
 
-    context 'when given a directory' do
-      let(:name) { 'test.d' }
+    context "when given a directory" do
+      let(:name) { "test.d" }
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
           Aruba.platform.mkdir(path)
         end
@@ -236,35 +236,35 @@ RSpec.describe Aruba::Api::Filesystem do
         it { expect(@aruba).to be_exist(name) }
       end
 
-      context 'when it does not exist' do
+      context "when it does not exist" do
         it { expect(@aruba).not_to be_exist(name) }
       end
     end
   end
 
-  describe '#file?' do
-    context 'when given a file' do
+  describe "#file?" do
+    context "when given a file" do
       let(:name) { @file_name }
       let(:path) { @file_path }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
-          Aruba.platform.write_file(path, '')
+          Aruba.platform.write_file(path, "")
         end
 
         it { expect(@aruba).to be_file(name) }
       end
 
-      context 'when does not exist' do
+      context "when does not exist" do
         it { expect(@aruba).not_to be_file(name) }
       end
     end
 
-    context 'when given a directory' do
-      let(:name) { 'test.d' }
+    context "when given a directory" do
+      let(:name) { "test.d" }
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
           Aruba.platform.mkdir(path)
         end
@@ -272,35 +272,35 @@ RSpec.describe Aruba::Api::Filesystem do
         it { expect(@aruba).not_to be_file(name) }
       end
 
-      context 'when does not exist' do
+      context "when does not exist" do
         it { expect(@aruba).not_to be_file(name) }
       end
     end
   end
 
-  describe '#directory?' do
-    context 'when given a file' do
+  describe "#directory?" do
+    context "when given a file" do
       let(:name) { @file_name }
       let(:path) { @file_path }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
-          Aruba.platform.write_file(path, '')
+          Aruba.platform.write_file(path, "")
         end
 
         it { expect(@aruba).not_to be_directory(name) }
       end
 
-      context 'when does not exist' do
+      context "when does not exist" do
         it { expect(@aruba).not_to be_directory(name) }
       end
     end
 
-    context 'when given a directory' do
-      let(:name) { 'test.d' }
+    context "when given a directory" do
+      let(:name) { "test.d" }
       let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
           Aruba.platform.mkdir(path)
         end
@@ -308,79 +308,79 @@ RSpec.describe Aruba::Api::Filesystem do
         it { expect(@aruba).to be_directory(name) }
       end
 
-      context 'when does not exist' do
+      context "when does not exist" do
         it { expect(@aruba).not_to be_directory(name) }
       end
     end
   end
 
-  describe '#copy' do
-    let(:source) { 'file.txt' }
-    let(:destination) { 'file1.txt' }
+  describe "#copy" do
+    let(:source) { "file.txt" }
+    let(:destination) { "file1.txt" }
 
-    context 'when source is existing' do
-      context 'when destination is non-existing' do
-        context 'when source is file' do
+    context "when source is existing" do
+      context "when destination is non-existing" do
+        context "when source is file" do
           before do
             create_test_files(source)
             @aruba.copy source, destination
           end
 
-          context 'when source is plain file' do
+          context "when source is plain file" do
             it { expect(destination).to be_an_existing_file }
           end
 
           context 'when source is contains "~" in path' do
-            let(:source) { '~/file.txt' }
+            let(:source) { "~/file.txt" }
 
             it { expect(destination).to be_an_existing_file }
           end
 
-          context 'when source is fixture' do
-            let(:source) { '%/copy/file.txt' }
-            let(:destination) { 'file.txt' }
+          context "when source is fixture" do
+            let(:source) { "%/copy/file.txt" }
+            let(:destination) { "file.txt" }
 
             it { expect(destination).to be_an_existing_file }
           end
 
-          context 'when source is list of files' do
+          context "when source is list of files" do
             let(:source) { %w(file1.txt file2.txt file3.txt) }
-            let(:destination) { 'file.d' }
+            let(:destination) { "file.d" }
             let(:destination_files) { source.map { |s| File.join(destination, s) } }
 
             it { expect(destination_files).to all be_an_existing_file }
           end
         end
 
-        context 'when source is directory' do
-          let(:source) { 'src.d' }
-          let(:destination) { 'dst.d' }
+        context "when source is directory" do
+          let(:source) { "src.d" }
+          let(:destination) { "dst.d" }
 
           before do
             Aruba.platform.mkdir(File.join(@aruba.aruba.current_directory, source))
             @aruba.copy source, destination
           end
 
-          context 'when source is single directory' do
+          context "when source is single directory" do
             it { expect(destination).to be_an_existing_directory }
           end
 
-          context 'when source is nested directory' do
-            let(:source) { 'src.d/subdir.d' }
-            let(:destination) { 'dst.d/' }
+          context "when source is nested directory" do
+            let(:source) { "src.d/subdir.d" }
+            let(:destination) { "dst.d/" }
 
             it { expect(destination).to be_an_existing_directory }
           end
         end
       end
 
-      context 'when destination is existing' do
-        context 'when source is list of files' do
+      context "when destination is existing" do
+        context "when source is list of files" do
           before { create_test_files(source) }
 
-          context 'when destination is directory' do
+          context "when destination is directory" do
             let(:source) { %w(file1.txt file2.txt file3.txt) }
-            let(:destination) { 'file.d' }
+            let(:destination) { "file.d" }
             let(:destination_files) { source.map { |s| File.join(destination, s) } }
 
             before do
@@ -391,26 +391,26 @@ RSpec.describe Aruba::Api::Filesystem do
             it { expect(destination_files).to all be_an_existing_file }
           end
 
-          context 'when destination is not a directory' do
+          context "when destination is not a directory" do
             let(:source) { %w(file1.txt file2.txt file3.txt) }
-            let(:destination) { 'file.txt' }
-            let(:error_message) { 'Multiples sources can only be copied to a directory' }
+            let(:destination) { "file.txt" }
+            let(:error_message) { "Multiples sources can only be copied to a directory" }
 
             before { create_test_files(destination) }
 
-            it 'raises an appropriate error' do
+            it "raises an appropriate error" do
               expect { @aruba.copy source, destination }
                 .to raise_error ArgumentError, error_message
             end
           end
 
-          context 'when a source is the same like destination' do
-            let(:source) { 'file1.txt' }
-            let(:destination) { 'file1.txt' }
+          context "when a source is the same like destination" do
+            let(:source) { "file1.txt" }
+            let(:destination) { "file1.txt" }
 
             before { create_test_files(source) }
 
-            it 'raises an appropriate error' do
+            it "raises an appropriate error" do
               src_path = File.expand_path(File.join(@aruba.aruba.current_directory, source))
               dest_path = File.expand_path(File.join(@aruba.aruba.current_directory,
                                                      destination))
@@ -420,14 +420,14 @@ RSpec.describe Aruba::Api::Filesystem do
             end
           end
 
-          context 'when a fixture is destination' do
-            let(:source) { '%/copy/file.txt' }
-            let(:destination) { '%/copy/file.txt' }
+          context "when a fixture is destination" do
+            let(:source) { "%/copy/file.txt" }
+            let(:destination) { "%/copy/file.txt" }
             let(:error_message) do
               "Using a fixture as destination (#{destination}) is not supported"
             end
 
-            it 'raises an appropriate error' do
+            it "raises an appropriate error" do
               expect { @aruba.copy source, destination }
                 .to raise_error ArgumentError, error_message
             end
@@ -435,31 +435,31 @@ RSpec.describe Aruba::Api::Filesystem do
         end
       end
 
-      context 'when source is non-existing' do
+      context "when source is non-existing" do
         it { expect { @aruba.copy source, destination }.to raise_error ArgumentError }
       end
     end
   end
 
-  describe '#write_file' do
-    it 'writes file' do
-      @aruba.write_file(@file_name, '')
+  describe "#write_file" do
+    it "writes file" do
+      @aruba.write_file(@file_name, "")
 
       expect(File.exist?(@file_path)).to eq true
     end
   end
 
-  describe '#write_fixed_size_file' do
-    it 'writes a fixed sized file' do
+  describe "#write_fixed_size_file" do
+    it "writes a fixed sized file" do
       @aruba.write_fixed_size_file(@file_name, @file_size)
       expect(File.exist?(@file_path)).to eq true
       expect(File.size(@file_path)).to eq @file_size
     end
 
-    it 'works with ~ in path name' do
-      file_path = File.join('~', random_string)
+    it "works with ~ in path name" do
+      file_path = File.join("~", random_string)
 
-      @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
+      @aruba.with_environment "HOME" => File.expand_path(aruba.current_directory) do
         @aruba.write_fixed_size_file(file_path, @file_size)
 
         expect(File.exist?(File.expand_path(file_path))).to eq true
@@ -468,67 +468,67 @@ RSpec.describe Aruba::Api::Filesystem do
     end
   end
 
-  describe '#chmod' do
+  describe "#chmod" do
     def actual_permissions
-      format('%o', File::Stat.new(file_path).mode)[-4, 4]
+      format("%o", File::Stat.new(file_path).mode)[-4, 4]
     end
 
     let(:file_name) { @file_name }
     let(:file_path) { @file_path }
-    let(:permissions) { '0644' }
+    let(:permissions) { "0644" }
 
     before do
-      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
-      File.open(file_path, 'w') { |f| f << '' }
+      @aruba.set_environment_variable "HOME", File.expand_path(@aruba.aruba.current_directory)
+      File.open(file_path, "w") { |f| f << "" }
       @aruba.chmod(permissions, file_name)
     end
 
-    context 'when file exists' do
-      context 'and permissions are given as string' do
-        it { expect(actual_permissions).to eq('0644') }
+    context "when file exists" do
+      context "and permissions are given as string" do
+        it { expect(actual_permissions).to eq("0644") }
       end
 
-      context 'and permissions are given as octal number' do
+      context "and permissions are given as octal number" do
         let(:permissions) { 0o644 }
 
-        it { expect(actual_permissions).to eq('0644') }
+        it { expect(actual_permissions).to eq("0644") }
       end
 
-      context 'and path has ~ in it' do
+      context "and path has ~ in it" do
         let(:path) { random_string }
-        let(:file_name) { File.join('~', path) }
+        let(:file_name) { File.join("~", path) }
         let(:file_path) { File.join(@aruba.aruba.current_directory, path) }
 
-        it { expect(actual_permissions).to eq('0644') }
+        it { expect(actual_permissions).to eq("0644") }
       end
     end
   end
 
-  describe '#with_file_content' do
+  describe "#with_file_content" do
     before do
-      @aruba.write_file(@file_name, 'foo bar baz')
+      @aruba.write_file(@file_name, "foo bar baz")
     end
 
     it "checks the given file's full content against the expectations in the passed block" do
       @aruba.with_file_content @file_name do |full_content|
-        expect(full_content).to eq 'foo bar baz'
+        expect(full_content).to eq "foo bar baz"
       end
     end
 
-    it 'works with ~ in path name' do
-      file_path = File.join('~', random_string)
+    it "works with ~ in path name" do
+      file_path = File.join("~", random_string)
 
-      @aruba.with_environment 'HOME' => File.expand_path(aruba.current_directory) do
-        @aruba.write_file(file_path, 'foo bar baz')
+      @aruba.with_environment "HOME" => File.expand_path(aruba.current_directory) do
+        @aruba.write_file(file_path, "foo bar baz")
 
         @aruba.with_file_content file_path do |full_content|
-          expect(full_content).to eq 'foo bar baz'
+          expect(full_content).to eq "foo bar baz"
         end
       end
     end
 
     context "checking the file's content against the expectations in the block" do
-      it 'is successful when the inner expectations match' do
+      it "is successful when the inner expectations match" do
         expect do
           @aruba.with_file_content @file_name do |full_content|
             expect(full_content).to     match(/foo/)
@@ -548,64 +548,64 @@ RSpec.describe Aruba::Api::Filesystem do
     end
   end
 
-  describe '#create_directory' do
+  describe "#create_directory" do
     before do
-      @directory_name = 'test_dir'
+      @directory_name = "test_dir"
       @directory_path = File.join(@aruba.aruba.current_directory, @directory_name)
     end
 
-    it 'creates a directory' do
+    it "creates a directory" do
       @aruba.create_directory @directory_name
       expect(File).to exist(File.expand_path(@directory_path))
     end
   end
 
-  describe '#read' do
-    let(:name) { 'test.txt' }
+  describe "#read" do
+    let(:name) { "test.txt" }
     let(:path) { File.join(@aruba.aruba.current_directory, name) }
-    let(:content) { 'asdf' }
+    let(:content) { "asdf" }
 
     before do
-      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
+      @aruba.set_environment_variable "HOME", File.expand_path(@aruba.aruba.current_directory)
     end
 
-    context 'when does not exist' do
+    context "when does not exist" do
       it { expect { @aruba.read(name) }.to raise_error ArgumentError }
     end
 
-    context 'when it exists' do
-      context 'when file' do
+    context "when it exists" do
+      context "when file" do
         before do
-          File.open(File.expand_path(path), 'w') { |f| f << content }
+          File.open(File.expand_path(path), "w") { |f| f << content }
         end
 
-        context 'when normal file' do
+        context "when normal file" do
           it { expect(@aruba.read(name)).to eq [content] }
         end
 
-        context 'when binary file' do
+        context "when binary file" do
           let(:content) { "\u0000" }
 
           it { expect(@aruba.read(name)).to eq [content] }
         end
 
-        context 'when is empty file' do
-          let(:content) { '' }
+        context "when is empty file" do
+          let(:content) { "" }
 
           it { expect(@aruba.read(name)).to eq [] }
         end
 
-        context 'when path contains ~' do
+        context "when path contains ~" do
           let(:string) { random_string }
-          let(:name) { File.join('~', string) }
+          let(:name) { File.join("~", string) }
           let(:path) { File.join(@aruba.aruba.current_directory, string) }
 
           it { expect(@aruba.read(name)).to eq [content] }
         end
       end
 
-      context 'when directory' do
-        let(:name) { 'test.d' }
+      context "when directory" do
+        let(:name) { "test.d" }
 
         before do
           Aruba.platform.mkdir path
@@ -616,49 +616,49 @@ RSpec.describe Aruba::Api::Filesystem do
     end
   end
 
-  describe '#list' do
-    let(:name) { 'test.d' }
+  describe "#list" do
+    let(:name) { "test.d" }
     let(:content) { %w(subdir.1.d subdir.2.d) }
     let(:path) { File.join(@aruba.aruba.current_directory, name) }
 
     before do
-      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
+      @aruba.set_environment_variable "HOME", File.expand_path(@aruba.aruba.current_directory)
     end
 
-    context 'when does not exist' do
+    context "when does not exist" do
       it { expect { @aruba.list(name) }.to raise_error ArgumentError }
     end
 
-    context 'when it exists' do
-      context 'when file' do
-        let(:name) { 'test.txt' }
+    context "when it exists" do
+      context "when file" do
+        let(:name) { "test.txt" }
 
         before do
-          File.open(File.expand_path(path), 'w') { |f| f << content }
+          File.open(File.expand_path(path), "w") { |f| f << content }
         end
 
-        context 'when normal file' do
+        context "when normal file" do
           it { expect { @aruba.list(name) }.to raise_error ArgumentError }
         end
       end
 
-      context 'when directory' do
+      context "when directory" do
         before do
           Aruba.platform.mkdir path
           Array(content).each { |it| Aruba.platform.mkdir File.join(path, it) }
         end
 
-        context 'when has subdirectories' do
-          context 'when is simple path' do
+        context "when has subdirectories" do
+          context "when is simple path" do
             let(:existing_files) { @aruba.list(name) }
             let(:expected_files) { content.map { |c| File.join(name, c) }.sort }
 
             it { expect(expected_files - existing_files).to be_empty }
           end
 
-          context 'when path contains ~' do
+          context "when path contains ~" do
             let(:string) { random_string }
-            let(:name) { File.join('~', string) }
+            let(:name) { File.join("~", string) }
             let(:path) { File.join(@aruba.aruba.current_directory, string) }
 
             let(:existing_files) { @aruba.list(name) }
@@ -668,7 +668,7 @@ RSpec.describe Aruba::Api::Filesystem do
           end
         end
 
-        context 'when has no subdirectories' do
+        context "when has no subdirectories" do
           let(:content) { [] }
 
           it { expect(@aruba.list(name)).to eq [] }
@@ -677,94 +677,94 @@ RSpec.describe Aruba::Api::Filesystem do
     end
   end
 
-  describe '#remove' do
-    let(:name) { 'test.txt' }
+  describe "#remove" do
+    let(:name) { "test.txt" }
     let(:path) { File.join(@aruba.aruba.current_directory, name) }
     let(:options) { {} }
 
     before do
-      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
+      @aruba.set_environment_variable "HOME", File.expand_path(@aruba.aruba.current_directory)
     end
 
-    context 'when given a file' do
-      context 'when it exists' do
+    context "when given a file" do
+      context "when it exists" do
         before do
-          Array(path).each { |it| File.open(File.expand_path(it), 'w') { |f| f << '' } }
+          Array(path).each { |it| File.open(File.expand_path(it), "w") { |f| f << "" } }
 
           @aruba.remove(name, options)
         end
 
-        context 'when is a single file' do
-          it_behaves_like 'a non-existing file'
+        context "when is a single file" do
+          it_behaves_like "a non-existing file"
         end
 
-        context 'when are multiple files' do
+        context "when are multiple files" do
           let(:name) { %w(file1 file2 file3) }
           let(:path) { name.map { |it| File.join(@aruba.aruba.current_directory, it) } }
 
-          it_behaves_like 'a non-existing file'
+          it_behaves_like "a non-existing file"
         end
 
-        context 'when path contains ~' do
+        context "when path contains ~" do
           let(:string) { random_string }
-          let(:name) { File.join('~', string) }
+          let(:name) { File.join("~", string) }
           let(:path) { File.join(@aruba.aruba.current_directory, string) }
 
-          it_behaves_like 'a non-existing file'
+          it_behaves_like "a non-existing file"
         end
       end
 
-      context 'when it does not exist' do
+      context "when it does not exist" do
         before do
           @aruba.remove(name, options)
         end
 
-        context 'when forced to delete the file' do
+        context "when forced to delete the file" do
           let(:options) { { force: true } }
 
-          it_behaves_like 'a non-existing file'
+          it_behaves_like "a non-existing file"
         end
       end
     end
 
-    context 'when given a directory' do
-      let(:name) { 'test.d' }
+    context "when given a directory" do
+      let(:name) { "test.d" }
 
-      context 'when it exists' do
+      context "when it exists" do
         before do
           Array(path).each { |it| Aruba.platform.mkdir it }
           @aruba.remove(name, options)
         end
 
-        context 'when is a single directory' do
-          it_behaves_like 'a non-existing directory'
+        context "when is a single directory" do
+          it_behaves_like "a non-existing directory"
         end
 
-        context 'when are multiple directorys' do
+        context "when are multiple directorys" do
           let(:name) { %w(directory1 directory2 directory3) }
           let(:path) { name.map { |it| File.join(@aruba.aruba.current_directory, it) } }
 
-          it_behaves_like 'a non-existing directory'
+          it_behaves_like "a non-existing directory"
         end
 
-        context 'when path contains ~' do
+        context "when path contains ~" do
           let(:string) { random_string }
-          let(:name) { File.join('~', string) }
+          let(:name) { File.join("~", string) }
           let(:path) { File.join(@aruba.aruba.current_directory, string) }
 
-          it_behaves_like 'a non-existing directory'
+          it_behaves_like "a non-existing directory"
         end
       end
 
-      context 'when it does not exist' do
+      context "when it does not exist" do
         before do
           @aruba.remove(name, options)
         end
 
-        context 'when forced to delete the directory' do
+        context "when forced to delete the directory" do
           let(:options) { { force: true } }
 
-          it_behaves_like 'a non-existing directory'
+          it_behaves_like "a non-existing directory"
         end
       end
     end

--- a/spec/aruba/api/runtime_spec.rb
+++ b/spec/aruba/api/runtime_spec.rb
@@ -1,15 +1,15 @@
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe 'aruba' do
-  describe '#config' do
+RSpec.describe "aruba" do
+  describe "#config" do
     subject(:config) { aruba.config }
 
-    context 'when initialized' do
+    context "when initialized" do
       it { is_expected.to eq Aruba.config }
     end
 
-    context 'when changed earlier' do
-      context 'values when init' do
+    context "when changed earlier" do
+      context "values when init" do
         let(:value) { 20 }
 
         before { aruba.config.io_wait_timeout = value }
@@ -17,7 +17,7 @@ RSpec.describe 'aruba' do
         it { expect(config.io_wait_timeout).to eq value }
       end
 
-      context 'default value' do
+      context "default value" do
         let(:value) { 0.1 } # Aruba.config.io_wait_timeout
 
         it { expect(config.io_wait_timeout).to eq value }

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -1,62 +1,62 @@
-require 'spec_helper'
-require 'aruba/api'
-require 'fileutils'
-require 'time'
+require "spec_helper"
+require "aruba/api"
+require "fileutils"
+require "time"
 
 describe Aruba::Api do
-  include_context 'uses aruba API'
+  include_context "uses aruba API"
 
-  describe 'tags' do
-    describe '@announce_stdout' do
+  describe "tags" do
+    describe "@announce_stdout" do
       after { @aruba.all_commands.each(&:stop) }
 
-      context 'enabled' do
+      context "enabled" do
         before do
-          @aruba.aruba.announcer = instance_double 'Aruba::Platforms::Announcer'
+          @aruba.aruba.announcer = instance_double "Aruba::Platforms::Announcer"
           allow(@aruba.aruba.announcer).to receive(:announce)
         end
 
-        it 'announces to stdout exactly once' do
+        it "announces to stdout exactly once" do
           @aruba.run_command_and_stop('echo "hello world"', fail_on_error: false)
 
           aggregate_failures do
-            expect(@aruba.last_command_started.output).to include('hello world')
+            expect(@aruba.last_command_started.output).to include("hello world")
             expect(@aruba.aruba.announcer).to have_received(:announce).with(:stdout).once
           end
         end
       end
 
-      context 'disabled' do
-        it 'does not announce to stdout' do
+      context "disabled" do
+        it "does not announce to stdout" do
           result = capture(:stdout) do
             @aruba.run_command_and_stop('echo "hello world"', fail_on_error: false)
           end
 
-          expect(result).not_to include('hello world')
-          expect(@aruba.last_command_started.output).to include('hello world')
+          expect(result).not_to include("hello world")
+          expect(@aruba.last_command_started.output).to include("hello world")
         end
       end
     end
   end
 
-  describe '#set_environment_variable' do
+  describe "#set_environment_variable" do
     after do
       @aruba.all_commands.each(&:stop)
     end
 
-    it 'set environment variable' do
-      @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.run_command_and_stop 'env'
+    it "set environment variable" do
+      @aruba.set_environment_variable "LONG_LONG_ENV_VARIABLE", "true"
+      @aruba.run_command_and_stop "env"
       expect(@aruba.last_command_started.output)
-        .to include('LONG_LONG_ENV_VARIABLE=true')
+        .to include("LONG_LONG_ENV_VARIABLE=true")
     end
 
-    it 'overwrites environment variable' do
-      @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'true'
-      @aruba.set_environment_variable 'LONG_LONG_ENV_VARIABLE', 'false'
-      @aruba.run_command_and_stop 'env'
+    it "overwrites environment variable" do
+      @aruba.set_environment_variable "LONG_LONG_ENV_VARIABLE", "true"
+      @aruba.set_environment_variable "LONG_LONG_ENV_VARIABLE", "false"
+      @aruba.run_command_and_stop "env"
       expect(@aruba.last_command_started.output)
-        .to include('LONG_LONG_ENV_VARIABLE=false')
+        .to include("LONG_LONG_ENV_VARIABLE=false")
     end
   end
 end

--- a/spec/aruba/aruba_path_spec.rb
+++ b/spec/aruba/aruba_path_spec.rb
@@ -1,54 +1,54 @@
-require 'spec_helper'
-require 'aruba/aruba_path'
+require "spec_helper"
+require "aruba/aruba_path"
 
 RSpec.describe Aruba::ArubaPath do
-  describe '#pop' do
-    it 'pops a previously pushed path element' do
-      path = described_class.new('path/to/dir')
-      path.push 'subdir'
+  describe "#pop" do
+    it "pops a previously pushed path element" do
+      path = described_class.new("path/to/dir")
+      path.push "subdir"
       popped = path.pop
 
       aggregate_failures do
-        expect(popped).to eq 'subdir'
-        expect(path.to_s).to eq 'path/to/dir'
+        expect(popped).to eq "subdir"
+        expect(path.to_s).to eq "path/to/dir"
       end
     end
   end
 
-  describe '#to_s' do
-    it 'returns the path given in the initializer' do
-      path = described_class.new('path/to/dir')
-      expect(path.to_s).to eq 'path/to/dir'
+  describe "#to_s" do
+    it "returns the path given in the initializer" do
+      path = described_class.new("path/to/dir")
+      expect(path.to_s).to eq "path/to/dir"
     end
 
-    it 'combines pushed relative path elements' do
-      path = described_class.new('path/to')
-      path << 'dir'
-      expect(path.to_s).to eq 'path/to/dir'
+    it "combines pushed relative path elements" do
+      path = described_class.new("path/to")
+      path << "dir"
+      expect(path.to_s).to eq "path/to/dir"
     end
 
-    it 'replaces earlier elements when an absolute path was pushed' do
-      path = described_class.new('path/to')
-      path << '/foo'
-      expect(path.to_s).to eq '/foo'
+    it "replaces earlier elements when an absolute path was pushed" do
+      path = described_class.new("path/to")
+      path << "/foo"
+      expect(path.to_s).to eq "/foo"
     end
 
-    it 'replaces earlier elements when a home directory-relative path was pushed' do
-      path = described_class.new('path/to')
-      path << '~/foo'
-      expect(path.to_s).to eq '~/foo'
+    it "replaces earlier elements when a home directory-relative path was pushed" do
+      path = described_class.new("path/to")
+      path << "~/foo"
+      expect(path.to_s).to eq "~/foo"
     end
   end
 
-  describe '#[]' do
-    let(:path) { described_class.new('path/to/dir') }
+  describe "#[]" do
+    let(:path) { described_class.new("path/to/dir") }
 
-    context 'when single index' do
-      it { expect(path[0]).to eq 'p' }
+    context "when single index" do
+      it { expect(path[0]).to eq "p" }
     end
 
-    context 'when range' do
-      it { expect(path[0..1]).to eq 'pa' }
+    context "when range" do
+      it { expect(path[0..1]).to eq "pa" }
     end
   end
 end

--- a/spec/aruba/basic_configuration_spec.rb
+++ b/spec/aruba/basic_configuration_spec.rb
@@ -1,5 +1,5 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::BasicConfiguration do
-  it_behaves_like 'a basic configuration'
+  it_behaves_like "a basic configuration"
 end

--- a/spec/aruba/command_spec.rb
+++ b/spec/aruba/command_spec.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Command do
   subject(:command) do
     described_class.new(
-      'true',
+      "true",
       event_bus: event_bus,
       exit_timeout: exit_timeout,
       io_wait_timeout: io_wait_timeout,
@@ -15,27 +15,27 @@ RSpec.describe Aruba::Command do
     )
   end
 
-  let(:event_bus) { instance_double('Aruba::EventBus') }
+  let(:event_bus) { instance_double("Aruba::EventBus") }
   let(:exit_timeout) { 0.01 }
   let(:io_wait_timeout) { 0.01 }
-  let(:working_directory) { expand_path('.') }
+  let(:working_directory) { expand_path(".") }
   let(:environment) { ENV.to_hash }
   let(:main_class) { nil }
   let(:stop_signal) { nil }
   let(:startup_wait_time) { 0.01 }
 
-  describe '#start' do
+  describe "#start" do
     before do
       allow(event_bus).to receive(:notify).with(Aruba::Events::CommandStarted)
       command.start
     end
 
-    it 'leaves the command in the started state' do
+    it "leaves the command in the started state" do
       expect(command).to be_started
     end
   end
 
-  describe '#stop' do
+  describe "#stop" do
     before do
       allow(event_bus).to receive(:notify).with(Aruba::Events::CommandStarted)
       allow(event_bus).to receive(:notify).with(Aruba::Events::CommandStopped)
@@ -45,18 +45,18 @@ RSpec.describe Aruba::Command do
 
     it { is_expected.to be_stopped }
 
-    it 'notifies the event bus only once per run' do
+    it "notifies the event bus only once per run" do
       command.stop
       expect(event_bus).to have_received(:notify).with(Aruba::Events::CommandStopped).once
     end
 
-    it 'prevents #terminate from notifying the event bus' do
+    it "prevents #terminate from notifying the event bus" do
       command.terminate
       expect(event_bus).to have_received(:notify).with(Aruba::Events::CommandStopped).once
     end
   end
 
-  describe '#terminate' do
+  describe "#terminate" do
     before do
       allow(event_bus).to receive(:notify).with(Aruba::Events::CommandStarted)
       allow(event_bus).to receive(:notify).with(Aruba::Events::CommandStopped)
@@ -66,12 +66,12 @@ RSpec.describe Aruba::Command do
 
     it { is_expected.to be_stopped }
 
-    it 'notifies the event bus only once per run' do
+    it "notifies the event bus only once per run" do
       command.terminate
       expect(event_bus).to have_received(:notify).with(Aruba::Events::CommandStopped).once
     end
 
-    it 'prevents #stop from notifying the event bus' do
+    it "prevents #stop from notifying the event bus" do
       command.stop
       expect(event_bus).to have_received(:notify).with(Aruba::Events::CommandStopped).once
     end

--- a/spec/aruba/configuration_spec.rb
+++ b/spec/aruba/configuration_spec.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Configuration do
-  it_behaves_like 'a basic configuration'
+  it_behaves_like "a basic configuration"
 
-  context 'when is modified' do
+  context "when is modified" do
     let(:config) { described_class.new }
 
     it "won't allow bad values" do

--- a/spec/aruba/hooks_spec.rb
+++ b/spec/aruba/hooks_spec.rb
@@ -1,16 +1,16 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Aruba::Hooks do
   let(:hooks) { described_class.new }
 
-  it 'executes a stored hook' do
+  it "executes a stored hook" do
     hook_was_run = false
     hooks.append :hook_label, -> { hook_was_run = true }
     hooks.execute :hook_label, self
     expect(hook_was_run).to be_truthy
   end
 
-  it 'executes a stored hook that takes multiple arguments' do
+  it "executes a stored hook that takes multiple arguments" do
     hook_values = []
     hooks.append :hook_label, ->(a, b, c) { hook_values = [a, b, c] }
     hooks.execute :hook_label, self, 1, 2, 3

--- a/spec/aruba/in_config_wrapper_spec.rb
+++ b/spec/aruba/in_config_wrapper_spec.rb
@@ -1,29 +1,29 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::InConfigWrapper do
   subject(:wrapper) { described_class.new(config) }
 
   let(:config) { {} }
 
-  context 'when option is defined' do
+  context "when option is defined" do
     before do
       config[:opt] = true
     end
 
-    context 'when valid' do
+    context "when valid" do
       it { expect(wrapper.opt).to be true }
     end
 
-    context 'when one tries to pass arguments to option' do
+    context "when one tries to pass arguments to option" do
       it {
-        expect { wrapper.opt('arg') }
-          .to raise_error ArgumentError, 'Options take no argument'
+        expect { wrapper.opt("arg") }
+          .to raise_error ArgumentError, "Options take no argument"
       }
     end
   end
 
-  context 'when option is not defined' do
-    it 'raises an error' do
+  context "when option is not defined" do
+    it "raises an error" do
       expect { wrapper.opt }.to raise_error NoMethodError
     end
   end

--- a/spec/aruba/jruby_spec.rb
+++ b/spec/aruba/jruby_spec.rb
@@ -1,78 +1,78 @@
-require 'spec_helper'
-require 'aruba/api'
+require "spec_helper"
+require "aruba/api"
 
-describe 'Aruba JRuby Startup Helper' do
+describe "Aruba JRuby Startup Helper" do
   include Aruba::Api
 
   let(:rb_config) { instance_double(Hash) }
   let(:command) do
     instance_double(Aruba::Processes::BasicProcess, environment: command_environment)
   end
-  let(:command_environment) { { 'JRUBY_OPTS' => '--1.9', 'JAVA_OPTS' => '-Xdebug' } }
+  let(:command_environment) { { "JRUBY_OPTS" => "--1.9", "JAVA_OPTS" => "-Xdebug" } }
 
   before do
     Aruba.config.reset
 
     # Define before :command hook
-    load 'aruba/config/jruby.rb'
+    load "aruba/config/jruby.rb"
   end
 
-  context 'when running under some MRI Ruby' do
+  context "when running under some MRI Ruby" do
     before do
-      stub_const('RUBY_PLATFORM', 'x86_64-chocolate')
+      stub_const("RUBY_PLATFORM", "x86_64-chocolate")
     end
 
-    it 'keeps the existing JRUBY_OPTS and JAVA_OPTS environment values' do
+    it "keeps the existing JRUBY_OPTS and JAVA_OPTS environment values" do
       # Run defined before :command hook
       Aruba.config.run_before_hook :command, self, command
 
       aggregate_failures do
-        expect(command_environment['JRUBY_OPTS']).to eq '--1.9'
-        expect(command_environment['JAVA_OPTS']).to eq '-Xdebug'
+        expect(command_environment["JRUBY_OPTS"]).to eq "--1.9"
+        expect(command_environment["JAVA_OPTS"]).to eq "-Xdebug"
       end
     end
   end
 
-  context 'when running under JRuby but not on Solaris' do
+  context "when running under JRuby but not on Solaris" do
     before do
-      unless RUBY_PLATFORM == 'java'
-        stub_const 'RUBY_PLATFORM', 'java'
-        stub_const 'JRUBY_VERSION', '9.2.0.0'
+      unless RUBY_PLATFORM == "java"
+        stub_const "RUBY_PLATFORM", "java"
+        stub_const "JRUBY_VERSION", "9.2.0.0"
       end
-      stub_const 'RbConfig::CONFIG', rb_config
+      stub_const "RbConfig::CONFIG", rb_config
 
-      allow(rb_config).to receive(:[]).with('host_os').and_return('foo-os')
+      allow(rb_config).to receive(:[]).with("host_os").and_return("foo-os")
     end
 
-    it 'updates the existing JRuby but not Java option values' do
+    it "updates the existing JRuby but not Java option values" do
       # Run defined before :command hook
       Aruba.config.run_before_hook :command, self, command
 
       aggregate_failures do
-        expect(command_environment['JRUBY_OPTS']).to eq '--dev -X-C --1.9'
-        expect(command_environment['JAVA_OPTS']).to eq '-Xdebug'
+        expect(command_environment["JRUBY_OPTS"]).to eq "--dev -X-C --1.9"
+        expect(command_environment["JAVA_OPTS"]).to eq "-Xdebug"
       end
     end
   end
 
-  context 'when running under JRuby on Solaris' do
+  context "when running under JRuby on Solaris" do
     before do
-      unless RUBY_PLATFORM == 'java'
-        stub_const 'RUBY_PLATFORM', 'java'
-        stub_const 'JRUBY_VERSION', '9.2.0.0'
+      unless RUBY_PLATFORM == "java"
+        stub_const "RUBY_PLATFORM", "java"
+        stub_const "JRUBY_VERSION", "9.2.0.0"
       end
-      stub_const 'RbConfig::CONFIG', rb_config
+      stub_const "RbConfig::CONFIG", rb_config
 
-      allow(rb_config).to receive(:[]).with('host_os').and_return('solaris')
+      allow(rb_config).to receive(:[]).with("host_os").and_return("solaris")
     end
 
-    it 'keeps the existing JRuby and Java option values' do
+    it "keeps the existing JRuby and Java option values" do
       # Run defined before :command hook
       Aruba.config.run_before_hook :command, self, command
 
       aggregate_failures do
-        expect(command_environment['JRUBY_OPTS']).to eq '--dev -X-C --1.9'
-        expect(command_environment['JAVA_OPTS']).to eq '-d32 -Xdebug'
+        expect(command_environment["JRUBY_OPTS"]).to eq "--dev -X-C --1.9"
+        expect(command_environment["JAVA_OPTS"]).to eq "-d32 -Xdebug"
       end
     end
   end

--- a/spec/aruba/matchers/collection_spec.rb
+++ b/spec/aruba/matchers/collection_spec.rb
@@ -1,22 +1,22 @@
-require 'spec_helper'
-require 'rspec/matchers/fail_matchers'
+require "spec_helper"
+require "rspec/matchers/fail_matchers"
 
-RSpec.describe 'Collection Matchers' do
+RSpec.describe "Collection Matchers" do
   include RSpec::Matchers::FailMatchers
 
-  describe '#include_an_object' do
-    context 'when succeeding' do
-      describe [1, 4, 'a', 11] do
+  describe "#include_an_object" do
+    context "when succeeding" do
+      describe [1, 4, "a", 11] do
         it { is_expected.to include_an_object(be_odd) }
         it { is_expected.to include_an_object(be_an(Integer)) }
         it { is_expected.to include_an_object(be < 10) }
-        it { is_expected.not_to include_an_object(eq 'b') }
+        it { is_expected.not_to include_an_object(eq "b") }
       end
     end
 
-    context 'when failing' do
-      it 'emits failure messages for all candidate objects' do
-        no_oddity = [14, 'a']
+    context "when failing" do
+      it "emits failure messages for all candidate objects" do
+        no_oddity = [14, "a"]
         expect { expect(no_oddity).to include_an_object(be_odd) }
           .to fail_with <<~MESSAGE.strip
             expected [14, "a"] to include an object be odd
@@ -29,25 +29,25 @@ RSpec.describe 'Collection Matchers' do
           MESSAGE
       end
 
-      it 'emits plain failure message when negated' do
-        contains_evens = [14, 'a']
+      it "emits plain failure message when negated" do
+        contains_evens = [14, "a"]
         expect { expect(contains_evens).not_to include_an_object(be_even) }
           .to fail_with 'expected [14, "a"] not to include an object be even'
       end
 
-      it 'skips boiler plate if only one candidate object is given' do
+      it "skips boiler plate if only one candidate object is given" do
         only_one = [14]
         expect { expect(only_one).to include_an_object(be_odd) }
-          .to fail_with 'expected `14.odd?` to be truthy, got false'
+          .to fail_with "expected `14.odd?` to be truthy, got false"
       end
     end
 
-    context 'when succeeding with compound matchers' do
-      describe [1, 'anything', 'something'] do
-        it { is_expected.to include_an_object(be_a(String).and(include('thing'))) }
-        it { is_expected.to include_an_object(be_a(String).and(end_with('g'))) }
-        it { is_expected.to include_an_object(start_with('q').or(include('y'))) }
-        it { is_expected.not_to include_an_object(start_with('b').or(include('b'))) }
+    context "when succeeding with compound matchers" do
+      describe [1, "anything", "something"] do
+        it { is_expected.to include_an_object(be_a(String).and(include("thing"))) }
+        it { is_expected.to include_an_object(be_a(String).and(end_with("g"))) }
+        it { is_expected.to include_an_object(start_with("q").or(include("y"))) }
+        it { is_expected.not_to include_an_object(start_with("b").or(include("b"))) }
       end
     end
   end

--- a/spec/aruba/matchers/command/have_output_size_spec.rb
+++ b/spec/aruba/matchers/command/have_output_size_spec.rb
@@ -1,23 +1,23 @@
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe 'Output Matchers' do
-  include_context 'uses aruba API'
+RSpec.describe "Output Matchers" do
+  include_context "uses aruba API"
 
   def expand_path(*args)
     @aruba.expand_path(*args)
   end
 
-  describe '#to_have_output_size' do
-    let(:obj) { 'string' }
+  describe "#to_have_output_size" do
+    let(:obj) { "string" }
 
-    context 'when has size' do
-      context 'when is string' do
+    context "when has size" do
+      context "when is string" do
         it { expect(obj).to have_output_size 6 }
       end
     end
 
-    context 'when does not have size' do
-      let(:obj) { 'string' }
+    context "when does not have size" do
+      let(:obj) { "string" }
 
       it { expect(obj).not_to have_output_size(-1) }
     end

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -1,7 +1,7 @@
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe 'Command Matchers' do
-  include_context 'uses aruba API'
+RSpec.describe "Command Matchers" do
+  include_context "uses aruba API"
 
   def expand_path(*args)
     @aruba.expand_path(*args)
@@ -11,50 +11,50 @@ RSpec.describe 'Command Matchers' do
     @aruba.send(:announcer, *args)
   end
 
-  describe '#to_have_exit_status' do
-    let(:cmd) { 'true' }
+  describe "#to_have_exit_status" do
+    let(:cmd) { "true" }
 
     before { run_command(cmd) }
 
-    context 'when has exit 0' do
+    context "when has exit 0" do
       it { expect(last_command_started).to have_exit_status 0 }
     end
 
-    context 'when does not have exit 0' do
-      let(:cmd) { 'false' }
+    context "when does not have exit 0" do
+      let(:cmd) { "false" }
 
       it { expect(last_command_started).not_to have_exit_status 0 }
     end
   end
 
-  describe '#to_be_successfully_executed_' do
-    let(:cmd) { 'true' }
+  describe "#to_be_successfully_executed_" do
+    let(:cmd) { "true" }
 
     before { run_command(cmd) }
 
-    context 'when has exit 0' do
+    context "when has exit 0" do
       it { expect(last_command_started).to be_successfully_executed }
     end
 
-    context 'when does not have exit 0' do
-      let(:cmd) { 'false' }
+    context "when does not have exit 0" do
+      let(:cmd) { "false" }
 
       it { expect(last_command_started).not_to be_successfully_executed }
     end
   end
 
-  describe '#to_have_output' do
+  describe "#to_have_output" do
     let(:cmd) { "echo #{output}" }
-    let(:output) { 'hello world' }
+    let(:output) { "hello world" }
 
-    context 'when have output hello world on stdout' do
+    context "when have output hello world on stdout" do
       before { run_command(cmd) }
 
       it { expect(last_command_started).to have_output output }
     end
 
-    context 'when multiple commands output hello world on stdout' do
-      context 'and all comands must have the output' do
+    context "when multiple commands output hello world on stdout" do
+      context "and all comands must have the output" do
         before do
           run_command(cmd)
           run_command(cmd)
@@ -63,17 +63,17 @@ RSpec.describe 'Command Matchers' do
         it { expect(all_commands).to all have_output output }
       end
 
-      context 'and any comand can have the output' do
+      context "and any comand can have the output" do
         before do
           run_command(cmd)
-          run_command('echo hello universe')
+          run_command("echo hello universe")
         end
 
         it { expect(all_commands).to include have_output(output) }
       end
     end
 
-    context 'when have output hello world on stderr' do
+    context "when have output hello world on stderr" do
       let(:cmd) { "sh -c \"echo #{output} >&2\"" }
 
       before { run_command(cmd) }
@@ -81,24 +81,24 @@ RSpec.describe 'Command Matchers' do
       it { expect(last_command_started).to have_output output }
     end
 
-    context 'when not has output' do
+    context "when not has output" do
       before { run_command(cmd) }
 
-      it { expect(last_command_started).not_to have_output 'hello universe' }
+      it { expect(last_command_started).not_to have_output "hello universe" }
     end
   end
 
-  describe '#to_have_output_on_stdout' do
+  describe "#to_have_output_on_stdout" do
     let(:cmd) { "echo #{output}" }
-    let(:output) { 'hello world' }
+    let(:output) { "hello world" }
 
-    context 'when have output hello world on stdout' do
+    context "when have output hello world on stdout" do
       before { run_command(cmd) }
 
       it { expect(last_command_started).to have_output_on_stdout output }
     end
 
-    context 'when have output hello world on stderr' do
+    context "when have output hello world on stderr" do
       let(:cmd) { "sh -c \"echo #{output} >&2\"" }
 
       before { run_command(cmd) }
@@ -106,24 +106,24 @@ RSpec.describe 'Command Matchers' do
       it { expect(last_command_started).not_to have_output_on_stdout output }
     end
 
-    context 'when not has output' do
+    context "when not has output" do
       before { run_command(cmd) }
 
-      it { expect(last_command_started).not_to have_output_on_stdout 'hello universe' }
+      it { expect(last_command_started).not_to have_output_on_stdout "hello universe" }
     end
   end
 
-  describe '#to_have_output_on_stderr' do
+  describe "#to_have_output_on_stderr" do
     let(:cmd) { "echo #{output}" }
-    let(:output) { 'hello world' }
+    let(:output) { "hello world" }
 
-    context 'when have output hello world on stdout' do
+    context "when have output hello world on stdout" do
       before { run_command(cmd) }
 
       it { expect(last_command_started).not_to have_output_on_stderr output }
     end
 
-    context 'when have output hello world on stderr' do
+    context "when have output hello world on stderr" do
       let(:cmd) { "sh -c \"echo #{output} >&2\"" }
 
       before { run_command(cmd) }
@@ -131,10 +131,10 @@ RSpec.describe 'Command Matchers' do
       it { expect(last_command_started).to have_output_on_stderr output }
     end
 
-    context 'when not has output' do
+    context "when not has output" do
       before { run_command(cmd) }
 
-      it { expect(last_command_started).not_to have_output_on_stderr 'hello universe' }
+      it { expect(last_command_started).not_to have_output_on_stderr "hello universe" }
     end
   end
 end

--- a/spec/aruba/matchers/directory_spec.rb
+++ b/spec/aruba/matchers/directory_spec.rb
@@ -1,15 +1,15 @@
-require 'spec_helper'
-require 'aruba/matchers/directory'
-require 'fileutils'
+require "spec_helper"
+require "aruba/matchers/directory"
+require "fileutils"
 
-RSpec.describe 'Directory Matchers' do
-  include_context 'uses aruba API'
+RSpec.describe "Directory Matchers" do
+  include_context "uses aruba API"
 
-  describe 'to_be_an_existing_directory' do
-    let(:name) { 'test.d' }
+  describe "to_be_an_existing_directory" do
+    let(:name) { "test.d" }
     let(:path) { @aruba.expand_path(name) }
 
-    context 'when directory exists' do
+    context "when directory exists" do
       before do
         FileUtils.mkdir_p path
       end
@@ -17,37 +17,37 @@ RSpec.describe 'Directory Matchers' do
       it { expect(name).to be_an_existing_directory }
     end
 
-    context 'when directory does not exist' do
+    context "when directory does not exist" do
       it { expect(name).not_to be_an_existing_directory }
     end
   end
 
-  describe 'to_have_sub_directory' do
-    let(:name) { 'test.d' }
+  describe "to_have_sub_directory" do
+    let(:name) { "test.d" }
     let(:path) { @aruba.expand_path(name) }
     let(:content) { %w(subdir.1.d subdir.2.d) }
 
-    context 'when directory exists' do
+    context "when directory exists" do
       before do
         FileUtils.mkdir_p path
         Array(content).each { |p| Dir.mkdir File.join(path, p) }
       end
 
-      context 'when single directory' do
-        it { expect(name).to have_sub_directory('subdir.1.d') }
+      context "when single directory" do
+        it { expect(name).to have_sub_directory("subdir.1.d") }
       end
 
-      context 'when multiple directories' do
-        it { expect(name).to have_sub_directory(['subdir.1.d', 'subdir.2.d']) }
+      context "when multiple directories" do
+        it { expect(name).to have_sub_directory(["subdir.1.d", "subdir.2.d"]) }
       end
 
-      context 'when non existing directory' do
-        it { expect(name).not_to have_sub_directory('subdir.3.d') }
+      context "when non existing directory" do
+        it { expect(name).not_to have_sub_directory("subdir.3.d") }
       end
     end
 
-    context 'when directory does not exist' do
-      it { expect(name).not_to have_sub_directory('subdir') }
+    context "when directory does not exist" do
+      it { expect(name).not_to have_sub_directory("subdir") }
     end
   end
 end

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -1,104 +1,104 @@
-require 'spec_helper'
-require 'aruba/matchers/file'
+require "spec_helper"
+require "aruba/matchers/file"
 
-RSpec.describe 'File Matchers' do
-  include_context 'uses aruba API'
+RSpec.describe "File Matchers" do
+  include_context "uses aruba API"
 
-  describe 'to_be_an_existing_file' do
+  describe "to_be_an_existing_file" do
     let(:name) { @file_name }
 
-    context 'when file exists' do
+    context "when file exists" do
       before { create_test_files(name) }
 
       it { expect(name).to be_an_existing_file }
     end
 
-    context 'when file does not exist' do
+    context "when file does not exist" do
       it { expect(name).not_to be_an_existing_file }
     end
 
-    context 'when contains ~' do
-      let(:name) { File.join('~', random_string) }
+    context "when contains ~" do
+      let(:name) { File.join("~", random_string) }
 
       before do
-        @aruba.with_environment 'HOME' => expand_path('.') do
+        @aruba.with_environment "HOME" => expand_path(".") do
           create_test_files(name)
         end
       end
 
       it do
-        @aruba.with_environment 'HOME' => expand_path('.') do
+        @aruba.with_environment "HOME" => expand_path(".") do
           expect(name).to be_an_existing_file
         end
       end
     end
   end
 
-  describe 'to_have_file_content' do
-    context 'when file exists' do
+  describe "to_have_file_content" do
+    context "when file exists" do
       before do
-        Aruba.platform.write_file(@file_path, 'aba')
+        Aruba.platform.write_file(@file_path, "aba")
       end
 
-      context 'and file content is exactly equal string ' do
-        it { expect(@file_name).to have_file_content('aba') }
+      context "and file content is exactly equal string " do
+        it { expect(@file_name).to have_file_content("aba") }
       end
 
-      context 'and file content contains string' do
+      context "and file content contains string" do
         it { expect(@file_name).to have_file_content(/b/) }
       end
 
-      context 'and file content is not exactly equal string' do
-        it { expect(@file_name).not_to have_file_content('c') }
+      context "and file content is not exactly equal string" do
+        it { expect(@file_name).not_to have_file_content("c") }
       end
 
-      context 'and file content not contains string' do
+      context "and file content not contains string" do
         it { expect(@file_name).not_to have_file_content(/c/) }
       end
 
       context 'when other matchers is given which matches a string start with "a"' do
-        it { expect(@file_name).to have_file_content(a_string_starting_with('a')) }
+        it { expect(@file_name).to have_file_content(a_string_starting_with("a")) }
       end
     end
 
-    context 'when file does not exist' do
-      it { expect(@file_name).not_to have_file_content('a') }
+    context "when file does not exist" do
+      it { expect(@file_name).not_to have_file_content("a") }
     end
 
-    describe 'description' do
-      context 'when string' do
-        it { expect(have_file_content('a').description).to eq('have file content: "a"') }
+    describe "description" do
+      context "when string" do
+        it { expect(have_file_content("a").description).to eq('have file content: "a"') }
       end
 
-      context 'when regexp' do
-        it { expect(have_file_content(/a/).description).to eq('have file content: /a/') }
+      context "when regexp" do
+        it { expect(have_file_content(/a/).description).to eq("have file content: /a/") }
       end
 
-      it 'is correct when using a matcher' do
-        expect(have_file_content(a_string_starting_with('a')).description)
+      it "is correct when using a matcher" do
+        expect(have_file_content(a_string_starting_with("a")).description)
           .to eq('have file content: a string starting with "a"')
       end
     end
 
-    describe 'failure messages' do
+    describe "failure messages" do
       def fail_with(message)
         raise_error(RSpec::Expectations::ExpectationNotMetError, message)
       end
 
-      example 'for a string' do
+      example "for a string" do
         expect do
-          expect(@file_name).to have_file_content('z')
+          expect(@file_name).to have_file_content("z")
         end.to fail_with('expected "test.txt" to have file content: "z"')
       end
 
-      example 'for a regular expression' do
+      example "for a regular expression" do
         expect do
           expect(@file_name).to have_file_content(/z/)
         end.to fail_with('expected "test.txt" to have file content: /z/')
       end
 
-      example 'for a matcher' do
-        expect { expect(@file_name).to have_file_content(a_string_starting_with('z')) }
+      example "for a matcher" do
+        expect { expect(@file_name).to have_file_content(a_string_starting_with("z")) }
           .to fail_with(
             'expected "test.txt" to have file content: a string starting with "z"'
           )
@@ -106,25 +106,25 @@ RSpec.describe 'File Matchers' do
     end
   end
 
-  describe 'to have_same_file_content_as' do
+  describe "to have_same_file_content_as" do
     let(:file_name) { @file_name }
     let(:file_path) { @file_path }
 
-    let(:reference_file) { 'fixture' }
+    let(:reference_file) { "fixture" }
 
     before do
-      @aruba.write_file(@file_name, 'foo bar baz')
+      @aruba.write_file(@file_name, "foo bar baz")
       @aruba.write_file(reference_file, reference_file_content)
     end
 
-    context 'when files are the same' do
-      let(:reference_file_content) { 'foo bar baz' }
+    context "when files are the same" do
+      let(:reference_file_content) { "foo bar baz" }
 
-      context 'and this is expected' do
+      context "and this is expected" do
         it { expect(file_name).to have_same_file_content_as reference_file }
       end
 
-      context 'and this is not expected' do
+      context "and this is not expected" do
         it do
           expect { expect(file_name).not_to have_same_file_content_as reference_file }
             .to raise_error RSpec::Expectations::ExpectationNotMetError
@@ -132,14 +132,14 @@ RSpec.describe 'File Matchers' do
       end
     end
 
-    context 'when files are not the same' do
-      let(:reference_file_content) { 'bar' }
+    context "when files are not the same" do
+      let(:reference_file_content) { "bar" }
 
-      context 'and this is expected' do
+      context "and this is expected" do
         it { expect(file_name).not_to have_same_file_content_as reference_file }
       end
 
-      context 'and this is not expected' do
+      context "and this is not expected" do
         it do
           expect { expect(file_name).to have_same_file_content_as reference_file }
             .to raise_error RSpec::Expectations::ExpectationNotMetError
@@ -148,26 +148,26 @@ RSpec.describe 'File Matchers' do
     end
   end
 
-  describe 'include a_file_with_same_content_as' do
-    let(:reference_file) { 'fixture' }
-    let(:reference_file_content) { 'foo bar baz' }
-    let(:file_with_same_content) { 'file_a.txt' }
-    let(:file_with_different_content) { 'file_b.txt' }
+  describe "include a_file_with_same_content_as" do
+    let(:reference_file) { "fixture" }
+    let(:reference_file_content) { "foo bar baz" }
+    let(:file_with_same_content) { "file_a.txt" }
+    let(:file_with_different_content) { "file_b.txt" }
 
     before do
       @aruba.write_file(file_with_same_content, reference_file_content)
       @aruba.write_file(reference_file, reference_file_content)
-      @aruba.write_file(file_with_different_content, 'Some different content here...')
+      @aruba.write_file(file_with_different_content, "Some different content here...")
     end
 
-    context 'when the array of files includes a file with the same content' do
+    context "when the array of files includes a file with the same content" do
       let(:files) { [file_with_different_content, file_with_same_content] }
 
-      context 'and this is expected' do
+      context "and this is expected" do
         it { expect(files).to include a_file_with_same_content_as reference_file }
       end
 
-      context 'and this is not expected' do
+      context "and this is not expected" do
         it do
           expect { expect(files).not_to include a_file_with_same_content_as reference_file }
             .to raise_error RSpec::Expectations::ExpectationNotMetError
@@ -175,14 +175,14 @@ RSpec.describe 'File Matchers' do
       end
     end
 
-    context 'when the array of files does not include a file with the same content' do
+    context "when the array of files does not include a file with the same content" do
       let(:files) { [file_with_different_content] }
 
-      context 'and this is expected' do
+      context "and this is expected" do
         it { expect(files).not_to include a_file_with_same_content_as reference_file }
       end
 
-      context 'and this is not expected' do
+      context "and this is not expected" do
         it do
           expect { expect(files).to include a_file_with_same_content_as reference_file }
             .to raise_error RSpec::Expectations::ExpectationNotMetError
@@ -191,22 +191,22 @@ RSpec.describe 'File Matchers' do
     end
   end
 
-  describe 'to_have_file_size' do
-    context 'when file exists' do
+  describe "to_have_file_size" do
+    context "when file exists" do
       before do
-        Aruba.platform.write_file(@file_path, '')
+        Aruba.platform.write_file(@file_path, "")
       end
 
-      context 'and file size is equal' do
+      context "and file size is equal" do
         it { expect(@file_name).to have_file_size(0) }
       end
 
-      context 'and file size is not equal' do
+      context "and file size is not equal" do
         it { expect(@file_name).not_to have_file_size(1) }
       end
     end
 
-    context 'when file does not exist' do
+    context "when file does not exist" do
       it { expect(@file_name).not_to have_file_size(0) }
     end
   end

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -1,48 +1,48 @@
-require 'spec_helper'
+require "spec_helper"
 
-require 'fileutils'
-require 'aruba/matchers/path'
+require "fileutils"
+require "aruba/matchers/path"
 
-RSpec.describe 'Path Matchers' do
-  include_context 'uses aruba API'
+RSpec.describe "Path Matchers" do
+  include_context "uses aruba API"
 
   def expand_path(*args)
     @aruba.expand_path(*args)
   end
 
-  describe 'to_be_an_absolute_path' do
+  describe "to_be_an_absolute_path" do
     let(:name) { @file_name }
     let(:path) { @aruba.expand_path(name) }
 
-    context 'when is absolute path' do
+    context "when is absolute path" do
       it { expect(path).to be_an_absolute_path }
     end
 
-    context 'when is relative path' do
+    context "when is relative path" do
       it { expect(name).not_to be_an_absolute_path }
     end
   end
 
-  describe 'to_be_an_existing_path' do
-    context 'when file' do
-      context 'exists' do
+  describe "to_be_an_existing_path" do
+    context "when file" do
+      context "exists" do
         before do
-          Aruba.platform.write_file(@file_path, '')
+          Aruba.platform.write_file(@file_path, "")
         end
 
         it { expect(@file_name).to be_an_existing_path }
       end
 
-      context 'does not exist' do
+      context "does not exist" do
         it { expect(@file_name).not_to be_an_existing_path }
       end
     end
 
-    context 'when directory' do
-      let(:name) { 'test.d' }
+    context "when directory" do
+      let(:name) { "test.d" }
       let(:path) { @aruba.expand_path(name) }
 
-      context 'exists' do
+      context "exists" do
         before do
           FileUtils.mkdir_p path
         end
@@ -50,45 +50,45 @@ RSpec.describe 'Path Matchers' do
         it { expect(name).to be_an_existing_path }
       end
 
-      context 'does not exist' do
+      context "does not exist" do
         it { expect(name).not_to be_an_existing_path }
       end
     end
   end
 
-  describe 'to have_permissions' do
+  describe "to have_permissions" do
     let(:file_name) { @file_name }
     let(:file_path) { @file_path }
 
-    let(:permissions) { '0644' }
+    let(:permissions) { "0644" }
 
     before do
-      @aruba.set_environment_variable 'HOME', File.expand_path(@aruba.aruba.current_directory)
-      File.open(file_path, 'w') { |f| f << '' }
+      @aruba.set_environment_variable "HOME", File.expand_path(@aruba.aruba.current_directory)
+      File.open(file_path, "w") { |f| f << "" }
       @aruba.chmod(permissions, file_name)
     end
 
-    context 'when file exists' do
-      context 'and should have the same permissions' do
-        context 'and permissions are given as string' do
+    context "when file exists" do
+      context "and should have the same permissions" do
+        context "and permissions are given as string" do
           it { expect(file_name).to have_permissions permissions }
         end
 
-        context 'and permissions are given as octal number' do
+        context "and permissions are given as octal number" do
           let(:permissions) { 0o644 }
 
           it { expect(file_name).to have_permissions permissions }
         end
 
-        context 'and path includes ~' do
+        context "and path includes ~" do
           let(:string) { random_string }
-          let(:file_name) { File.join('~', string) }
+          let(:file_name) { File.join("~", string) }
           let(:file_path) { File.join(@aruba.aruba.current_directory, string) }
 
           it { expect(file_name).to have_permissions permissions }
         end
 
-        context 'but the permissions are different' do
+        context "but the permissions are different" do
           let(:expected_permissions) { 0o666 }
 
           it do
@@ -98,14 +98,14 @@ RSpec.describe 'Path Matchers' do
         end
       end
 
-      context 'and should not have the same permissions' do
-        context 'and permissions are different' do
+      context "and should not have the same permissions" do
+        context "and permissions are different" do
           let(:different_permissions) { 0o666 }
 
           it { expect(file_name).not_to have_permissions different_permissions }
         end
 
-        context 'but permissions are the same' do
+        context "but permissions are the same" do
           let(:different_permissions) { 0o644 }
 
           it do

--- a/spec/aruba/platform/simple_table_spec.rb
+++ b/spec/aruba/platform/simple_table_spec.rb
@@ -1,20 +1,20 @@
-require 'spec_helper'
-require 'aruba/platform'
+require "spec_helper"
+require "aruba/platform"
 
-RSpec.describe '.simple_table' do
-  context 'when valid hash' do
+RSpec.describe ".simple_table" do
+  context "when valid hash" do
     let(:hash) do
       {
-        key1: 'value',
-        key2: 'value'
+        key1: "value",
+        key2: "value"
       }
     end
-    let(:rows) { ['# key1 => value', '# key2 => value'] }
+    let(:rows) { ["# key1 => value", "# key2 => value"] }
 
     it { expect(Aruba.platform.simple_table(hash).to_s).to eq rows.join("\n") }
   end
 
-  context 'when empty hash' do
+  context "when empty hash" do
     let(:hash) { {} }
     let(:rows) { [] }
 

--- a/spec/aruba/platform/windows_environment_variables_spec.rb
+++ b/spec/aruba/platform/windows_environment_variables_spec.rb
@@ -1,198 +1,198 @@
-require 'spec_helper'
-require 'aruba/platforms/windows_environment_variables'
+require "spec_helper"
+require "aruba/platforms/windows_environment_variables"
 
 RSpec.describe Aruba::Platforms::WindowsEnvironmentVariables do
   subject(:environment) { described_class.new(old_environment) }
 
-  describe '#[]' do
-    context 'when environment contains uppercase variable' do
-      let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+  describe "#[]" do
+    context "when environment contains uppercase variable" do
+      let(:old_environment) { { "MY_VARIABLE" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
         it { expect(environment[variable]).to eq nil }
       end
     end
 
-    context 'when environment contains lowercase variable' do
-      let(:old_environment) { { 'my_variable' => '1' } }
+    context "when environment contains lowercase variable" do
+      let(:old_environment) { { "my_variable" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
         it { expect(environment[variable]).to eq nil }
       end
     end
 
-    context 'when environment contains mixed case variable' do
-      let(:old_environment) { { 'MY_variable' => '1' } }
+    context "when environment contains mixed case variable" do
+      let(:old_environment) { { "MY_variable" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq '1' }
+        it { expect(environment[variable]).to eq "1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
         it { expect(environment[variable]).to eq nil }
       end
     end
   end
 
-  describe '#fetch' do
-    context 'when environment contains uppercase variable' do
-      let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+  describe "#fetch" do
+    context "when environment contains uppercase variable" do
+      let(:old_environment) { { "MY_VARIABLE" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        context 'and no default is given' do
+        context "and no default is given" do
           it { expect { environment.fetch(variable) }.to raise_error KeyError }
         end
 
-        context 'and default is given' do
-          let(:default_value) { 'default_value' }
+        context "and default is given" do
+          let(:default_value) { "default_value" }
 
           it { expect(environment.fetch(variable, default_value)).to eq default_value }
         end
       end
     end
 
-    context 'when environment contains lowercase variable' do
-      let(:old_environment) { { 'my_variable' => '1' } }
+    context "when environment contains lowercase variable" do
+      let(:old_environment) { { "my_variable" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        context 'and no default is given' do
+        context "and no default is given" do
           it { expect { environment.fetch(variable) }.to raise_error KeyError }
         end
 
-        context 'and default is given' do
-          let(:default_value) { 'default_value' }
+        context "and default is given" do
+          let(:default_value) { "default_value" }
 
           it { expect(environment.fetch(variable, default_value)).to eq default_value }
         end
       end
     end
 
-    context 'when environment contains mixed case variable' do
-      let(:old_environment) { { 'MY_variable' => '1' } }
+    context "when environment contains mixed case variable" do
+      let(:old_environment) { { "MY_variable" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment.fetch(variable)).to eq '1' }
+        it { expect(environment.fetch(variable)).to eq "1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        context 'and no default is given' do
+        context "and no default is given" do
           it { expect { environment.fetch(variable) }.to raise_error KeyError }
         end
 
-        context 'and default is given' do
-          let(:default_value) { 'default_value' }
+        context "and default is given" do
+          let(:default_value) { "default_value" }
 
           it { expect(environment.fetch(variable, default_value)).to eq default_value }
         end
@@ -200,291 +200,291 @@ RSpec.describe Aruba::Platforms::WindowsEnvironmentVariables do
     end
   end
 
-  describe '#key?' do
-    context 'when environment contains uppercase variable' do
-      let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+  describe "#key?" do
+    context "when environment contains uppercase variable" do
+      let(:old_environment) { { "MY_VARIABLE" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
-
-        it { expect(environment).to be_key variable }
-      end
-
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
         it { expect(environment).to be_key variable }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
         it { expect(environment).to be_key variable }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
+
+        it { expect(environment).to be_key variable }
+      end
+
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
         it { expect(environment).not_to be_key variable }
       end
     end
 
-    context 'when environment contains lowercase variable' do
-      let(:old_environment) { { 'my_variable' => '1' } }
+    context "when environment contains lowercase variable" do
+      let(:old_environment) { { "my_variable" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
-
-        it { expect(environment).to be_key variable }
-      end
-
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
         it { expect(environment).to be_key variable }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
         it { expect(environment).to be_key variable }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
+
+        it { expect(environment).to be_key variable }
+      end
+
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
         it { expect(environment).not_to be_key variable }
       end
     end
 
-    context 'when environment contains mixed case variable' do
-      let(:old_environment) { { 'MY_variable' => '1' } }
+    context "when environment contains mixed case variable" do
+      let(:old_environment) { { "MY_variable" => "1" } }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
-
-        it { expect(environment).to be_key variable }
-      end
-
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
         it { expect(environment).to be_key variable }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
         it { expect(environment).to be_key variable }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
+
+        it { expect(environment).to be_key variable }
+      end
+
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
         it { expect(environment).not_to be_key variable }
       end
     end
   end
 
-  describe '#append' do
-    let(:value) { 'NEW_VALUE' }
+  describe "#append" do
+    let(:value) { "NEW_VALUE" }
 
-    context 'when environment contains uppercase variable' do
-      let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+    context "when environment contains uppercase variable" do
+      let(:old_environment) { { "MY_VARIABLE" => "1" } }
 
       before { environment.append(variable, value) }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE' }
+        it { expect(environment[variable]).to eq "NEW_VALUE" }
       end
     end
 
-    context 'when environment contains lowercase variable' do
-      let(:old_environment) { { 'my_variable' => '1' } }
+    context "when environment contains lowercase variable" do
+      let(:old_environment) { { "my_variable" => "1" } }
 
       before { environment.append(variable, value) }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE' }
+        it { expect(environment[variable]).to eq "NEW_VALUE" }
       end
     end
 
-    context 'when environment contains mixed case variable' do
-      let(:old_environment) { { 'MY_variable' => '1' } }
+    context "when environment contains mixed case variable" do
+      let(:old_environment) { { "MY_variable" => "1" } }
 
       before { environment.append(variable, value) }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq '1NEW_VALUE' }
+        it { expect(environment[variable]).to eq "1NEW_VALUE" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE' }
+        it { expect(environment[variable]).to eq "NEW_VALUE" }
       end
     end
   end
 
-  describe '#prepend' do
-    let(:value) { 'NEW_VALUE' }
+  describe "#prepend" do
+    let(:value) { "NEW_VALUE" }
 
-    context 'when environment contains uppercase variable' do
-      let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+    context "when environment contains uppercase variable" do
+      let(:old_environment) { { "MY_VARIABLE" => "1" } }
 
       before { environment.prepend(variable, value) }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE' }
+        it { expect(environment[variable]).to eq "NEW_VALUE" }
       end
     end
 
-    context 'when environment contains lowercase variable' do
-      let(:old_environment) { { 'my_variable' => '1' } }
+    context "when environment contains lowercase variable" do
+      let(:old_environment) { { "my_variable" => "1" } }
 
       before { environment.prepend(variable, value) }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE' }
+        it { expect(environment[variable]).to eq "NEW_VALUE" }
       end
     end
 
-    context 'when environment contains mixed case variable' do
-      let(:old_environment) { { 'MY_variable' => '1' } }
+    context "when environment contains mixed case variable" do
+      let(:old_environment) { { "MY_variable" => "1" } }
 
       before { environment.prepend(variable, value) }
 
-      context 'when uppercase key is given' do
-        let(:variable) { 'MY_VARIABLE' }
+      context "when uppercase key is given" do
+        let(:variable) { "MY_VARIABLE" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when lowercase key is given' do
-        let(:variable) { 'my_variable' }
+      context "when lowercase key is given" do
+        let(:variable) { "my_variable" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when mixed case key is given' do
-        let(:variable) { 'MY_variable' }
+      context "when mixed case key is given" do
+        let(:variable) { "MY_variable" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE1' }
+        it { expect(environment[variable]).to eq "NEW_VALUE1" }
       end
 
-      context 'when unknown variable is given' do
-        let(:variable) { 'unknown' }
+      context "when unknown variable is given" do
+        let(:variable) { "unknown" }
 
-        it { expect(environment[variable]).to eq 'NEW_VALUE' }
+        it { expect(environment[variable]).to eq "NEW_VALUE" }
       end
     end
   end
 
-  describe '#delete' do
-    let(:variable) { 'my_variable' }
-    let(:old_environment) { { 'MY_VARIABLE' => '1' } }
+  describe "#delete" do
+    let(:variable) { "my_variable" }
+    let(:old_environment) { { "MY_VARIABLE" => "1" } }
 
-    it 'deletes a value from the environment' do
+    it "deletes a value from the environment" do
       environment.delete(variable)
       expect(environment[variable]).to eq nil
     end
 
-    it 'returns deleted value' do
-      expect(environment.delete(variable)).to eq('1')
+    it "returns deleted value" do
+      expect(environment.delete(variable)).to eq("1")
     end
   end
 end

--- a/spec/aruba/platforms/announcer_spec.rb
+++ b/spec/aruba/platforms/announcer_spec.rb
@@ -1,16 +1,16 @@
-require 'spec_helper'
-require 'aruba/platforms/announcer'
+require "spec_helper"
+require "aruba/platforms/announcer"
 
 RSpec.describe Aruba::Platforms::Announcer do
   let(:announcer) { described_class.new }
 
-  describe '#mode=' do
-    it 'sets the mode to :puts' do
+  describe "#mode=" do
+    it "sets the mode to :puts" do
       announcer.mode = :puts
       expect(announcer.mode).to eq :puts
     end
 
-    it 'sets the mode to :kernel_puts' do
+    it "sets the mode to :kernel_puts" do
       announcer.mode = :kernel_puts
       expect(announcer.mode).to eq :kernel_puts
     end

--- a/spec/aruba/platforms/command_monitor_spec.rb
+++ b/spec/aruba/platforms/command_monitor_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::CommandMonitor do
   let(:monitor) { described_class.new(announcer: announcer) }
@@ -6,13 +6,13 @@ RSpec.describe Aruba::CommandMonitor do
   let(:process) { instance_double(Aruba::Processes::BasicProcess) }
 
   before do
-    allow(process).to receive(:commandline).and_return('foobar')
+    allow(process).to receive(:commandline).and_return("foobar")
     monitor.register_command(process)
   end
 
-  describe '#find' do
-    it 'works' do
-      expect(monitor.find('foobar')).to eq(process)
+  describe "#find" do
+    it "works" do
+      expect(monitor.find("foobar")).to eq(process)
     end
   end
 end

--- a/spec/aruba/platforms/unix_command_string_spec.rb
+++ b/spec/aruba/platforms/unix_command_string_spec.rb
@@ -1,25 +1,25 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Platforms::UnixCommandString do
   let(:command_string) { described_class.new(base_command, *arguments) }
   let(:arguments) { [] }
 
-  describe '#to_a' do
-    context 'with a command with a path' do
-      let(:base_command) { '/foo/bar' }
+  describe "#to_a" do
+    context "with a command with a path" do
+      let(:base_command) { "/foo/bar" }
 
       it { expect(command_string.to_a).to eq [base_command] }
     end
 
-    context 'with a command with a path containing spaces' do
-      let(:base_command) { '/foo bar/baz' }
+    context "with a command with a path containing spaces" do
+      let(:base_command) { "/foo bar/baz" }
 
       it { expect(command_string.to_a).to eq [base_command] }
     end
 
-    context 'with a command and arguments' do
-      let(:base_command) { '/foo/bar' }
-      let(:arguments) { ['-w', 'baz quux'] }
+    context "with a command and arguments" do
+      let(:base_command) { "/foo/bar" }
+      let(:arguments) { ["-w", "baz quux"] }
 
       it { expect(command_string.to_a).to eq [base_command, *arguments] }
     end

--- a/spec/aruba/platforms/windows_command_string_spec.rb
+++ b/spec/aruba/platforms/windows_command_string_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Platforms::WindowsCommandString do
   let(:command_string) { described_class.new(base_command, *arguments) }
@@ -6,29 +6,29 @@ RSpec.describe Aruba::Platforms::WindowsCommandString do
   let(:arguments) { [] }
 
   before do
-    allow(Aruba.platform).to receive(:which).with('cmd.exe').and_return(cmd_path)
+    allow(Aruba.platform).to receive(:which).with("cmd.exe").and_return(cmd_path)
   end
 
-  describe '#to_a' do
-    context 'with a command with a path' do
+  describe "#to_a" do
+    context "with a command with a path" do
       let(:base_command) { 'C:\Foo\Bar' }
 
-      it { expect(command_string.to_a).to eq [cmd_path, '/c', base_command] }
+      it { expect(command_string.to_a).to eq [cmd_path, "/c", base_command] }
     end
 
-    context 'with a command with a path containing spaces' do
+    context "with a command with a path containing spaces" do
       let(:base_command) { 'C:\Foo Bar\Baz' }
 
-      it { expect(command_string.to_a).to eq [cmd_path, '/c', 'C:\Foo""" """Bar\Baz'] }
+      it { expect(command_string.to_a).to eq [cmd_path, "/c", 'C:\Foo""" """Bar\Baz'] }
     end
 
-    context 'with a command and arguments' do
+    context "with a command and arguments" do
       let(:base_command) { 'C:\Foo\Bar' }
-      let(:arguments) { ['-w', 'baz quux'] }
+      let(:arguments) { ["-w", "baz quux"] }
 
       it {
         expect(command_string.to_a)
-          .to eq [cmd_path, '/c', "#{base_command} -w \"baz quux\""]
+          .to eq [cmd_path, "/c", "#{base_command} -w \"baz quux\""]
       }
     end
   end

--- a/spec/aruba/processes/basic_process_spec.rb
+++ b/spec/aruba/processes/basic_process_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Processes::BasicProcess do
   let(:process) do
@@ -19,42 +19,42 @@ RSpec.describe Aruba::Processes::BasicProcess do
     end.new(stdout, stderr, cmd, exit_timeout, io_wait_timeout, working_directory)
   end
 
-  let(:cmd) { 'foobar' }
+  let(:cmd) { "foobar" }
   let(:exit_timeout) { 0 }
   let(:io_wait_timeout) { 0 }
   let(:working_directory) { Dir.pwd }
-  let(:stdout) { 'foo output' }
-  let(:stderr) { 'foo error output' }
+  let(:stdout) { "foo output" }
+  let(:stderr) { "foo error output" }
 
-  describe '#inspect' do
-    it 'shows useful info' do
+  describe "#inspect" do
+    it "shows useful info" do
       expected = /commandline="foobar": stdout="foo output" stderr="foo error output"/
       expect(process.inspect).to match(expected)
     end
 
-    context 'with no stdout' do
+    context "with no stdout" do
       let(:stdout) { nil }
 
-      it 'shows useful info' do
+      it "shows useful info" do
         expected = /commandline="foobar": stdout=nil stderr="foo error output"/
         expect(process.inspect).to match(expected)
       end
     end
 
-    context 'with no stderr' do
+    context "with no stderr" do
       let(:stderr) { nil }
 
-      it 'shows useful info' do
+      it "shows useful info" do
         expected = /commandline="foobar": stdout="foo output" stderr=nil/
         expect(process.inspect).to match(expected)
       end
     end
 
-    context 'with neither stderr nor stdout' do
+    context "with neither stderr nor stdout" do
       let(:stderr) { nil }
       let(:stdout) { nil }
 
-      it 'shows useful info' do
+      it "shows useful info" do
         expected = /commandline="foobar": stdout=nil stderr=nil/
         expect(process.inspect).to match(expected)
       end

--- a/spec/aruba/processes/in_process_spec.rb
+++ b/spec/aruba/processes/in_process_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Processes::InProcess do
   let(:base_runner) do
@@ -16,7 +16,7 @@ RSpec.describe Aruba::Processes::InProcess do
   let(:stdout_runner) do
     Class.new(base_runner) do
       def execute!
-        @stdout.puts 'yo'
+        @stdout.puts "yo"
       end
     end
   end
@@ -24,7 +24,7 @@ RSpec.describe Aruba::Processes::InProcess do
   let(:stderr_runner) do
     Class.new(base_runner) do
       def execute!
-        @stderr.puts 'yo'
+        @stderr.puts "yo"
       end
     end
   end
@@ -32,7 +32,7 @@ RSpec.describe Aruba::Processes::InProcess do
   let(:failed_runner) do
     Class.new(base_runner) do
       def execute!
-        raise 'Oops'
+        raise "Oops"
       end
     end
   end
@@ -42,14 +42,14 @@ RSpec.describe Aruba::Processes::InProcess do
                         environment, main_class)
   end
 
-  let(:command) { 'foo' }
+  let(:command) { "foo" }
   let(:exit_timeout) { 1 }
   let(:io_wait) { 1 }
   let(:working_directory) { Dir.getwd }
   let(:environment) { ENV.to_hash.dup }
   let(:main_class) { base_runner }
 
-  describe '#stdout' do
+  describe "#stdout" do
     let(:main_class) { stdout_runner }
 
     before do
@@ -57,16 +57,16 @@ RSpec.describe Aruba::Processes::InProcess do
       process.stop
     end
 
-    context 'when invoked once' do
+    context "when invoked once" do
       it { expect(process.stdout).to eq "yo\n" }
     end
 
-    context 'when invoked twice' do
+    context "when invoked twice" do
       it { 2.times { expect(process.stdout).to eq "yo\n" } }
     end
   end
 
-  describe '#stderr' do
+  describe "#stderr" do
     let(:main_class) { stderr_runner }
 
     before do
@@ -74,46 +74,46 @@ RSpec.describe Aruba::Processes::InProcess do
       process.stop
     end
 
-    context 'when invoked once' do
+    context "when invoked once" do
       it { expect(process.stderr).to eq "yo\n" }
     end
 
-    context 'when invoked twice' do
+    context "when invoked twice" do
       it { 2.times { expect(process.stderr).to eq "yo\n" } }
     end
   end
 
-  describe '#stop' do
+  describe "#stop" do
     before { process.start }
 
-    context 'when stopped successfully' do
+    context "when stopped successfully" do
       it { expect { process.stop }.not_to raise_error }
 
-      it 'makes the process stopped' do
+      it "makes the process stopped" do
         process.stop
         expect(process).to be_stopped
       end
     end
   end
 
-  describe '#start' do
-    context 'when process run succeeds' do
+  describe "#start" do
+    context "when process run succeeds" do
       it { expect { process.start }.not_to raise_error }
 
-      it 'makes the process started' do
+      it "makes the process started" do
         process.start
         expect(process).to be_started
       end
     end
 
-    context 'when process run fails' do
+    context "when process run fails" do
       let(:main_class) { failed_runner }
 
-      it { expect { process.start }.to raise_error RuntimeError, 'Oops' }
+      it { expect { process.start }.to raise_error RuntimeError, "Oops" }
     end
   end
 
-  describe '#exit_status' do
+  describe "#exit_status" do
     def run_process(&block)
       process = described_class.new(
         command, exit_timeout, io_wait, working_directory,
@@ -124,21 +124,21 @@ RSpec.describe Aruba::Processes::InProcess do
       process
     end
 
-    it 'exits success' do
+    it "exits success" do
       expect(run_process { nil }.exit_status).to eq 0
     end
 
-    it 'exits with given status' do
+    it "exits with given status" do
       expect(run_process { @kernel.exit 12 }.exit_status).to eq 12
     end
 
-    it 'exits with boolean' do
+    it "exits with boolean" do
       expect(run_process { @kernel.exit false }.exit_status).to eq 1
     end
 
-    it 'refuses to exit with anything else' do
-      expect { run_process { @kernel.exit 'false' } }
-        .to raise_error(TypeError, 'no implicit conversion of String into Integer')
+    it "refuses to exit with anything else" do
+      expect { run_process { @kernel.exit "false" } }
+        .to raise_error(TypeError, "no implicit conversion of String into Integer")
     end
   end
 end

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Processes::SpawnProcess do
   subject(:process) do
@@ -10,22 +10,22 @@ RSpec.describe Aruba::Processes::SpawnProcess do
   let(:io_wait) { 1 }
   let(:working_directory) { Dir.getwd }
 
-  describe '#stdout' do
+  describe "#stdout" do
     before do
       process.start
       process.stop
     end
 
-    context 'when invoked once' do
-      it { expect(process.stdout.chomp).to eq 'yo' }
+    context "when invoked once" do
+      it { expect(process.stdout.chomp).to eq "yo" }
     end
 
-    context 'when invoked twice' do
-      it { 2.times { expect(process.stdout.chomp).to eq 'yo' } }
+    context "when invoked twice" do
+      it { 2.times { expect(process.stdout.chomp).to eq "yo" } }
     end
   end
 
-  describe '#stderr' do
+  describe "#stderr" do
     let(:command_line) { "sh -c \"echo 'yo' >&2\"" }
 
     before do
@@ -33,51 +33,51 @@ RSpec.describe Aruba::Processes::SpawnProcess do
       process.stop
     end
 
-    it 'returns the output of the process on stderr' do
+    it "returns the output of the process on stderr" do
       expect(process).not_to be_timed_out
-      expect(process.stderr.chomp).to eq 'yo'
+      expect(process.stderr.chomp).to eq "yo"
     end
 
-    it 'returns the same result when invoked a second time' do
-      2.times { expect(process.stderr.chomp).to eq 'yo' }
+    it "returns the same result when invoked a second time" do
+      2.times { expect(process.stderr.chomp).to eq "yo" }
     end
   end
 
-  describe '#stop' do
+  describe "#stop" do
     before { process.start }
 
-    context 'when stopped successfully' do
+    context "when stopped successfully" do
       it { expect { process.stop }.not_to raise_error }
 
-      it 'makes the process stopped' do
+      it "makes the process stopped" do
         process.stop
         expect(process).to be_stopped
       end
     end
   end
 
-  describe '#start' do
-    context 'when process run succeeds' do
+  describe "#start" do
+    context "when process run succeeds" do
       it { expect { process.start }.not_to raise_error }
 
-      it 'makes the process started' do
+      it "makes the process started" do
         process.start
         expect(process).to be_started
       end
     end
 
-    context 'when process run fails' do
-      let(:command_line) { 'does_not_exists' }
+    context "when process run fails" do
+      let(:command_line) { "does_not_exists" }
 
       it { expect { process.start }.to raise_error Aruba::LaunchError }
     end
 
-    context 'when on unix' do
+    context "when on unix" do
       let(:child) { instance_double(ChildProcess::AbstractProcess).as_null_object }
       let(:io) { instance_double(ChildProcess::AbstractIO).as_null_object }
-      let(:command_line) { 'foo' }
-      let(:command) { 'foo' }
-      let(:command_path) { '/bar/foo' }
+      let(:command_line) { "foo" }
+      let(:command) { "foo" }
+      let(:command_path) { "/bar/foo" }
 
       before do
         allow(Aruba.platform).to receive(:command_string)
@@ -90,9 +90,9 @@ RSpec.describe Aruba::Processes::SpawnProcess do
         allow(child).to receive(:environment).and_return({})
       end
 
-      context 'with a childprocess launch error' do
+      context "with a childprocess launch error" do
         before do
-          allow(child).to receive(:start).and_raise(ChildProcess::LaunchError, 'Foobar!')
+          allow(child).to receive(:start).and_raise(ChildProcess::LaunchError, "Foobar!")
         end
 
         it "reraises LaunchError as Aruba's LaunchError" do
@@ -101,8 +101,8 @@ RSpec.describe Aruba::Processes::SpawnProcess do
         end
       end
 
-      context 'with a command with a space in the path' do
-        let(:command_path) { '/path with space/foo' }
+      context "with a command with a space in the path" do
+        let(:command_path) { "/path with space/foo" }
 
         before do
           allow(Aruba.platform).to receive(:command_string)
@@ -114,35 +114,35 @@ RSpec.describe Aruba::Processes::SpawnProcess do
           allow(child).to receive(:environment).and_return({})
         end
 
-        it 'passes the command path as a single string to ChildProcess.build' do
+        it "passes the command path as a single string to ChildProcess.build" do
           process.start
           expect(ChildProcess).to have_received(:build).with(command_path)
         end
       end
 
-      context 'with a command with arguments' do
+      context "with a command with arguments" do
         let(:command_line) { 'foo -x "bar baz"' }
 
-        it 'passes the command and arguments as separate items to ChildProcess.build' do
+        it "passes the command and arguments as separate items to ChildProcess.build" do
           process.start
           expect(ChildProcess).to have_received(:build)
-            .with(command_path, '-x', 'bar baz')
+            .with(command_path, "-x", "bar baz")
         end
       end
     end
 
-    context 'when on windows' do
+    context "when on windows" do
       let(:child) { instance_double(ChildProcess::AbstractProcess).as_null_object }
       let(:io) { instance_double(ChildProcess::AbstractIO).as_null_object }
-      let(:command_line) { 'foo' }
-      let(:command) { 'foo' }
+      let(:command_line) { "foo" }
+      let(:command) { "foo" }
       let(:cmd_path) { 'C:\Bar\cmd.exe' }
       let(:command_path) { 'D:\Foo\foo' }
 
       before do
         allow(Aruba.platform).to receive(:command_string)
           .and_return Aruba::Platforms::WindowsCommandString
-        allow(Aruba.platform).to receive(:which).with('cmd.exe').and_return(cmd_path)
+        allow(Aruba.platform).to receive(:which).with("cmd.exe").and_return(cmd_path)
         allow(Aruba.platform)
           .to receive(:which).with(command, anything).and_return(command_path)
         allow(ChildProcess).to receive(:build).and_return(child)
@@ -151,9 +151,9 @@ RSpec.describe Aruba::Processes::SpawnProcess do
         allow(child).to receive(:environment).and_return({})
       end
 
-      context 'with a childprocess launch error' do
+      context "with a childprocess launch error" do
         before do
-          allow(child).to receive(:start).and_raise(ChildProcess::LaunchError, 'Foobar!')
+          allow(child).to receive(:start).and_raise(ChildProcess::LaunchError, "Foobar!")
         end
 
         it "reraises LaunchError as Aruba's LaunchError" do
@@ -162,48 +162,48 @@ RSpec.describe Aruba::Processes::SpawnProcess do
         end
       end
 
-      context 'with a command without a space in the path' do
-        it 'passes the command and shell paths as single strings to ChildProcess.build' do
+      context "with a command without a space in the path" do
+        it "passes the command and shell paths as single strings to ChildProcess.build" do
           process.start
-          expect(ChildProcess).to have_received(:build).with(cmd_path, '/c', command_path)
+          expect(ChildProcess).to have_received(:build).with(cmd_path, "/c", command_path)
         end
       end
 
-      context 'with a command with a space in the path' do
+      context "with a command with a space in the path" do
         let(:command_path) { 'D:\Bar Baz\foo' }
 
-        it 'escapes the spaces using excessive double quotes' do
+        it "escapes the spaces using excessive double quotes" do
           process.start
           expect(ChildProcess)
-            .to have_received(:build).with(cmd_path, '/c', 'D:\Bar""" """Baz\foo')
+            .to have_received(:build).with(cmd_path, "/c", 'D:\Bar""" """Baz\foo')
         end
       end
 
-      context 'with a command with arguments' do
+      context "with a command with arguments" do
         let(:command_line) { "foo -x 'bar \"baz\"'" }
 
-        it 'passes the command and arguments as one string with escaped quotes' do
+        it "passes the command and arguments as one string with escaped quotes" do
           process.start
           expect(ChildProcess).to have_received(:build)
-            .with(cmd_path, '/c', "#{command_path} -x \"bar \"\"\"baz\"\"\"\"")
+            .with(cmd_path, "/c", "#{command_path} -x \"bar \"\"\"baz\"\"\"\"")
         end
       end
     end
   end
 
-  describe '#command' do
+  describe "#command" do
     let(:command_line) { "ruby -e 'warn \"yo\"'" }
 
-    it 'returns the first item of the command line' do
-      expect(process.command).to eq 'ruby'
+    it "returns the first item of the command line" do
+      expect(process.command).to eq "ruby"
     end
   end
 
-  describe '#arguments' do
+  describe "#arguments" do
     let(:command_line) { "ruby -e 'warn \"yo\"'" }
 
-    it 'handles arguments delimited with quotes' do
-      expect(process.arguments).to eq ['-e', 'warn "yo"']
+    it "handles arguments delimited with quotes" do
+      expect(process.arguments).to eq ["-e", 'warn "yo"']
     end
   end
 end

--- a/spec/aruba/rspec_spec.rb
+++ b/spec/aruba/rspec_spec.rb
@@ -1,25 +1,25 @@
-require 'spec_helper'
+require "spec_helper"
 
-RSpec.describe 'RSpec Integration', type: :aruba do
-  describe 'Configuration' do
+RSpec.describe "RSpec Integration", type: :aruba do
+  describe "Configuration" do
     subject(:config) { aruba.config }
 
-    context 'when io_wait_timeout is 0.5', io_wait_timeout: 0.5 do
+    context "when io_wait_timeout is 0.5", io_wait_timeout: 0.5 do
       it { expect(config.io_wait_timeout).to eq 0.5 }
     end
 
-    context 'when io_wait_timeout is 0.1' do
+    context "when io_wait_timeout is 0.1" do
       it { expect(config.io_wait_timeout).to eq 0.1 }
     end
   end
 
-  describe 'Setting up the environment' do
-    it 'sets HOME to the configured value' do
-      expect(ENV['HOME']).to eq aruba.config.home_directory
+  describe "Setting up the environment" do
+    it "sets HOME to the configured value" do
+      expect(ENV["HOME"]).to eq aruba.config.home_directory
     end
 
-    it 'includes configured command search paths in PATH' do
-      expect(ENV['PATH'])
+    it "includes configured command search paths in PATH" do
+      expect(ENV["PATH"])
         .to include aruba.config.command_search_paths.join(File::PATH_SEPARATOR)
     end
   end

--- a/spec/aruba/runtime_spec.rb
+++ b/spec/aruba/runtime_spec.rb
@@ -1,31 +1,31 @@
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Aruba::Runtime do
-  include_context 'uses aruba API'
+  include_context "uses aruba API"
 
-  describe '#fixtures_directory' do
+  describe "#fixtures_directory" do
     let(:runtime) do
       @aruba.aruba
     end
 
-    context 'when no fixtures directories exist' do
+    context "when no fixtures directories exist" do
       before do
-        runtime.config.fixtures_directories = ['not-there', 'not/here', 'does/not/exist']
+        runtime.config.fixtures_directories = ["not-there", "not/here", "does/not/exist"]
       end
 
-      it 'raises exception' do
+      it "raises exception" do
         expect { runtime.fixtures_directory }
           .to raise_error RuntimeError, /No existing fixtures directory found/
       end
     end
 
-    context 'when one of the configures fixture directories exists' do
+    context "when one of the configures fixture directories exists" do
       before do
-        runtime.config.fixtures_directories = ['not-there', 'fixtures', 'does/not/exist']
+        runtime.config.fixtures_directories = ["not-there", "fixtures", "does/not/exist"]
       end
 
-      it 'returns that directory' do
-        expect(runtime.fixtures_directory.to_s).to eq File.expand_path('fixtures',
+      it "returns that directory" do
+        expect(runtime.fixtures_directory.to_s).to eq File.expand_path("fixtures",
                                                                        runtime.root_directory)
       end
     end

--- a/spec/event_bus/name_resolver_spec.rb
+++ b/spec/event_bus/name_resolver_spec.rb
@@ -1,64 +1,64 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe Aruba::EventBus::NameResolver do
   subject(:resolver) { described_class.new(default_name_space) }
 
-  let(:default_name_space) { 'Events' }
+  let(:default_name_space) { "Events" }
   let(:resolved_name) { resolver.transform(original_name) }
 
   before do
-    stub_const('Events::MyEvent', Class.new)
-    stub_const('Events::MyEvent', Class.new)
+    stub_const("Events::MyEvent", Class.new)
+    stub_const("Events::MyEvent", Class.new)
   end
 
-  describe '#transform' do
-    context 'when name is string' do
-      context 'when simple' do
-        let(:original_name) { 'Events::MyEvent' }
+  describe "#transform" do
+    context "when name is string" do
+      context "when simple" do
+        let(:original_name) { "Events::MyEvent" }
 
         it { expect(resolved_name).to eq Events::MyEvent }
       end
 
-      context 'when prefixed' do
-        let(:original_name) { '::Events::MyEvent' }
+      context "when prefixed" do
+        let(:original_name) { "::Events::MyEvent" }
 
         it { expect(resolved_name).to eq Events::MyEvent }
       end
     end
 
-    context 'when name is class' do
-      context 'when simple' do
+    context "when name is class" do
+      context "when simple" do
         let(:original_name) { Events::MyEvent }
 
         it { expect(resolved_name).to eq Events::MyEvent }
       end
 
-      context 'when prefixed' do
+      context "when prefixed" do
         let(:original_name) { ::Events::MyEvent }
 
         it { expect(resolved_name).to eq Events::MyEvent }
       end
     end
 
-    context 'when name is symbol' do
+    context "when name is symbol" do
       let(:original_name) { :my_event }
 
       it { expect(resolved_name).to eq Events::MyEvent }
     end
 
-    context 'when namespace ...' do
+    context "when namespace ..." do
       before do
-        stub_const('MyLib::Events::MyEvent', Class.new)
+        stub_const("MyLib::Events::MyEvent", Class.new)
       end
 
-      context 'when is string' do
-        let(:default_name_space) { 'MyLib::Events' }
+      context "when is string" do
+        let(:default_name_space) { "MyLib::Events" }
         let(:original_name) { :my_event }
 
         it { expect(resolved_name).to eq MyLib::Events::MyEvent }
       end
 
-      context 'when is module' do
+      context "when is module" do
         let(:default_name_space) { MyLib::Events }
         let(:original_name) { :my_event }
 
@@ -66,7 +66,7 @@ describe Aruba::EventBus::NameResolver do
       end
     end
 
-    context 'when invalid' do
+    context "when invalid" do
       let(:original_name) { 1 }
 
       it {

--- a/spec/event_bus_spec.rb
+++ b/spec/event_bus_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 module Events
   class TestEvent; end
@@ -17,7 +17,7 @@ class MyMalformedHandler; end
 describe Aruba::EventBus do
   subject(:bus) { described_class.new(name_resolver) }
 
-  let(:name_resolver) { instance_double('Events::NameResolver') }
+  let(:name_resolver) { instance_double("Events::NameResolver") }
 
   let(:event_klass) { Events::TestEvent }
   let(:event_name) { event_klass }
@@ -27,13 +27,13 @@ describe Aruba::EventBus do
   let(:another_event_name) { another_event_klass }
   let(:another_event_instance) { Events::AnotherTestEvent.new }
 
-  describe '#notify' do
+  describe "#notify" do
     before do
       allow(name_resolver)
         .to receive(:transform).with(event_name).and_return(event_klass)
     end
 
-    context 'when subscribed to the event' do
+    context "when subscribed to the event" do
       before do
         bus.register(event_klass) do |event|
           @received_payload = event
@@ -42,12 +42,12 @@ describe Aruba::EventBus do
         bus.notify event_instance
       end
 
-      it 'calls the block with an instance of the event passed as payload' do
+      it "calls the block with an instance of the event passed as payload" do
         expect(@received_payload).to eq(event_instance)
       end
     end
 
-    context 'when not subscriber to event' do
+    context "when not subscriber to event" do
       before do
         @received_payload = false
         bus.register(event_klass) { @received_payload = true }
@@ -57,7 +57,7 @@ describe Aruba::EventBus do
       it { expect(@received_payload).to eq(false) }
     end
 
-    context 'when event is not an instance of event class' do
+    context "when event is not an instance of event class" do
       let(:event_name) { :test_event }
       let(:received_payload) { [] }
 
@@ -69,14 +69,14 @@ describe Aruba::EventBus do
     end
   end
 
-  describe '#register' do
+  describe "#register" do
     before do
       allow(name_resolver)
         .to receive(:transform).with(event_name).and_return(event_klass)
     end
 
-    context 'when valid subscriber' do
-      context 'when multiple instances are given' do
+    context "when valid subscriber" do
+      context "when multiple instances are given" do
         let(:received_events) { [] }
 
         before do
@@ -94,7 +94,7 @@ describe Aruba::EventBus do
         it { expect(received_events).to all eq event_instance }
       end
 
-      context 'when is string' do
+      context "when is string" do
         let(:event_name) { event_klass.to_s }
         let(:received_payload) { [] }
 
@@ -109,7 +109,7 @@ describe Aruba::EventBus do
         it { expect(received_payload).to include event_instance }
       end
 
-      context 'when is symbol and event is defined in the default namespace' do
+      context "when is symbol and event is defined in the default namespace" do
         let(:event_name) { :test_event }
         let(:received_payload) { [] }
 
@@ -125,8 +125,8 @@ describe Aruba::EventBus do
       end
     end
 
-    context 'when valid custom handler' do
-      context 'when single event class' do
+    context "when valid custom handler" do
+      context "when single event class" do
         before do
           allow(name_resolver)
             .to receive(:transform).with(event_name).and_return(event_klass)
@@ -136,7 +136,7 @@ describe Aruba::EventBus do
         it { expect { bus.notify event_instance }.not_to raise_error }
       end
 
-      context 'when list of event classes' do
+      context "when list of event classes" do
         before do
           allow(name_resolver)
             .to receive(:transform).with(event_name).and_return(event_klass)
@@ -150,15 +150,15 @@ describe Aruba::EventBus do
       end
     end
 
-    context 'when malformed custom handler' do
-      it 'raises an ArgumentError' do
+    context "when malformed custom handler" do
+      it "raises an ArgumentError" do
         expect { bus.register(event_klass, MyMalformedHandler.new) }
           .to raise_error ArgumentError
       end
     end
 
-    context 'when no handler is given' do
-      it 'raises an ArgumentError' do
+    context "when no handler is given" do
+      it "raises an ArgumentError" do
         expect { bus.register(event_klass) }.to raise_error ArgumentError
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
-$LOAD_PATH << ::File.expand_path('../lib', __dir__)
+$LOAD_PATH << ::File.expand_path("../lib", __dir__)
 
-unless RUBY_PLATFORM.include?('java')
-  require 'simplecov'
-  SimpleCov.command_name 'rspec'
+unless RUBY_PLATFORM.include?("java")
+  require "simplecov"
+  SimpleCov.command_name "rspec"
   SimpleCov.start
 end
 
 # Pull in all of the gems including those in the `test` group
-require 'bundler'
+require "bundler"
 Bundler.require
 
 # Loading support files
-Dir.glob(::File.expand_path('support/*.rb', __dir__)).each { |f| require_relative f }
-Dir.glob(::File.expand_path('support/**/*.rb', __dir__)).each { |f| require_relative f }
+Dir.glob(::File.expand_path("support/*.rb", __dir__)).each { |f| require_relative f }
+Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).each { |f| require_relative f }

--- a/spec/support/configs/aruba.rb
+++ b/spec/support/configs/aruba.rb
@@ -1,5 +1,5 @@
-require 'aruba/rspec'
-require 'aruba/config/jruby'
+require "aruba/rspec"
+require "aruba/config/jruby"
 
 Aruba.configure do |config|
   config.activate_announcer_on_command_failure = [:stderr, :stdout, :command]

--- a/spec/support/configs/pry.rb
+++ b/spec/support/configs/pry.rb
@@ -1,3 +1,3 @@
 # Otherwise pry doesn't find it's RC file
 # if ENV['HOME'] is mocked
-ENV['PRYRC'] = File.expand_path('~/.pryrc')
+ENV["PRYRC"] = File.expand_path("~/.pryrc")

--- a/spec/support/configs/rspec.rb
+++ b/spec/support/configs/rspec.rb
@@ -1,12 +1,12 @@
-require 'rspec/core'
-require 'aruba/api'
+require "rspec/core"
+require "aruba/api"
 
 RSpec.configure do |config|
   config.filter_run focus: true
 
   config.run_all_when_everything_filtered = true
 
-  config.example_status_persistence_file_path = 'spec/examples.txt'
+  config.example_status_persistence_file_path = "spec/examples.txt"
   config.profile_examples = 10
 
   config.expect_with :rspec do |c|

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -1,19 +1,19 @@
-require 'fileutils'
-require 'securerandom'
+require "fileutils"
+require "securerandom"
 
-RSpec.shared_context 'uses aruba API' do
+RSpec.shared_context "uses aruba API" do
   def random_string(options = {})
     options[:prefix].to_s + SecureRandom.hex + options[:suffix].to_s
   end
 
-  def create_test_files(files, data = 'a')
+  def create_test_files(files, data = "a")
     Array(files).each do |s|
-      next if s.to_s[0] == '%'
+      next if s.to_s[0] == "%"
 
       local_path = @aruba.expand_path(s)
 
       FileUtils.mkdir_p File.dirname(local_path)
-      File.open(local_path, 'w') { |f| f << data }
+      File.open(local_path, "w") { |f| f << data }
     end
   end
 
@@ -28,13 +28,13 @@ RSpec.shared_context 'uses aruba API' do
 
     @aruba = klass.new
 
-    @file_name = 'test.txt'
+    @file_name = "test.txt"
     @file_size = 256
     @file_path = @aruba.expand_path(@file_name)
     @aruba.setup_aruba
 
-    if @aruba.aruba.current_directory[0] == '/'
-      raise 'We must work with relative paths, everything else is dangerous'
+    if @aruba.aruba.current_directory[0] == "/"
+      raise "We must work with relative paths, everything else is dangerous"
     end
   end
 end

--- a/spec/support/shared_examples/configuration.rb
+++ b/spec/support/shared_examples/configuration.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples 'a basic configuration' do
+RSpec.shared_examples "a basic configuration" do
   subject(:config) do
     Class.new(described_class) do
       option_accessor :use_test, type: Contracts::Bool,
@@ -8,7 +8,7 @@ RSpec.shared_examples 'a basic configuration' do
 
   it { expect(config).not_to be_nil }
 
-  describe '.option_reader' do
+  describe ".option_reader" do
     subject(:config) { config_klass.new }
 
     let(:config_klass) { Class.new(described_class) }
@@ -18,15 +18,15 @@ RSpec.shared_examples 'a basic configuration' do
                                            default: 1
     end
 
-    context 'when value is read' do
+    context "when value is read" do
       it { expect(config.new_opt).to eq 1 }
     end
 
-    context 'when one tries to write a value' do
+    context "when one tries to write a value" do
       it { expect { config.new_opt = 1 }.to raise_error NoMethodError }
     end
 
-    context 'when block is defined' do
+    context "when block is defined" do
       before do
         config_klass.option_reader(
           :new_opt2,
@@ -34,23 +34,23 @@ RSpec.shared_examples 'a basic configuration' do
         ) { |c| c.new_opt.value + 1 }
       end
 
-      it 'uses the block to set the value' do
+      it "uses the block to set the value" do
         expect(config.new_opt2).to eq 2
       end
     end
 
-    context 'when block and default value is defined' do
-      it 'complains that only one or the other can be specified' do
+    context "when block and default value is defined" do
+      it "complains that only one or the other can be specified" do
         expect do
           config_klass
             .option_accessor(:new_opt2, type: Contracts::Num,
                                         default: 2) { |c| c.new_opt.value + 1 }
-        end.to raise_error ArgumentError, 'Either use block or default value'
+        end.to raise_error ArgumentError, "Either use block or default value"
       end
     end
   end
 
-  describe '.option_accessor' do
+  describe ".option_accessor" do
     subject(:config) { config_klass.new }
 
     let(:config_klass) { Class.new(described_class) }
@@ -60,17 +60,17 @@ RSpec.shared_examples 'a basic configuration' do
                                              default: 1
     end
 
-    context 'when default is used' do
+    context "when default is used" do
       it { expect(config.new_opt).to eq 1 }
     end
 
-    context 'when is modified' do
+    context "when is modified" do
       before { config.new_opt = 2 }
 
       it { expect(config.new_opt).to eq 2 }
     end
 
-    context 'when block is defined' do
+    context "when block is defined" do
       before do
         config_klass.option_accessor(
           :new_opt2, type: Contracts::Num
@@ -79,47 +79,47 @@ RSpec.shared_examples 'a basic configuration' do
         end
       end
 
-      it 'uses the block to set the default value' do
+      it "uses the block to set the default value" do
         expect(config.new_opt2).to eq 2
       end
     end
 
-    context 'when block and default value is defined' do
-      it 'complains that only one or the other can be specified' do
+    context "when block and default value is defined" do
+      it "complains that only one or the other can be specified" do
         expect do
           config_klass.option_accessor(:new_opt2,
                                        type: Contracts::Num,
                                        default: 2) { |c| c.new_opt1 + 1 }
-        end.to raise_error ArgumentError, 'Either use block or default value'
+        end.to raise_error ArgumentError, "Either use block or default value"
       end
     end
   end
 
-  describe 'option?' do
+  describe "option?" do
     let(:name) { :use_test }
 
-    context 'when valid option' do
+    context "when valid option" do
       it { expect(name).to be_valid_option }
     end
 
-    context 'when invalid_option' do
+    context "when invalid_option" do
       let(:name) { :blub }
 
       it { expect(name).not_to be_valid_option }
     end
   end
 
-  describe 'set_if_option' do
+  describe "set_if_option" do
     let(:name) { :use_test }
     let(:value) { true }
 
-    context 'when valid option' do
+    context "when valid option" do
       before { config.set_if_option(name, value) }
 
       it { expect(name).to have_option_value true }
     end
 
-    context 'when invalid_option' do
+    context "when invalid_option" do
       let(:name) { :blub }
 
       it { expect { config.set_if_option(name, value) }.not_to raise_error }

--- a/spec/support/shared_examples/directory.rb
+++ b/spec/support/shared_examples/directory.rb
@@ -1,7 +1,7 @@
-shared_examples 'an existing directory' do
+shared_examples "an existing directory" do
   it { Array(path).each { |p| expect(File).to be_directory(p) } }
 end
 
-shared_examples 'a non-existing directory' do
+shared_examples "a non-existing directory" do
   it { Array(path).each { |p| expect(File).not_to be_exist(p) } }
 end

--- a/spec/support/shared_examples/file.rb
+++ b/spec/support/shared_examples/file.rb
@@ -1,7 +1,7 @@
-shared_examples 'an existing file' do
+shared_examples "an existing file" do
   it { Array(path).each { |p| expect(File).to be_file(p) } }
 end
 
-shared_examples 'a non-existing file' do
+shared_examples "a non-existing file" do
   it { Array(path).each { |p| expect(File).not_to be_exist(p) } }
 end


### PR DESCRIPTION
## Summary

Configure RuboCop to require double quotes in strings by default, and autocorrect existing strings.

## Motivation and Context

This style improves consistency and is the chosen style for StandardRB and rubyfmt. Also, it's what I'm used to right now.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)