### PR TITLE
Make absolute file name warning an error

### DIFF
--- a/features/04_aruba_api/core/expand_path.feature
+++ b/features/04_aruba_api/core/expand_path.feature
@@ -52,7 +52,7 @@ Feature: Expand paths with aruba
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Warn when using absolute path
+  Scenario: Raise error when using absolute path
     Given a file named "spec/expand_path_spec.rb" with:
     """ruby
     require 'spec_helper'
@@ -63,15 +63,15 @@ Feature: Expand paths with aruba
     end
     """
     When I run `rspec`
-    Then the specs should all pass
+    Then the specs should not all pass
     And the output should contain:
     """
     Aruba's `expand_path` method was called with an absolute path
     """
 
-  Scenario: Silence warning about using absolute path
+  Scenario: Silence error about using absolute path
 
-    You can use config.allow_absolute_paths to silence the warning about the
+    You can use config.allow_absolute_paths to silence the error about the
     use of absolute paths.
 
     Given a file named "spec/expand_path_spec.rb" with:

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -117,28 +117,29 @@ module Aruba
       #
       # @example Single file name
       #
-      #   # => <path>/tmp/aruba/file
       #   expand_path('file')
+      #   # => <path>/tmp/aruba/file
       #
       # @example Single Dot
       #
-      #   # => <path>/tmp/aruba
       #   expand_path('.')
+      #   # => <path>/tmp/aruba
       #
       # @example using home directory
       #
-      #   # => <path>/home/<name>/file
       #   expand_path('~/file')
+      #   # => <path>/home/<name>/file
       #
       # @example using fixtures directory
       #
-      #   # => <path>/test/fixtures/file
       #   expand_path('%/file')
+      #   # => <path>/test/fixtures/file
       #
-      # @example Absolute directory
+      # @example Absolute directory (requires aruba.config.allow_absolute_paths
+      # to be set)
       #
-      #   # => /foo/bar
       #   expand_path('/foo/bar')
+      #   # => /foo/bar
       #
       def expand_path(file_name, dir_string = nil)
         unless file_name.is_a?(String) && !file_name.empty?
@@ -157,7 +158,7 @@ module Aruba
 
         prefix = file_name[0]
 
-        if aruba.config.fixtures_path_prefix == prefix
+        if prefix == aruba.config.fixtures_path_prefix
           rest = file_name[2..-1]
           path = File.join(*[aruba.fixtures_directory, rest].compact)
           unless Aruba.platform.exist? path
@@ -189,11 +190,13 @@ module Aruba
           unless aruba.config.allow_absolute_paths
             caller_location = caller_locations(1, 1).first
             caller_file_line = "#{caller_location.path}:#{caller_location.lineno}"
-            aruba.logger.warn \
+            message =
               "Aruba's `expand_path` method was called with an absolute path" \
               " at #{caller_file_line}, which is not recommended." \
+              " The path passed was '#{file_name}'." \
               " Change the call to pass a relative path or set "\
               "`config.allow_absolute_paths = true` to silence this warning"
+            raise UserError, message
           end
           file_name
         else

--- a/spec/aruba/api/core_spec.rb
+++ b/spec/aruba/api/core_spec.rb
@@ -82,21 +82,16 @@ RSpec.describe Aruba::Api::Core do
       let(:logger) { @aruba.aruba.logger }
 
       before do
-        allow(@aruba.aruba.logger).to receive :warn
+        allow(logger).to receive :warn
       end
 
-      it { expect(@aruba.expand_path(@file_path)).to eq @file_path }
-
-      it "warns about it" do
-        @aruba.expand_path(@file_path)
-        expect(logger).to have_received(:warn)
-          .with(/Aruba's `expand_path` method was called with an absolute path/)
+      it "raises a UserError" do
+        expect { @aruba.expand_path(@file_path) }.to raise_error Aruba::UserError
       end
 
-      it "does not warn about it if told not to" do
+      it "does not raise an error if told not to" do
         @aruba.aruba.config.allow_absolute_paths = true
-        @aruba.expand_path(@file_path)
-        expect(logger).not_to have_received(:warn)
+        expect { @aruba.expand_path(@file_path) }.not_to raise_error
       end
     end
 

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Command Matchers" do
     end
 
     context "when multiple commands output hello world on stdout" do
-      context "and all comands must have the output" do
+      context "and all commands must have the output" do
         before do
           run_command(cmd)
           run_command(cmd)
@@ -63,7 +63,7 @@ RSpec.describe "Command Matchers" do
         it { expect(all_commands).to all have_output output }
       end
 
-      context "and any comand can have the output" do
+      context "and any command can have the output" do
         before do
           run_command(cmd)
           run_command("echo hello universe")


### PR DESCRIPTION
## Summary

Make it easier to locate where an absolute file name was passed to Aruba by raising an error about it.

## Details

Instead of a warning, raise an error.

## Motivation and Context

Fixes #691.

## How Has This Been Tested?

Specs and scenarios have been updated. I also tried this with the simplecov features.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update

## Checklist:

- I've added tests for my code
- My change requires a change to the documentation.
- I have updated the documentation accordingly.