### PR TITLE
Allow upcoming rspec-expectations 4.x to be used

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
   spec.add_runtime_dependency "contracts", [">= 0.16.0", "< 0.18.0"]
   spec.add_runtime_dependency "cucumber", [">= 2.4", "< 7.0"]
-  spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
+  spec.add_runtime_dependency "rspec-expectations", [">= 3.4", "< 5.0"]
   spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.4"


### PR DESCRIPTION
## Summary

Loosen dependency on rspec-expections to allow version 4.x

## Motivation and Context

This prepares Aruba for the upcoming RSpec 4.0, and will allow Aruba 1.x to be
used to test that release.

## How Has This Been Tested?

This was split off from #787 so has been tested in CI already.

## Types of changes

- New feature (non-breaking change which adds functionality)