### PR TITLE
Improve linting tasks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Run cukes
       run: bundle exec rake cucumber
 
-  lint:
+  checks:
 
     runs-on: ubuntu-latest
 
@@ -66,5 +66,9 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
+    - name: Install license_finder
+      run: gem install license_finder
     - name: Run linters
       run: bundle exec rake lint
+    - name: Run license_finder
+      run: license_finder

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,8 @@ Bundler.setup
 
 require "cucumber/rake/task"
 require "rspec/core/rake_task"
+require "rubocop/rake_task"
+require "yard-junk/rake"
 
 Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = %w(--format progress)
@@ -24,21 +26,8 @@ RSpec::Core::RakeTask.new
 desc "Run the whole test suite."
 task test: [:spec, :cucumber]
 
-namespace :lint do
-  desc 'Lint our code with "rubocop"'
-  task :coding_guidelines do
-    sh "bundle exec rubocop"
-  end
-
-  require "yard-junk/rake"
-  YardJunk::Rake.define_task
-end
-
-desc "Run all linters."
-task lint: %w(lint:coding_guidelines)
-
-# Also check the manifest as part of the linting
-task lint: "manifest:check"
+RuboCop::RakeTask.new
+YardJunk::Rake.define_task
 
 Bundler::GemHelper.install_tasks
 
@@ -49,6 +38,10 @@ Rake::Manifest::Task.new do |t|
                 "LICENSE", "README.md"]
 end
 
+# Check the manifest before building the gem
 task build: "manifest:check"
+
+desc "Run checks"
+task lint: %w(rubocop manifest:check)
 
 task default: :test

--- a/Rakefile
+++ b/Rakefile
@@ -30,17 +30,12 @@ namespace :lint do
     sh "bundle exec rubocop"
   end
 
-  desc "Check for relevant licenses in project"
-  task :licenses do
-    sh "bundle exec license_finder"
-  end
-
   require "yard-junk/rake"
   YardJunk::Rake.define_task
 end
 
 desc "Run all linters."
-task lint: %w(lint:coding_guidelines lint:licenses)
+task lint: %w(lint:coding_guidelines)
 
 # Also check the manifest as part of the linting
 task lint: "manifest:check"

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "json", "~> 2.1"
-  spec.add_development_dependency "license_finder", "~> 6.0"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "pry-doc", "~> 1.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "json", "~> 2.1"
+  spec.add_development_dependency "kramdown", "~> 2.1"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "pry-doc", "~> 1.0"
   spec.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
## Summary

Some improvements to the linting tasks

## Details

- Move `license_finder` out of the bundle and lint tasks and install it separately in CI

Additionally:

- Simplify rubocop and yard:junk task definitions
- Provide kramdown dependency so yard:junk doesn't error out

## Motivation and Context

License finder has a lot of dependencies but is slow to update them. We also don't need to depend on any particular version.

## How Has This Been Tested?

I rank the lint task with the new definition.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)