### PR TITLE
Inherit default RuboCop exclusions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,13 @@
+inherit_mode:
+  merge:
+    - Exclude
+
 require:
   - rubocop-packaging
   - rubocop-performance
   - rubocop-rspec
 
 AllCops:
-  Exclude:
-    - tmp/**/*
-    - vendor/**/*
   DisplayCopNames: true
   NewCops: enable
   TargetRubyVersion: 2.5


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Simplify RubyCop config by inheriting default exclusions

## Details

RubyCop excludes tmp/ and vendor/ by default, so remove them from the local exclusions list and make sure they remain even if we add new local exclusions, by specifying the 'merge' inherit mode for exclusions.

## Motivation and Context

Simpler is better.

## How Has This Been Tested?

N/A

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
