### PR TITLE
bugfix: Undefined module/class `Bundler` when running cucumber-rails from RubyMine

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -21,12 +21,12 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/cucumber/aruba"
   }
 
+  spec.add_runtime_dependency "bundler", [">= 1.17", "< 3.0"]
   spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
   spec.add_runtime_dependency "contracts", "~> 0.16.0"
   spec.add_runtime_dependency "cucumber", [">= 2.4", "< 6.0"]
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
   spec.add_runtime_dependency "thor", "~> 1.0"
-  spec.add_runtime_dependency "bundler", "~> 2.1"
 
   spec.add_development_dependency "json", "~> 2.1"
   spec.add_development_dependency "kramdown", "~> 2.1"

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cucumber", [">= 2.4", "< 6.0"]
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
   spec.add_runtime_dependency "thor", "~> 1.0"
+  spec.add_runtime_dependency "bundler", "~> 2.1"
 
   spec.add_development_dependency "json", "~> 2.1"
   spec.add_development_dependency "kramdown", "~> 2.1"

--- a/lib/aruba/api/bundler.rb
+++ b/lib/aruba/api/bundler.rb
@@ -1,4 +1,5 @@
 require "aruba/api/environment"
+require "bundler"
 
 module Aruba
   module Api


### PR DESCRIPTION
Bundler is a runtime dependency inside `aruba/api/bundler` - So require it as so

## Summary

Fix gemspec to pull in bundler as a requirement of using the gem (As it's needed to run some methods)

## Details

Self-explanatory

## Motivation and Context

When running cucumber-rails in a test/valid context, this throws an error when consuming aruba helpers

## How Has This Been Tested?

CI / Manual
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
