### PR TITLE
Fix some cucumber timeout issues on MacOS in CI

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/stop_command.feature
@@ -46,7 +46,7 @@ Feature: Stop commands
     Feature: Run it
       Scenario: Run command
         Given the default aruba exit timeout is 0.2 seconds
-        And I wait 0.1 seconds for a command to start up
+        And I wait 0.2 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I run `aruba-test-cli2` in background
         And I terminate the command started last
@@ -98,7 +98,7 @@ Feature: Stop commands
 
       Scenario: Run command
         Given the default aruba exit timeout is 0.2 seconds
-        And I wait 0.1 seconds for a command to start up
+        And I wait 0.2 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I run `aruba-test-cli2` in background
         And I stop the command started last
@@ -148,7 +148,7 @@ Feature: Stop commands
         Given the default aruba exit timeout is 0.2 seconds
 
       Scenario: Run command
-        Given I wait 0.1 seconds for a command to start up
+        Given I wait 0.2 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         When I run `aruba-test-cli2` in background
         And I terminate the command "aruba-test-cli1"
@@ -200,7 +200,7 @@ Feature: Stop commands
         Given the default aruba exit timeout is 0.2 seconds
 
       Scenario: Run command
-        Given I wait 0.1 seconds for a command to start up
+        Given I wait 0.2 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I run `aruba-test-cli2` in background
         When I stop the command "aruba-test-cli1"
@@ -272,7 +272,7 @@ Feature: Stop commands
     Feature: Run it
       Scenario: Run command
         Given the default aruba exit timeout is 0.3 seconds
-        And I wait 0.1 seconds for a command to start up
+        And I wait 0.2 seconds for a command to start up
         When I run `aruba-test-cli1` in background
         And I terminate the command started last
         Then the exit status should be 100

--- a/features/04_aruba_api/command/run_command.feature
+++ b/features/04_aruba_api/command/run_command.feature
@@ -1,13 +1,13 @@
 Feature: Run command
 
-  To run a command use the `#run_command` method. There are some configuration options
-  which are relevant here:
+  To run a command use the `#run_command` method. There are some configuration
+  options which are relevant here:
 
   - `startup_wait_time`:
 
     Given this option `aruba` waits n seconds after it started the command.
-    This is most useful when using `#run_command()` and not really makes sense for
-    `#run_command_and_stop()`.
+    This is most useful when using `#run_command()` and does not really make
+    sense for `#run_command_and_stop()`.
 
     You can use `#run_command()` + `startup_wait_time` to start background jobs.
 
@@ -116,7 +116,7 @@ Feature: Run command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.3 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1, startup_wait_time: 0.4 do
       before do
         run_command('aruba-test-cli')
         last_command_started.send_signal 'HUP'
@@ -154,7 +154,7 @@ Feature: Run command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.3 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.4 do
       before { run_command('aruba-test-cli') }
 
       it 'runs the command with the expected results' do
@@ -178,7 +178,7 @@ Feature: Run command
     #!/usr/bin/env bash
 
     function initialize_script {
-      sleep 0.2
+      sleep 0.3
     }
 
     function do_some_work {
@@ -235,8 +235,8 @@ Feature: Run command
 
     RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.1 do
       before do
-        run_command 'aruba-test-cli1', startup_wait_time: 0.3
-        run_command 'aruba-test-cli2', startup_wait_time: 0.1
+        run_command 'aruba-test-cli1', startup_wait_time: 0.5
+        run_command 'aruba-test-cli2', startup_wait_time: 0.2
         last_command_started.send_signal 'HUP'
       end
 

--- a/features/04_aruba_api/command/send_signal_to_command.feature
+++ b/features/04_aruba_api/command/send_signal_to_command.feature
@@ -25,7 +25,7 @@ Feature: Send running command a signal
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 1, startup_wait_time: 0.2 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 1, startup_wait_time: 0.3 do
       before { run_command('aruba-test-cli') }
       before { last_command_started.send_signal 'HUP' }
       it { expect(last_command_started).to have_output /Exit/ }
@@ -44,7 +44,7 @@ Feature: Send running command a signal
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 1, startup_wait_time: 0.1 do
+    RSpec.describe 'Run command', type: :aruba, exit_timeout: 1, startup_wait_time: 0.2 do
       before { run_command('aruba-test-cli') }
       it { expect { last_command_started.send_signal 'HUP' }.to raise_error Aruba::CommandAlreadyStoppedError, /Command "aruba-test-cli" with PID/ }
     end

--- a/features/04_aruba_api/command/stop_single_command.feature
+++ b/features/04_aruba_api/command/stop_single_command.feature
@@ -52,7 +52,7 @@ Feature: Stop command
     """ruby
     require 'spec_helper'
 
-    RSpec.describe 'Run command', type: :aruba, exit_timeout: 0.2 do
+    RSpec.describe 'Run command', type: :aruba, startup_wait_time: 0.1, exit_timeout: 0.3 do
       before { run_command('aruba-test-cli') }
       before { find_command('aruba-test-cli').stop }
       it { expect(last_command_started).to be_successfully_executed }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Fix some cucumber timeout issues on MacOS in CI

## Details

Makes some timeouts larger to avoid cucumber scenario failures.

## Motivation and Context

Cukes fail regularly in CI on MacOS.

## How Has This Been Tested?

CI of course.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
