### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,10 +23,6 @@ jobs:
         ruby: [2.7, "3.0", jruby-9.2]
         appraisal: [cucumber_6]
         include:
-          - ruby: "2.4.0"
-            appraisal: cucumber_4
-          - ruby: "2.4"
-            appraisal: cucumber_4
           - ruby: "2.5"
             appraisal: cucumber_4
           - ruby: "2.6"
@@ -63,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.5, 2.6, 2.7, "3.0"]
 
     runs-on: macos-latest
 
@@ -83,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.5, 2.6, 2.7, "3.0"]
 
     runs-on: windows-latest
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - vendor/**/*
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 # Ignore gemfiles created by Appraisal
 Bundler/OrderedGems:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ We try to comply with [Semantic Versioning 2.0.0](http://semver.org/spec/v2.0.0.
 
 ## Supported Ruby versions
 
-Aruba is supported on Ruby 2.4 and up, and tested against CRuby 2.4, 2.5, 2.6
-and 2.7, and JRuby 9.2.
+Aruba is supported on Ruby 2.5 and up, and tested against CRuby 2.5, 2.6 and
+2.7, and JRuby 9.2.
 
 ## Supported operating systems
 
@@ -91,10 +91,10 @@ Please see the [CONTRIBUTING](CONTRIBUTING.md) file.
 
 ## Code branches
 
-Development takes place in the `main` branch and currently targets the 1.x
-releases. If necessary, maintenance of the old 0.14.x releases takes place in
-the `0-14-stable` branch. Stable branches will not be created until absolutely
-necessary.
+Development takes place in the `main` branch and currently targets the 2.x
+releases. If necessary, maintenance of the old 1.1.x releases will take place
+in a `1-1-stable` branch, and of 0.14.x releases in the `0-14-stable` branch.
+Stable branches will not be created until absolutely necessary.
 
 ## License
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "yard-junk", "~> 0.0.7"
 
   spec.rubygems_version = ">= 1.6.1"
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.files = File.readlines("Manifest.txt", chomp: true)
 

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -49,11 +49,9 @@ Before "@unsupported-on-platform-windows" do
 end
 
 Before "@requires-readline" do
-  begin
-    require "readline"
-  rescue LoadError
-    skip_this_scenario
-  end
+  require "readline"
+rescue LoadError
+  skip_this_scenario
 end
 
 Before "@unsupported-on-platform-unix" do

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -64,47 +64,42 @@ end
 
 When(/^I stop the command(?: started last)? if (output|stdout|stderr) contains:$/) \
   do |channel, expected|
-  begin
-    Timeout.timeout(aruba.config.exit_timeout) do
-      loop do
-        output = last_command_started.public_send channel.to_sym, wait_for_io: 0
 
-        output   = sanitize_text(output)
-        expected = sanitize_text(expected)
+  Timeout.timeout(aruba.config.exit_timeout) do
+    loop do
+      output = last_command_started.public_send channel.to_sym, wait_for_io: 0
 
-        if output.include? expected
-          last_command_started.terminate
+      output   = sanitize_text(output)
+      expected = sanitize_text(expected)
 
-          break
-        end
+      if output.include? expected
+        last_command_started.terminate
 
-        sleep 0.1
+        break
       end
+
+      sleep 0.1
     end
-  rescue ChildProcess::TimeoutError, Timeout::Error
-    last_command_started.terminate
   end
+rescue ChildProcess::TimeoutError, Timeout::Error
+  last_command_started.terminate
 end
 
 When(/^I wait for (?:output|stdout) to contain:$/) do |expected|
   Timeout.timeout(aruba.config.exit_timeout) do
-    begin
-      expect(last_command_started).to have_output an_output_string_including(expected)
-    rescue ExpectationError
-      sleep 0.1
-      retry
-    end
+    expect(last_command_started).to have_output an_output_string_including(expected)
+  rescue ExpectationError
+    sleep 0.1
+    retry
   end
 end
 
 When(/^I wait for (?:output|stdout) to contain "([^"]*)"$/) do |expected|
   Timeout.timeout(aruba.config.exit_timeout) do
-    begin
-      expect(last_command_started).to have_output an_output_string_including(expected)
-    rescue ExpectationError
-      sleep 0.1
-      retry
-    end
+    expect(last_command_started).to have_output an_output_string_including(expected)
+  rescue ExpectationError
+    sleep 0.1
+    retry
   end
 end
 

--- a/lib/aruba/platforms/windows_environment_variables.rb
+++ b/lib/aruba/platforms/windows_environment_variables.rb
@@ -76,7 +76,7 @@ module Aruba
       end
 
       def self.upcase_env(env)
-        env.each_with_object({}) { |(k, v), a| a[k.to_s.upcase] = v }
+        env.to_h.transform_keys { |k| k.to_s.upcase }
       end
 
       private


### PR DESCRIPTION
## Summary

Drop support for Ruby 2.4

## Details

- Bump required ruby version to 2.5
- Adjust GitHub Actions configuration accordingly
- Bump TargetRubyVersion in RuboCop configuration and autocorrect new offenses

## Motivation and Context

Fixes #728.

## How Has This Been Tested?

CI.

## Types of changes

- Potentially breaking change
- Update of dependencies

## Checklist:

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
