### PR TITLE
Remove pry-byebug depedency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,6 @@ your normal development workflow.
 Example `Gemfile.local`:
 
 ```ruby
-gem 'pry'
 gem 'pry-byebug'
 gem 'byebug'
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,3 @@ gemspec
 if File.file? File.expand_path("Gemfile.local", __dir__)
   load File.expand_path("Gemfile.local", __dir__)
 end
-
-gem "byebug", "~> 11.0", platform: :mri
-gem "pry-byebug", "~> 3.4", platform: :mri

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "json", "~> 2.1"
   spec.add_development_dependency "kramdown", "~> 2.1"
   spec.add_development_dependency "minitest", "~> 5.10"
+  spec.add_development_dependency "pry", [">= 0.13.0", "< 0.15.0"]
   spec.add_development_dependency "pry-doc", "~> 1.0"
   spec.add_development_dependency "rake", [">= 12.0", "< 14.0"]
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"

--- a/gemfiles/cucumber_4.gemfile
+++ b/gemfiles/cucumber_4.gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "byebug", "~> 11.0", platform: :mri
-gem "pry-byebug", "~> 3.4", platform: :mri
 gem "cucumber", "~> 4.0"
 gem "childprocess", "~> 2.0.0"
 

--- a/gemfiles/cucumber_5.gemfile
+++ b/gemfiles/cucumber_5.gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "byebug", "~> 11.0", platform: :mri
-gem "pry-byebug", "~> 3.4", platform: :mri
 gem "cucumber", "~> 5.0"
 gem "childprocess", "~> 3.0.0"
 

--- a/gemfiles/cucumber_6.gemfile
+++ b/gemfiles/cucumber_6.gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "byebug", "~> 11.0", platform: :mri
-gem "pry-byebug", "~> 3.4", platform: :mri
 gem "cucumber", "~> 6.0"
 gem "childprocess", "~> 4.0"
 

--- a/gemfiles/cucumber_7.gemfile
+++ b/gemfiles/cucumber_7.gemfile
@@ -2,8 +2,6 @@
 
 source "https://rubygems.org"
 
-gem "byebug", "~> 11.0", platform: :mri
-gem "pry-byebug", "~> 3.4", platform: :mri
 gem "cucumber", "~> 7.0"
 gem "childprocess", "~> 4.0"
 


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Remove pry-byebug and byebug.

## Details

This removes the hard development dependencies on byebug and pry-byebug. This will allow intalling the latest version of pry. If pry-byebug is needed, it can still be added in Gemfile.local. The pry dependency is set to be lenient enough to allow installing a version compatible with pry-byebug.

## Motivation and Context

This keeps dependencies up-to-date. I find I don't use byebug so dropping it from the default set shouldn't be problematic. Once support for Ruby 2.5 has been dropped, the new debug gem can be added as a permanent dependency to provide extended debugging features by default.

## How Has This Been Tested?

CI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
