### PR TITLE
Improve testing of be_an_existing_executable matcher

### DIFF
--- a/features/05_use_rspec_matchers/file/be_existing_executable.feature
+++ b/features/05_use_rspec_matchers/file/be_existing_executable.feature
@@ -3,30 +3,22 @@ Feature: Check if path exists and is an executable file
   If you need to check if a given path exists and is a file, you can use the
   `be_an_existing_executable`-matcher.
 
-  ```ruby
-  require 'spec_helper'
-
-  RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
-    let(:file) { 'file.txt' }
-    before { touch(file) }
-    before { chmod(0o755, file) }
-
-    it { expect(file).to be_an_existing_executable }
-  end
-  ```
-
   Background:
     Given I use a fixture named "cli-app"
 
-  Scenario: Expect single existing executable file
+  @unsupported-on-platform-windows
+  Scenario: Checking an executable file by permissions on Unix
     Given a file named "spec/existing_executable_spec.rb" with:
     """
     require 'spec_helper'
 
-    RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
-      let(:file) { 'file.txt' }
-      before { touch(file) }
-      before { chmod(0o755, file) }
+    RSpec.describe 'Check if file exists and is an executable file', type: :aruba do
+      let(:file) { 'my-exe' }
+
+      before do
+        touch(file)
+        chmod(0o755, file)
+      end
 
       it { expect(file).to be_an_existing_executable }
     end
@@ -34,54 +26,21 @@ Feature: Check if path exists and is an executable file
     When I run `rspec`
     Then the specs should all pass
 
-  Scenario: Expect single non-existing executable file
+  @unsupported-on-platform-unix
+  Scenario: Checking an executable file by file name on Windows
     Given a file named "spec/existing_executable_spec.rb" with:
     """
     require 'spec_helper'
 
-    RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
-      let(:file) { 'file.txt' }
-      it { expect(file).not_to be_an_existing_executable }
-    end
-    """
-    When I run `rspec`
-    Then the specs should all pass
+    RSpec.describe 'Check if file exists and is an executable file', type: :aruba do
+      let(:file) { 'foo.bat' }
 
-  Scenario: Expect multiple existing executable files
-    Given a file named "spec/existing_executable_spec.rb" with:
-    """
-    require 'spec_helper'
-
-    RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
-      let(:files) { %w(file1.txt file2.txt) }
-
-      before :each do
-        files.each do |f|
-          touch(f)
-          chmod(0o755, f)
-        end
+      before do
+        touch(file)
+        chmod(0o755, file)
       end
 
-      it { expect(files).to all be_an_existing_executable }
-    end
-    """
-    When I run `rspec`
-    Then the specs should all pass
-
-  Scenario: Expect a least one existing executable file
-    Given a file named "spec/existing_executable_spec.rb" with:
-    """
-    require 'spec_helper'
-
-    RSpec.describe 'Check if file exists and is an executable file', :type => :aruba do
-      let(:files) { %w(file1.txt file2.txt) }
-
-      before :each do
-        touch(files.first)
-        chmod(0o755, files.first)
-      end
-
-      it { expect(files).to include an_existing_executable }
+      it { expect(file).to be_an_existing_executable }
     end
     """
     When I run `rspec`

--- a/spec/aruba/matchers/file_spec.rb
+++ b/spec/aruba/matchers/file_spec.rb
@@ -4,7 +4,7 @@ require "aruba/matchers/file"
 RSpec.describe "File Matchers" do
   include_context "uses aruba API"
 
-  describe "to_be_an_existing_file" do
+  describe "#be_an_existing_file" do
     let(:name) { @file_name }
 
     context "when file exists" do
@@ -34,7 +34,7 @@ RSpec.describe "File Matchers" do
     end
   end
 
-  describe "to_have_file_content" do
+  describe "#have_file_content" do
     context "when file exists" do
       before do
         Aruba.platform.write_file(@file_path, "aba")
@@ -109,7 +109,7 @@ RSpec.describe "File Matchers" do
     end
   end
 
-  describe "to have_same_file_content_as" do
+  describe "#have_same_file_content_as" do
     let(:file_name) { @file_name }
     let(:file_path) { @file_path }
 
@@ -151,6 +151,7 @@ RSpec.describe "File Matchers" do
     end
   end
 
+  # FIXME: This basically checks a_file_with_same_content_as as an alias
   describe "include a_file_with_same_content_as" do
     let(:reference_file) { "fixture" }
     let(:reference_file_content) { "foo bar baz" }
@@ -194,7 +195,7 @@ RSpec.describe "File Matchers" do
     end
   end
 
-  describe "to_have_file_size" do
+  describe "#have_file_size" do
     context "when file exists" do
       before do
         Aruba.platform.write_file(@file_path, "")
@@ -211,6 +212,41 @@ RSpec.describe "File Matchers" do
 
     context "when file does not exist" do
       it { expect(@file_name).not_to have_file_size(0) }
+    end
+  end
+
+  describe "#be_an_existing_executable" do
+    context "when file exists and is executable" do
+      let(:file) { Gem.win_platform? ? "foo.bat" : "foo" }
+
+      before do
+        @aruba.write_file(file, "")
+        @aruba.chmod(0x755, file) unless Gem.win_platform?
+      end
+
+      it "matches" do
+        expect(file).to be_an_existing_executable
+      end
+    end
+
+    context "when file exists and is not executable" do
+      let(:file) { Gem.win_platform? ? "foo.txt" : "foo" }
+
+      before do
+        @aruba.write_file(file, "")
+      end
+
+      it "does not match" do
+        expect(file).not_to be_an_existing_executable
+      end
+    end
+
+    context "when file does not exist" do
+      let(:file) { Gem.win_platform? ? "foo.bat" : "foo" }
+
+      it "does not match" do
+        expect(file).not_to be_an_existing_executable
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Improve testing of `be_an_existing_executable` matcher

## Details

* Test behavior of `be_an_existing_executable` matcher in the specs
* Leave simple scenario as documentation
* Provide separate scenarios for Windows and Unix

## Motivation and Context

Continuous improvement.

## How Has This Been Tested?

I ran the relevant specs and scenarios.

## Types of changes

- Documentation update
- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
