### PR TITLE
Add GitHub action to automerge minor and patch updates

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,30 @@
+name: Automerge dependency updates
+
+on: [pull_request]
+jobs:
+  auto_merge:
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' &&
+      github.actor == 'dependabot[bot]'
+    steps:
+      - name: "@dependabot merge"
+        uses: actions/github-script@v3
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const update_regex = /Update [^ ]* requirement from ~> ([1-9][0-9]*)\.\d+\.\d+ to ~> \1\.\d+\.\d+/;
+            const update_match = title.match(update_regex);
+
+            if (update_match !== null) {
+              console.log(`Detected allowed update in '${title}'`);
+            } else {
+              return;
+            }
+
+            github.issues.createComment({
+              owner: context.payload.repository.owner.login,
+              repo: context.payload.repository.name,
+              issue_number: context.payload.pull_request.number,
+              body: '@dependabot merge'
+            })


### PR DESCRIPTION
## Summary

Add GitHub action to automerge minor and patch updates

## Details

Adds an action that:
- Only runs for pull request events from dependabot[bot]
- Adds a `@dependabot merge` comment for any pull requests that upgrade a minor
  or micro version of a dependency using the `~>` operator

Any dependabot pull requests with some other change are left alone and need to
be merged by hand.

## Motivation and Context

Simplify the maintainers' life.

## How Has This Been Tested?

Other repositories, but still a work in progress.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)