### PR TITLE
Update remaining references to default branch

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,9 +6,9 @@ name: Ruby
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   CUCUMBER_PUBLISH_QUIET: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1364,4 +1364,4 @@ Note: These are changes w.r.t. Aruba version 0.14.1.
 
 [1]:  http://semver.org
 [2]:  http://keepachangelog.com
-[3]:  https://github.com/cucumber/aruba/blob/master/CONTRIBUTING.md
+[3]:  https://github.com/cucumber/aruba/blob/main/CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Please...
 
 * Use pull requests for larger or controversial changes made by yourself or
   changes you might expected to break the build.
-* Commit smaller changes directly to master, e.g. fixing typos, adding tests or
+* Commit smaller changes directly to `main`, e.g. fixing typos, adding tests or
   adding documentation.
 * Update [`CHANGELOG.md`][] when a pull request is merged.
 * Make sure all tests are green before merging a pull request.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/master/LICENSE)
+[![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/main/LICENSE)
 [![Docs](https://img.shields.io/badge/cucumber.pro-aruba-3d10af.svg)](https://app.cucumber.pro/projects/aruba)
 [![Gem Version](https://badge.fury.io/rb/aruba.svg)](http://badge.fury.io/rb/aruba)
 [![Code Climate](https://codeclimate.com/github/cucumber/aruba.svg)](https://codeclimate.com/github/cucumber/aruba)
@@ -32,7 +32,7 @@ gem install aruba
 ### As a user getting started with Aruba
 
 Our most current documentation to get started with Aruba as a user can be
-found in [./features/](https://github.com/cucumber/aruba/tree/master/features/).
+found in [./features/](https://github.com/cucumber/aruba/tree/main/features/).
 
 ### As a user getting started with a ruby testing framework
 
@@ -91,7 +91,7 @@ Please see the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 ## Code branches
 
-Development takes place in the `master` branch and currently targets the 1.x
+Development takes place in the `main` branch and currently targets the 1.x
 releases. If necessary, maintenance of the old 0.14.x releases takes place in
 the `0-14-stable` branch. Stable branches will not be created until absolutely
 necessary.

--- a/features/README.md
+++ b/features/README.md
@@ -20,7 +20,7 @@ Your benefits:
 * No worries about leaking state: The file system and the process environment
   will be reset between tests
 * Support by a helpful and welcoming community &ndash; see our
-  [Code of Conduct](https://github.com/cucumber/cucumber/blob/master/CODE_OF_CONDUCT.md)
+  [Code of Conduct](https://github.com/cucumber/cucumber/blob/main/CODE_OF_CONDUCT.md)
 * The [documentation](https://app.cucumber.pro/projects/aruba) is our contract
   with you. You can expect Aruba to work as documented
 
@@ -60,7 +60,7 @@ gem install aruba
 # Usage
 
 **Note:** Please also see this
-[feature test](https://app.cucumber.pro/projects/Aruba/documents/master/features/01_getting_started_with_aruba/supported_testing_frameworks.feature)
+[feature test](01_getting_started_with_aruba/supported_testing_frameworks.feature)
 for the most up to date documentation.
 
 ## Getting started


### PR DESCRIPTION
## Summary

Update remaining references of `master` branch to `main`

## Details

- Update references to `master` branch to main in documentation
- Make GitHub Actions run when targeting `main`

## Motivation and Context

The default branch was renamed but that made the documentation and GitHub Actions configuration incorrect. This fixes that.

## How Has This Been Tested?

N/A

## Types of changes

- Documentation update
- Internal change (refactoring, test improvements, developer experience or update of dependencies)
