### PR TITLE
Loosen dependency on the contracts gem

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
-  spec.add_runtime_dependency "contracts", "~> 0.16.0"
+  spec.add_runtime_dependency "contracts", [">= 0.16.0", "< 0.18.0"]
   spec.add_runtime_dependency "cucumber", [">= 2.4", "< 7.0"]
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
   spec.add_runtime_dependency "thor", "~> 1.0"


### PR DESCRIPTION
## Summary

Loosen dependency on the contracts gem to allow version 0.17.

## Motivation and Context

Keep things up-to-date. We still allow 0.16 because 0.17 requires Ruby 3.0.

## How Has This Been Tested?

CI will check it.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
