### PR TITLE
Use Ruby's built-in windows platform detection

### DIFF
--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -31,7 +31,7 @@ module Aruba
     # @private
     class UnixPlatform
       def self.match?
-        !Cucumber::WINDOWS
+        !Gem.win_platform?
       end
 
       def environment_variables

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -1,5 +1,3 @@
-require "cucumber/platform"
-
 require "aruba/platforms/unix_platform"
 require "aruba/platforms/windows_command_string"
 require "aruba/platforms/windows_environment_variables"
@@ -20,7 +18,7 @@ module Aruba
     # @private
     class WindowsPlatform < UnixPlatform
       def self.match?
-        Cucumber::WINDOWS
+        Gem.win_platform?
       end
 
       # @see UnixPlatform#command_string

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe Aruba::Api::Commands do
     end
 
     context "when running a relative command" do
-      let(:cmd) { Cucumber::WINDOWS ? "bin/testcmd.bat" : "bin/testcmd" }
+      let(:cmd) { Gem.win_platform? ? "bin/testcmd.bat" : "bin/testcmd" }
 
       before do
-        if Cucumber::WINDOWS
+        if Gem.win_platform?
           @aruba.write_file cmd, <<~BAT
             exit 0
           BAT

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe Aruba::Processes::SpawnProcess do
   end
 
   describe "#send_signal" do
-    let(:signal) { Cucumber::WINDOWS ? 9 : "KILL" }
+    let(:signal) { Gem.win_platform? ? 9 : "KILL" }
 
     context "with a command that is running" do
       let(:cmd) { "bin/test-cli" }


### PR DESCRIPTION
## Summary

Use Ruby's built-in windows platform detection.

## Details

Use `Gem.win_platform?` instead of piggy-backing on Cucumber to check if we're running on Windows.

## Motivation and Context

This avoids the need to load Cucumber when using Aruba with RSpec. A step toward fixing #402 and #806.

## How Has This Been Tested?

Mostly CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
