### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1"]
+        ruby: [2.6, 2.7, "3.0"]
 
     runs-on: windows-latest
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,17 +23,17 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", jruby-9.2, jruby-9.3]
-        appraisal: [cucumber_7]
+        ruby: ["3.1", jruby-9.3]
+        appraisal: [cucumber_8]
         include:
-          - ruby: "2.5"
-            appraisal: cucumber_4
           - ruby: "2.6"
+            appraisal: cucumber_4
+          - ruby: "2.7"
             appraisal: cucumber_5
           - ruby: "2.7"
             appraisal: cucumber_6
-          - ruby: "3.1"
-            appraisal: cucumber_8
+          - ruby: "3.0"
+            appraisal: cucumber_7
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.6, 2.7, "3.0", "3.1"]
 
     runs-on: macos-latest
 
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.6, 2.7, "3.0", "3.1"]
 
     runs-on: windows-latest
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 # Ignore gemfiles created by Appraisal
 Bundler/OrderedGems:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ bump.
 
 ## Supported Ruby versions
 
-Aruba is supported on Ruby 2.5 and up, and tested against CRuby 2.5, 2.6, 2.7,
-3.0 and 3.1, and JRuby 9.2 and 9.2.
+Aruba is supported on Ruby 2.6 and up, and tested against CRuby 2.6, 2.7, 3.0
+and 3.1, and JRuby 9.3.
 
 ## Supported Cucumber versions
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.22.0"]
   spec.add_development_dependency "yard-junk", "~> 0.0.7"
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.files = File.readlines("Manifest.txt", chomp: true)
 

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Description"
   spec.homepage      = "http://example.com"
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Description"
   spec.homepage      = "http://example.com"
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.6"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -160,7 +160,7 @@ module Aruba
         prefix = file_name[0]
 
         if prefix == aruba.config.fixtures_path_prefix
-          rest = file_name[2..-1]
+          rest = file_name[2..]
           path = File.join(*[aruba.fixtures_directory, rest].compact)
           unless Aruba.platform.exist? path
             aruba_fixture_candidates = aruba.config.fixtures_directories

--- a/lib/aruba/event_bus/name_resolver.rb
+++ b/lib/aruba/event_bus/name_resolver.rb
@@ -10,7 +10,7 @@ module Aruba
       # Helpers for Resolvers
       module ResolveHelpers
         def camel_case(underscored_name)
-          underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..-1] }.join
+          underscored_name.to_s.split("_").map { |word| word.upcase[0] + word[1..] }.join
         end
 
         # Thanks ActiveSupport

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -125,7 +125,7 @@ module Aruba
       end
 
       def arguments
-        return Shellwords.split(commandline)[1..-1] if Shellwords.split(commandline).size > 1
+        return Shellwords.split(commandline)[1..] if Shellwords.split(commandline).size > 1
 
         []
       end


### PR DESCRIPTION
## Summary

Drop support for Ruby 2.5

## Details

- Require Ruby 2.6 or higher in the gemspec
- Update RuboCop configuration and fix new offenses
- Update set of Rubies in CI

## Motivation and Context

With the release of JRuby 9.3.0.0, we can drop compatibility with Ruby 2.5. MRI 2.5 has been unmaintained for a while now.

## How Has This Been Tested?

CI

## Types of changes

This is a potentially breaking change for versions of rubygems and bundler that do not take ruby version requirements into account. From the standpoint of semver, it is not a breaking API change so does not require a major version bump.

## Checklist:

- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
