### PR TITLE
Fix specs for have_file_content matcher

### DIFF
--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe "File Matchers" do
     end
 
     describe "failure messages" do
+      before do
+        Aruba.platform.write_file(@file_path, "aba")
+      end
+
       def fail_with(message)
         raise_error(RSpec::Expectations::ExpectationNotMetError, message)
       end
@@ -88,20 +92,19 @@ RSpec.describe "File Matchers" do
       example "for a string" do
         expect do
           expect(@file_name).to have_file_content("z")
-        end.to fail_with('expected "test.txt" to have file content: "z"')
+        end.to fail_with('expected "aba" to have file content: "z"')
       end
 
       example "for a regular expression" do
         expect do
           expect(@file_name).to have_file_content(/z/)
-        end.to fail_with('expected "test.txt" to have file content: /z/')
+        end.to fail_with('expected "aba" to have file content: /z/')
       end
 
       example "for a matcher" do
-        expect { expect(@file_name).to have_file_content(a_string_starting_with("z")) }
-          .to fail_with(
-            'expected "test.txt" to have file content: a string starting with "z"'
-          )
+        expect do
+          expect(@file_name).to have_file_content(a_string_starting_with("z"))
+        end.to fail_with 'expected "aba" to have file content: a string starting with "z"'
       end
     end
   end


### PR DESCRIPTION
## Summary

Fix specs for have_file_content matcher

## Details

- Give file under test known contents instead of assuming it does not
  exist
- Update expected failure messages

## Motivation and Context

This avoids a rare test failure that seems to happen if the file under
test accidentally exists.

## How Has This Been Tested?

I ran the specs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
