### PR TITLE
Ensure Gem.win_platform? is available

### DIFF
--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -1,4 +1,5 @@
 require "rbconfig"
+require "rubygems"
 require "pathname"
 
 require "aruba/aruba_path"

--- a/spec/aruba/platforms/unix_platform_spec.rb
+++ b/spec/aruba/platforms/unix_platform_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+require "aruba/platforms/unix_platform"
+
+RSpec.describe Aruba::Platforms::UnixPlatform do
+  include_context "uses aruba API"
+
+  describe ".match?" do
+    it "works even when ruby is launched with --disable-gems and --disable-rubyopt" do
+      aruba_lib = File.expand_path("../../../lib", __dir__)
+      run_command_and_stop(
+        "ruby --disable-rubyopt --disable-gems -I#{aruba_lib}" \
+        " -e 'require \"aruba/platforms/unix_platform\";" \
+        " Aruba::Platforms::UnixPlatform.match?;'"
+      )
+      expect(last_command_started).to be_successfully_executed
+    end
+  end
+end

--- a/spec/aruba/platforms/windows_platform_spec.rb
+++ b/spec/aruba/platforms/windows_platform_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+require "aruba/platforms/windows_platform"
+
+RSpec.describe Aruba::Platforms::WindowsPlatform do
+  include_context "uses aruba API"
+
+  describe ".match?" do
+    it "works even when ruby is launched with --disable-gems and --disable-rubyopt" do
+      aruba_lib = File.expand_path("../../../lib", __dir__)
+      run_command_and_stop(
+        "ruby --disable-rubyopt --disable-gems -I#{aruba_lib}" \
+        " -e 'require \"aruba/platforms/windows_platform\";" \
+        " Aruba::Platforms::WindowsPlatform.match?;'"
+      )
+      expect(last_command_started).to be_successfully_executed
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Ensure `Gem.win_platform?` is available by explicitly requiring `rubygems`.

## Motivation and Context

Even though rubygems is nearly always loaded by ruby automatically, it is possible to avoid doing so. Therefore, to make platform detection work, we have to require "rubygems" explicitly.

Fixes #852.

## How Has This Been Tested?

Specs were added that exercise the relevant functionality for the case where rubygems is not loaded.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- I've added tests for my code
