### PR TITLE
Remove code supporting cucumber 3 from simplecov set-up

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,12 +12,8 @@ require "aruba/cucumber"
 require "aruba/config/jruby"
 require "rspec/expectations"
 
-Before do |scenario|
-  command_name = if scenario.respond_to?(:feature) # Cucumber < 4
-                   "#{scenario.feature.file} #{scenario.name}"
-                 else
-                   "#{scenario.location.file}:#{scenario.location.line} # #{scenario.name}"
-                 end
+Before do |test_case|
+  command_name = "#{test_case.location.file}:#{test_case.location.line} # #{test_case.name}"
 
   # Used in simplecov_setup so that each scenario has a different name and
   # their coverage results are merged instead of overwriting each other as


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Removes obsolete support for Cucumber 3 from `features/support/env.rb`.

## Details

With Cucumber 4, `scenario.feature` stopped working in a `Before do |scenario|` block. Since Aruba no longer supports Cucumber below version 4, the code path for using `scenario.feature` was obsolete and has now been removed.

Additionally, the parameter for a `Before` block is no longer a scenario. Instead, it's a test case. I've adjusted the parameter name accordingly. More details here: https://github.com/cucumber/cucumber-ruby/issues/1432.

## Motivation and Context

I came across https://github.com/cucumber/cucumber-ruby/issues/1432 and decided to clean things up.

## How Has This Been Tested?

I ran one cucumber feature file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
