### PR TITLE
Update some step definitions to use Cucumber Expression syntax

### DIFF
--- a/Manifest.txt
+++ b/Manifest.txt
@@ -26,6 +26,7 @@ lib/aruba/cucumber/command.rb
 lib/aruba/cucumber/environment.rb
 lib/aruba/cucumber/file.rb
 lib/aruba/cucumber/hooks.rb
+lib/aruba/cucumber/parameter_types.rb
 lib/aruba/cucumber/testing_frameworks.rb
 lib/aruba/errors.rb
 lib/aruba/event_bus.rb

--- a/lib/aruba/cucumber.rb
+++ b/lib/aruba/cucumber.rb
@@ -2,6 +2,7 @@ require "aruba/version"
 
 require "aruba/api"
 require "aruba/cucumber/hooks"
+require "aruba/cucumber/parameter_types"
 require "aruba/cucumber/command"
 require "aruba/cucumber/environment"
 require "aruba/cucumber/file"

--- a/lib/aruba/cucumber/parameter_types.rb
+++ b/lib/aruba/cucumber/parameter_types.rb
@@ -1,0 +1,1 @@
+ParameterType(name: "channel", regexp: "output|stderr|stdout", transformer: ->(name) { name })


### PR DESCRIPTION
## Summary

Update some step definitions to use Cucumber Expression syntax

## Details

This updates some of the step definitions in the command section to use Cucumber Expression syntax. In particalar, this uses the {string} parameter type for the expected output strings.

## Motivation and Context

The main goal of this change is to allow specifying expected output that contains double qoutes.

## How Has This Been Tested?

I ran some of the cucumber scenarios that seemed relevant. 

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
