### PR TITLE
Remove pretend-nils

### DIFF
--- a/lib/aruba/console.rb
+++ b/lib/aruba/console.rb
@@ -43,7 +43,7 @@ module Aruba
         end
 
         def inspect
-          "nil"
+          "aruba console"
         end
       end
 

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -320,7 +320,7 @@ Then(/^the output should( not)? match:$/) do |negated, expected|
 end
 
 Then(/^the exit status should( not)? be (\d+)$/) do |negated, exit_status|
-  last_command_started.stop if last_command_stopped.nil?
+  last_command_started.stop if last_command_stopped.empty?
 
   if negated
     expect(last_command_stopped).not_to have_exit_status exit_status.to_i

--- a/lib/aruba/matchers/command/have_exit_status.rb
+++ b/lib/aruba/matchers/command/have_exit_status.rb
@@ -18,33 +18,27 @@
 #     end
 RSpec::Matchers.define :have_exit_status do |expected|
   match do |actual|
-    @old_actual = actual
+    actual.stop
+    @actual_exit_status = actual.exit_status
 
-    @old_actual.stop
-    @actual = actual.exit_status
-
-    unless @old_actual.respond_to? :exit_status
-      raise "Expected #{@old_actual} to respond to #exit_status"
-    end
-
-    values_match? expected, @actual
+    values_match? expected, @actual_exit_status
   end
 
   failure_message do |actual|
     format(
       %(expected that command "%s" has exit status of "%s", but has "%s".),
-      @old_actual.commandline,
+      actual.commandline,
       expected.to_s,
-      actual.to_s
+      @actual_exit_status.to_s
     )
   end
 
   failure_message_when_negated do |actual|
     format(
       %(expected that command "%s" does not have exit status of "%s", but has "%s".),
-      @old_actual.commandline,
+      actual.commandline,
       expected.to_s,
-      actual.to_s
+      @actual_exit_status.to_s
     )
   end
 end

--- a/lib/aruba/platforms/command_monitor.rb
+++ b/lib/aruba/platforms/command_monitor.rb
@@ -15,7 +15,7 @@ module Aruba
     attr_reader :registered_commands, :last_command_started, :last_command_stopped
 
     class DefaultLastCommandStopped
-      def nil?
+      def empty?
         true
       end
 
@@ -29,7 +29,7 @@ module Aruba
     end
 
     class DefaultLastCommandStarted
-      def nil?
+      def empty?
         true
       end
 

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -130,6 +130,10 @@ module Aruba
         []
       end
 
+      def empty?
+        false
+      end
+
       private
 
       def truncate(string, max_length)


### PR DESCRIPTION
- Don't pretend console self is nil
- Use #empty? instead of #nil? to distinguish empty commands
- Simplify implementation of have_exit_status matcher

## Summary

Remove methods that make non-nil objects pretend they are nil.

## Details

Removes implementations of `#nil?` that returned `true` for classes that are not NilClass; Also updates the `#inspect` method for `self` in the Aruba console not to return the string `"nil"`.

## Motivation and Context

Having objects respond with `true` to the `#nil?` message is super-confusing for humans, machines and cyborgs.

## How Has This Been Tested?

I ran the specs and cukes.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
