### PR TITLE
Improve test robustness a bit more

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,7 @@ jobs:
 
   test-macos:
     strategy:
+      fail-fast: false
       matrix:
         ruby: [2.4, 2.5, 2.6, 2.7, "3.0"]
 

--- a/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_for_exit_statuses.feature
@@ -95,7 +95,7 @@ Feature: Check exit status of commands
     """
     Feature: Failing program
       Scenario: Run command
-        Given the default aruba exit timeout is 0.3 seconds
+        Given the default aruba exit timeout is 0.4 seconds
         When I successfully run `aruba-test-cli`
     """
     When I run `cucumber`
@@ -112,7 +112,7 @@ Feature: Check exit status of commands
     Feature: Failing program
       Scenario: Run command
         Given the default aruba exit timeout is 0 seconds
-        When I successfully run `aruba-test-cli` for up to 0.3 seconds
+        When I successfully run `aruba-test-cli` for up to 0.4 seconds
     """
     When I run `cucumber`
     Then the features should all pass

--- a/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
@@ -271,7 +271,7 @@ Feature: Stop commands
     """
     Feature: Run it
       Scenario: Run command
-        Given the default aruba exit timeout is 0.2 seconds
+        Given the default aruba exit timeout is 0.3 seconds
         And I wait 0.1 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I terminate the command started last

--- a/features/04_aruba_api/command/read_stdout_of_command.feature
+++ b/features/04_aruba_api/command/read_stdout_of_command.feature
@@ -36,7 +36,7 @@ Feature: Access STDOUT of command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.3 do
+    RSpec.describe 'Run command', type: :aruba, io_wait_timeout: 0.4 do
       before { run_command('aruba-test-cli') }
       it { expect(last_command_started.stdout).to start_with 'Hello' }
     end

--- a/features/04_aruba_api/command/run_simple.feature
+++ b/features/04_aruba_api/command/run_simple.feature
@@ -91,7 +91,7 @@ Feature: Run command in a simpler fashion
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.4 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.5 do
       before { run_command_and_stop('aruba-test-cli') }
 
       it 'runs the command with the expected results' do


### PR DESCRIPTION
## Summary

Just one more step on the road to consistently green tests

## Details

This does two things:
- Make all MacOS jobs always finish to help with problem-solving when cukes fail there.
- Give several scenarios a bit more time to finish

## Motivation and Context

In the end, we want to be certain that the tests will be green if nothing is broken. Right now, the MacOS builds fail far too often.

## How Has This Been Tested?

I ran the scenario, but it already was fine when run locally.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.