### PR TITLE
Update RuboCop and correct new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,10 @@ Bundler/OrderedGems:
 Gemspec/RequireMFA:
   Enabled: false
 
+# Spaces in strings with line continuations go at the beginning of the line.
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Assume the programmer knows how bracketed block syntax works
 Lint/AmbiguousBlockAssociation:
   Enabled: false

--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,8 @@ Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = %w(--format progress)
 end
 
-Cucumber::Rake::Task.new("cucumber:wip", "Run Cucumber features "\
-                                         'which are "WORK IN PROGRESS" and '\
+Cucumber::Rake::Task.new("cucumber:wip", "Run Cucumber features " \
+                                         'which are "WORK IN PROGRESS" and ' \
                                          "are allowed to fail") do |t|
   t.cucumber_opts = %w(--tags @wip:3 --wip)
 end

--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,9 @@ Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = %w(--format progress)
 end
 
-Cucumber::Rake::Task.new("cucumber:wip", "Run Cucumber features " \
-                                         'which are "WORK IN PROGRESS" and ' \
-                                         "are allowed to fail") do |t|
+Cucumber::Rake::Task.new("cucumber:wip", "Run Cucumber features" \
+                                         " which are \"WORK IN PROGRESS\" and" \
+                                         " are allowed to fail") do |t|
   t.cucumber_opts = %w(--tags @wip:3 --wip)
 end
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -44,7 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", [">= 0.18.0", "< 0.22.0"]
   spec.add_development_dependency "yard-junk", "~> 0.0.7"
 
-  spec.rubygems_version = ">= 1.6.1"
   spec.required_ruby_version = ">= 2.5"
 
   spec.files = File.readlines("Manifest.txt", chomp: true)

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -144,7 +144,7 @@ module Aruba
       def expand_path(file_name, dir_string = nil)
         unless file_name.is_a?(String) && !file_name.empty?
           message = "Filename #{file_name} needs to be a string." \
-                    " It cannot be nil or empty either."\
+                    " It cannot be nil or empty either." \
                     " Please use `expand_path('.')` if you want" \
                     " the current directory to be expanded."
 
@@ -195,7 +195,7 @@ module Aruba
               "Aruba's `expand_path` method was called with an absolute path" \
               " at #{caller_file_line}, which is not recommended." \
               " The path passed was '#{file_name}'." \
-              " Change the call to pass a relative path or set "\
+              " Change the call to pass a relative path or set " \
               "`config.allow_absolute_paths = true` to silence this warning"
             raise UserError, message
           end

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -195,8 +195,8 @@ module Aruba
               "Aruba's `expand_path` method was called with an absolute path" \
               " at #{caller_file_line}, which is not recommended." \
               " The path passed was '#{file_name}'." \
-              " Change the call to pass a relative path or set " \
-              "`config.allow_absolute_paths = true` to silence this warning"
+              " Change the call to pass a relative path or set" \
+              " `config.allow_absolute_paths = true` to silence this warning"
             raise UserError, message
           end
           file_name


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

~~Bump RuboCop version to allow configuring of LineContinuationLeadingSpace, and~~ Handle new RuboCop offenses from RuboCop 1.31 and 1.32. LineContinuationLeadingSpace is configured to match the most common current style in the codebase.

## Details

- ~~Bump RuboCop version to support LineContinuationLeadingSpace config~~
- Configure Layout/LineContinuationLeadingSpace
- Autocorrect Layout/LineContinuationSpacing
- Fix Layout/LineContinuationLeadingSpace and unify quote characters
- Fix Gemspec/DeprecatedAttributeAssignment

## Motivation and Context

Make RuboCop not fail when updated to its latest version.

## How Has This Been Tested?

I ran RuboCop.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
