### PR TITLE
Remove ability to append to non-existent file

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/filesystem/append_to_file.feature
+++ b/features/03_testing_frameworks/cucumber/steps/filesystem/append_to_file.feature
@@ -47,25 +47,3 @@ Feature: Append content to file
     """
     When I run `cucumber`
     Then the features should all pass
-
-  Scenario: Append to a non-existing file (deprecated)
-    Given a file named "features/non-existence.feature" with:
-    """
-    Feature: Existence
-      Scenario: Existence
-        Given a file named "foo/bar/example.txt" does not exist
-        When I append to "foo/bar/example.txt" with:
-        \"\"\"
-        this was appended
-        \"\"\"
-        Then the file named "foo/bar/example.txt" should contain:
-        \"\"\"
-        this was appended
-        \"\"\"
-    """
-    When I run `cucumber`
-    Then the features should all pass
-    And the output should contain:
-    """
-    The ability to call #append_to_file with a file that does not exist is deprecated
-    """

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -326,12 +326,6 @@ module Aruba
       def append_to_file(file_name, file_content)
         file_name = expand_path(file_name)
 
-        unless File.exist? file_name
-          Aruba.platform.deprecated("The ability to call #append_to_file with a file that" \
-                                    " does not exist is deprecated and will be removed in" \
-                                    " Aruba 2.0.")
-          Aruba.platform.mkdir(File.dirname(file_name))
-        end
         File.open(file_name, "a") { |f| f << file_content }
       end
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Remove deprecated functionality from `#append_to_file`

## Details

Removes the feature where appending to a non-existing file would create the file.

## Motivation and Context

This functionality was deprecated and is now removed in preparation for the 2.0 release. Fixes #726.

## How Has This Been Tested?

I ran the relevant cucumber feature file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
