### PR TITLE
Improve specs for Aruba::CommandMonitor

### DIFF
--- a/spec/aruba/platforms/command_monitor_spec.rb
+++ b/spec/aruba/platforms/command_monitor_spec.rb
@@ -3,16 +3,19 @@ require "spec_helper"
 RSpec.describe Aruba::CommandMonitor do
   let(:monitor) { described_class.new(announcer: announcer) }
   let(:announcer) { instance_double(Aruba::Platforms::Announcer) }
-  let(:process) { instance_double(Aruba::Processes::BasicProcess) }
+  let(:process) { instance_double(Aruba::Processes::BasicProcess, commandline: "foobar") }
 
   before do
-    allow(process).to receive(:commandline).and_return("foobar")
     monitor.register_command(process)
   end
 
   describe "#find" do
-    it "works" do
-      expect(monitor.find("foobar")).to eq(process)
+    it "find the process with the given name" do
+      expect(monitor.find("foobar")).to eq process
+    end
+
+    it "fails if no process with the given name exists" do
+      expect { monitor.find("boofar") }.to raise_error Aruba::CommandNotFoundError
     end
   end
 end


### PR DESCRIPTION
## Summary

This improves specs for Aruba::CommandMonitor, fixing a lint failure.

## Details

- Improve spec description
- Add spec for failure mode

## Motivation and Context

Fixes #877.

## How Has This Been Tested?

I ran the updated spec and rubocop.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
