### PR TITLE
Allow newer versions of Cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG][2].
 
 ## [Unreleased]
 
-* Update dependencies to cucumber to allow depends on future version
+* Update dependencies to cucumber to allow working with incoming major versions
   ([#801] by [mattwynne])
 
 ## [1.0.4] / 2021-01-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This project adheres to [Semantic Versioning][1].
 
 This document is formatted according to the principles of [Keep A CHANGELOG][2].
 
+## [Unreleased]
+
+* Update dependencies to cucumber to allow depends on future version
+  ([#801] by [mattwynne])
+
 ## [1.0.4] / 2021-01-04
 
 * Update rubocop and fix new offenses (various pull requests)
@@ -964,6 +969,7 @@ Note: These are changes w.r.t. Aruba version 0.14.1.
 
 <!-- issues & pull requests -->
 
+[#801]: https://github.com/cucumber/aruba/pull/801
 [#727]: https://github.com/cucumber/aruba/pull/727
 [#725]: https://github.com/cucumber/aruba/pull/725
 [#724]: https://github.com/cucumber/aruba/pull/724
@@ -1242,7 +1248,8 @@ Note: These are changes w.r.t. Aruba version 0.14.1.
 
 <!-- Releases -->
 
-[Unreleased]:     https://github.com/cucumber/aruba/compare/v1.0.3...master
+[Unreleased]:     https://github.com/cucumber/aruba/compare/v1.0.4...master
+[1.0.4]:          https://github.com/cucumber/aruba/compare/v1.0.3...v1.0.4
 [1.0.3]:          https://github.com/cucumber/aruba/compare/v1.0.2...v1.0.3
 [1.0.2]:          https://github.com/cucumber/aruba/compare/v1.0.1...v1.0.2
 [1.0.1]:          https://github.com/cucumber/aruba/compare/v1.0.0...v1.0.1

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
   spec.add_runtime_dependency "contracts", "~> 0.16.0"
-  spec.add_runtime_dependency "cucumber", ">= 2.4"
+  spec.add_runtime_dependency "cucumber", [">= 2.4", "< 7.0"]
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
   spec.add_runtime_dependency "thor", "~> 1.0"
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
   spec.add_runtime_dependency "contracts", "~> 0.16.0"
-  spec.add_runtime_dependency "cucumber", [">= 2.4", "< 6.0"]
+  spec.add_runtime_dependency "cucumber", ">= 2.4"
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
   spec.add_runtime_dependency "thor", "~> 1.0"
 


### PR DESCRIPTION
This allows us to test / release new versions of Cucumber without first having to come here to make a new release of Arubua.
    
I think the only reason to cap the max version would be if we knew there was a backwards-compatibility problem with a release of Cucumber, but there isn't, so I think we can safely just remove it?