### PR TITLE
Fix steps that wait for output from commands

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
@@ -54,13 +54,13 @@ Feature: Wait for output of commands
           \"\"\"
           irb(main):001:0>
           \"\"\"
-        And I type "10.times { |i| puts i + 2; sleep 0.1 }"
+        And I type '3.times { |i| puts "Test #{i}"; sleep 0.1 }'
         And I stop the command if output contains:
           \"\"\"
-          3
+          Test 0
           \"\"\"
-        Then the output should contain "3"
-        Then the output should not contain "4"
+        Then the output should contain "Test 0"
+        Then the output should not contain "Test 2"
     """
     When I run `cucumber`
     Then the features should all pass

--- a/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
@@ -1,0 +1,45 @@
+Feature: Wait for output of commands
+
+  In order to interact with my program at the right moment
+  As a developer using Aruba
+  I want to wait for particular output to appear
+
+  Background:
+    Given I use a fixture named "cli-app"
+
+  Scenario: Detect subset of one-line output
+    Given a file named "features/output.feature" with:
+    """cucumber
+    Feature: Run command
+      Scenario: Run command
+        When I run `irb --prompt default` interactively
+        And I wait for output to contain "irb"
+        And I type "puts 6 + 5"
+        And I type "exit"
+        Then the output should contain "11"
+    """
+    When I run `cucumber`
+    Then the features should all pass
+
+  Scenario: Detect subset of multiline output
+    Given an executable named "bin/aruba-test-cli" with:
+    """bash
+    #!/usr/bin/env bash
+
+    echo -e "hello\nworld"
+    """
+    And a file named "features/output.feature" with:
+    """cucumber
+    Feature: Run command
+      Scenario: Run command
+        When I run `irb --prompt default` interactively
+        And I wait for output to contain:
+          \"\"\"
+          irb(main):001:0>
+          \"\"\"
+        And I type "puts 'hello'"
+        And I type "exit"
+        Then the output should contain "hello"
+    """
+    When I run `cucumber`
+    Then the features should all pass

--- a/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
@@ -43,3 +43,24 @@ Feature: Wait for output of commands
     """
     When I run `cucumber`
     Then the features should all pass
+
+  Scenario: Stop when output appears
+    Given a file named "features/output.feature" with:
+    """cucumber
+    Feature: Run command
+      Scenario: Run command
+        When I run `irb --prompt default` interactively
+        And I wait for output to contain:
+          \"\"\"
+          irb(main):001:0>
+          \"\"\"
+        And I type "10.times { |i| puts i + 2; sleep 0.1 }"
+        And I stop the command if output contains:
+          \"\"\"
+          3
+          \"\"\"
+        Then the output should contain "3"
+        Then the output should not contain "4"
+    """
+    When I run `cucumber`
+    Then the features should all pass

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -85,21 +85,33 @@ rescue ChildProcess::TimeoutError, Timeout::Error
   last_command_started.terminate
 end
 
-When "I wait for output/stdout to contain" do |expected|
+When "I wait for output/stdout to contain:" do |expected|
   Timeout.timeout(aruba.config.exit_timeout) do
-    expect(last_command_started).to have_output an_output_string_including(expected)
-  rescue ExpectationError
-    sleep 0.1
-    retry
+    loop do
+      output = last_command_started.public_send :stdout, wait_for_io: 0
+
+      output   = sanitize_text(output)
+      expected = sanitize_text(expected)
+
+      break if output.include? expected
+
+      sleep 0.1
+    end
   end
 end
 
 When "I wait for output/stdout to contain {string}" do |expected|
   Timeout.timeout(aruba.config.exit_timeout) do
-    expect(last_command_started).to have_output an_output_string_including(expected)
-  rescue ExpectationError
-    sleep 0.1
-    retry
+    loop do
+      output = last_command_started.public_send :stdout, wait_for_io: 0
+
+      output   = sanitize_text(output)
+      expected = sanitize_text(expected)
+
+      break if output.include? expected
+
+      sleep 0.1
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

Fix the 'wait for output to contain' steps

## Details

- Fix implementation of steps for waiting for output
- Add scenario to test the 'stop the command if output contains' step

## Motivation and Context

Fixes #854.

## How Has This Been Tested?

Three new scenarios test this functionality.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
