### PR TITLE
Remove obsolete Ruby version check

### DIFF
--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -81,10 +81,8 @@ module Aruba
         @stdout_file.sync = true
         @stderr_file.sync = true
 
-        if RUBY_VERSION >= "1.9"
-          @stdout_file.set_encoding("ASCII-8BIT")
-          @stderr_file.set_encoding("ASCII-8BIT")
-        end
+        @stdout_file.set_encoding("ASCII-8BIT")
+        @stderr_file.set_encoding("ASCII-8BIT")
 
         @exit_status = nil
         @duplex      = true


### PR DESCRIPTION
## Summary

Remove obsolete Ruby version check

## Details

Removes a check for Ruby version 1.9. Older versions are not supported and guarded against in the gemspec, so this check is no longer needed.

## Motivation and Context

Clean things up.

## How Has This Been Tested?

CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.