### PR TITLE
Fix new RuboCop offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,10 @@ Metrics/BlockLength:
 RSpec/PredicateMatcher:
   Enabled: false
 
+# This cop doesn't seem to add much for us.
+Style/FetchEnvVar:
+  Enabled: false
+
 # Use older RuboCop default
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", [">= 12.0", "< 14.0"]
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.11"
-  spec.add_development_dependency "rubocop", "~> 1.26"
+  spec.add_development_dependency "rubocop", "~> 1.28"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.8"

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -12,7 +12,7 @@ describe Aruba::Api do
 
       context "enabled" do
         before do
-          @aruba.aruba.announcer = instance_double "Aruba::Platforms::Announcer"
+          @aruba.aruba.announcer = instance_double Aruba::Platforms::Announcer
           allow(@aruba.aruba.announcer).to receive(:announce)
         end
 

--- a/spec/aruba/command_spec.rb
+++ b/spec/aruba/command_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Aruba::Command do
     )
   end
 
-  let(:event_bus) { instance_double("Aruba::EventBus") }
+  let(:event_bus) { instance_double(Aruba::EventBus) }
   let(:exit_timeout) { 0.01 }
   let(:io_wait_timeout) { 0.01 }
   let(:working_directory) { File.expand_path(".") }


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Handle new offenses found by the latest versions of rubocop and rubocop-rspec.

## Details

- Bump rubocop dependency to ensure Style/FetchEnvVar is present
- Disable Style/FetchEnvVar
- Autocorrect RSpec/VerifiedDoubleReference

## Motivation and Context

Keeping the build green.

## How Has This Been Tested?

I ran RuboCop.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
