### PR TITLE
Test with Ruby 3.1 in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   CUCUMBER_PUBLISH_QUIET: true
+  RUBYOPTS: "--disable-did-you-mean"
   JRUBY_OPTS: "--dev"
 
 jobs:
@@ -22,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", jruby-9.2]
+        ruby: ["3.0", "3.1", jruby-9.2]
         appraisal: [cucumber_7]
         include:
           - ruby: "2.5"

--- a/.simplecov
+++ b/.simplecov
@@ -31,6 +31,3 @@ SimpleCov.configure do
   # lets, befores, afters, etc are being used.
   add_group "Specs", "spec/"
 end
-
-# Run simplecov by default
-SimpleCov.start unless ENV.key? "ARUBA_NO_COVERAGE"

--- a/features/support/simplecov_setup.rb
+++ b/features/support/simplecov_setup.rb
@@ -3,7 +3,10 @@
 unless RUBY_PLATFORM.include?("java")
   require "simplecov"
   root = File.expand_path("../..", __dir__)
-  SimpleCov.command_name(ENV["SIMPLECOV_COMMAND_NAME"])
+  command_name = ENV["SIMPLECOV_COMMAND_NAME"] || "Cucumber Features"
+  SimpleCov.command_name(command_name)
   SimpleCov.root(root)
-  load File.join(root, ".simplecov")
+
+  # Run simplecov by default
+  SimpleCov.start unless ENV.key? "ARUBA_NO_COVERAGE"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,10 @@ $LOAD_PATH << ::File.expand_path("../lib", __dir__)
 
 unless RUBY_PLATFORM.include?("java")
   require "simplecov"
-  SimpleCov.command_name "rspec"
-  SimpleCov.start
+  SimpleCov.command_name "RSpec"
+
+  # Run simplecov by default
+  SimpleCov.start unless ENV.key? "ARUBA_NO_COVERAGE"
 end
 
 # Loading support files


### PR DESCRIPTION
## Summary

Test with Ruby 3.1 in CI

## Details

Add Ruby 3.1 to the CI matrix; also add `--disable-did-you-mean` option to avoid extra output that disturbs the cucumber scenario's.

## Motivation and Context

Aruba should work with Ruby 3.1.

## How Has This Been Tested?

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
