### PR TITLE
Use just IRB for debugging

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -32,8 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "json", "~> 2.1"
   spec.add_development_dependency "kramdown", "~> 2.1"
   spec.add_development_dependency "minitest", "~> 5.10"
-  spec.add_development_dependency "pry", [">= 0.13.0", "< 0.15.0"]
-  spec.add_development_dependency "pry-doc", "~> 1.0"
   spec.add_development_dependency "rake", [">= 12.0", "< 14.0"]
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.10.0"

--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -7,7 +7,6 @@ Feature: Debug your command in cucumber-test-run
     Given I use a fixture named "cli-app"
     And the default aruba exit timeout is 60 seconds
 
-  @unsupported-on-platform-java
   Scenario: You can use a debug repl in your cli program
 
     If you want to debug an error, which only occurs in one of your
@@ -15,15 +14,14 @@ Feature: Debug your command in cucumber-test-run
     DebugProcess runner, making your program use the default stdin, stdout and
     stderr streams so you can interact with it directly.
 
-    This will, for example, make `binding.pry` and `byebug` work in your
-    program. However, Aruba steps that access the input and output of your
-    program will not work.
+    This will, for example, make `binding.irb` work in your program. However,
+    Aruba steps that access the input and output of your program will not work.
 
-    Please make sure, that there's a statement after the `binding.pry`-call.
-    Otherwise you might not get an interactive shell, because your program will
-    just exit.
+    Please make sure, that there's a statement after the statement starting the
+    debugger. Otherwise you might not get an interactive shell, because your
+    program will just exit.
 
-    We are going to demonstrate this using `pry`, but any other interactive
+    We are going to demonstrate this using `irb`, but any other interactive
     debugger for any other programming language should also work.
 
     Given an executable named "bin/aruba-test-cli" with:
@@ -35,8 +33,7 @@ Feature: Debug your command in cucumber-test-run
 
     foo = 'hello'
 
-    require 'pry'
-    binding.pry
+    binding.irb
 
     exit 0
     """
@@ -53,11 +50,15 @@ Feature: Debug your command in cucumber-test-run
     And I type "foo"
     And I type "exit"
     Then the output should contain:
-    """
-    [1] pry(main)> foo
-    => "hello"
-    [2] pry(main)> exit
-    """
+      """
+       => 8: binding.irb
+          9: 
+          10: exit 0
+      Switch to inspect mode.
+      foo
+      "hello"
+      exit
+      """
 
   Scenario: Can handle announcers
     Given an executable named "bin/aruba-test-cli" with:

--- a/fixtures/cli-app/script/console
+++ b/fixtures/cli-app/script/console
@@ -6,9 +6,5 @@ require "cli/app"
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
 require "irb"
 IRB.start

--- a/spec/support/configs/pry.rb
+++ b/spec/support/configs/pry.rb
@@ -1,3 +1,0 @@
-# Otherwise pry doesn't find it's RC file
-# if ENV['HOME'] is mocked
-ENV["PRYRC"] = File.expand_path("~/.pryrc")


### PR DESCRIPTION
## Summary

Use plain irb for debugging and for demonstrating debugging

## Details, Motivation and Context

Development of pry has stalled and it is suggested that debug in combination with irb is the future. For now, we cannot use debug yet since only a very old version runs on Ruby 2.5.

For now, this change removes the pry, pry-doc, byebug and pry-byebug dependencies. If needed for local development, these can be added back via Gemfile.local.

Debugging inside a scenario using Aruba is now demonstrated using plain irb. This has the added advantage of also working on JRuby.

Once support for Ruby 2.5 has been dropped, the new debug gem can be added as a permanent dependency to provide extended debugging features by default.

## How Has This Been Tested?

I did a simple debug session with debug. This worked on Ruby 3.1, but not really on 2.5.

I ran the adjusted scenario on Ruby 3.1 and JRuby.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
