### PR TITLE
Remove Bundler.require_relative from spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,10 +6,6 @@ unless RUBY_PLATFORM.include?("java")
   SimpleCov.start
 end
 
-# Pull in all of the gems including those in the `test` group
-require "bundler"
-Bundler.require
-
 # Loading support files
 Dir.glob(::File.expand_path("support/*.rb", __dir__)).each { |f| require_relative f }
 Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).each { |f| require_relative f }


### PR DESCRIPTION
## Summary

Remove Bundler.require from `spec/spec_helper.rb`.

## Motivation and Context

Our code should require necessary dependencies explicitly. This also avoids circular reference errors while loading specs

## How Has This Been Tested?

Ran the specs.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
