### PR TITLE
Fix new RuboCop offenses

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", [">= 12.0", "< 14.0"]
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.11"
-  spec.add_development_dependency "rubocop", "~> 1.28"
+  spec.add_development_dependency "rubocop", ["~> 1.28", "!= 1.29.0"]
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.8"

--- a/fixtures/cli-app/lib/cli/app.rb
+++ b/fixtures/cli-app/lib/cli/app.rb
@@ -1,6 +1,6 @@
 require "cli/app/version"
 
-::Dir.glob(File.expand_path("**/*.rb", __dir__)).each { |f| require_relative f }
+::Dir.glob(File.expand_path("**/*.rb", __dir__)).sort.each { |f| require_relative f }
 
 module Cli
   module App

--- a/fixtures/cli-app/spec/spec_helper.rb
+++ b/fixtures/cli-app/spec/spec_helper.rb
@@ -4,5 +4,5 @@ require "cli/app"
 
 require_relative "support/aruba"
 
-::Dir.glob(::File.expand_path("support/**/*.rb", __dir__))
+::Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).sort
      .each { |f| require_relative f }

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -100,7 +100,7 @@ module Aruba
       end
 
       def require_matching_files(pattern, base)
-        ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require_relative f }
+        ::Dir.glob(::File.expand_path(pattern, base)).sort.each { |f| require_relative f }
       end
 
       # Create directory and subdirectories

--- a/spec/aruba/rspec_spec.rb
+++ b/spec/aruba/rspec_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "RSpec Integration", type: :aruba do
 
   describe "Setting up the environment" do
     it "sets HOME to the configured value" do
-      expect(ENV["HOME"]).to eq aruba.config.home_directory
+      expect(Dir.home).to eq aruba.config.home_directory
     end
 
     it "includes configured command search paths in PATH" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ unless RUBY_PLATFORM.include?("java")
 end
 
 # Loading support files
-Dir.glob(::File.expand_path("support/*.rb", __dir__)).each { |f| require_relative f }
-Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).each { |f| require_relative f }
+Dir.glob(::File.expand_path("support/*.rb", __dir__)).sort.each { |f| require_relative f }
+Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).sort.each { |f| require_relative f }


### PR DESCRIPTION
## Summary

Fix two new RuboCop offenses. Also skip RubyCop 1.29.0 since it dropped support for Ruby 2.5 by accident.

## Details

- Ensure use of RuboCop version supporting TargetRubyVersion 2.5
- Autocorrect Style/EnvHome
- Autocorrect Lint/NonDeterministicRequireOrder

## Motivation and Context

Make the checks pass in CI again. Also this does actually improve the code.

## How Has This Been Tested?

I ran RuboCop.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
