### PR TITLE
Correct Style/RedundantConstantBase offenses

### DIFF
--- a/fixtures/cli-app/lib/cli/app.rb
+++ b/fixtures/cli-app/lib/cli/app.rb
@@ -1,6 +1,6 @@
 require "cli/app/version"
 
-::Dir.glob(File.expand_path("**/*.rb", __dir__)).sort.each { |f| require_relative f }
+Dir.glob(File.expand_path("**/*.rb", __dir__)).sort.each { |f| require_relative f }
 
 module Cli
   module App

--- a/fixtures/cli-app/spec/spec_helper.rb
+++ b/fixtures/cli-app/spec/spec_helper.rb
@@ -4,5 +4,5 @@ require "cli/app"
 
 require_relative "support/aruba"
 
-::Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).sort
-     .each { |f| require_relative f }
+Dir.glob(File.expand_path("support/**/*.rb", __dir__)).sort
+   .each { |f| require_relative f }

--- a/spec/aruba/event_bus/name_resolver_spec.rb
+++ b/spec/aruba/event_bus/name_resolver_spec.rb
@@ -33,7 +33,7 @@ describe Aruba::EventBus::NameResolver do
       end
 
       context "when prefixed" do
-        let(:original_name) { ::Events::MyEvent }
+        let(:original_name) { Events::MyEvent }
 
         it { expect(resolved_name).to eq Events::MyEvent }
       end

--- a/spec/aruba/event_bus/name_resolver_spec.rb
+++ b/spec/aruba/event_bus/name_resolver_spec.rb
@@ -26,17 +26,9 @@ describe Aruba::EventBus::NameResolver do
     end
 
     context "when name is class" do
-      context "when simple" do
-        let(:original_name) { Events::MyEvent }
+      let(:original_name) { Events::MyEvent }
 
-        it { expect(resolved_name).to eq Events::MyEvent }
-      end
-
-      context "when prefixed" do
-        let(:original_name) { Events::MyEvent }
-
-        it { expect(resolved_name).to eq Events::MyEvent }
-      end
+      it { expect(resolved_name).to eq Events::MyEvent }
     end
 
     context "when name is symbol" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << ::File.expand_path("../lib", __dir__)
+$LOAD_PATH << File.expand_path("../lib", __dir__)
 
 unless RUBY_PLATFORM.include?("java")
   require "simplecov"
@@ -9,5 +9,5 @@ unless RUBY_PLATFORM.include?("java")
 end
 
 # Loading support files
-Dir.glob(::File.expand_path("support/*.rb", __dir__)).sort.each { |f| require_relative f }
-Dir.glob(::File.expand_path("support/**/*.rb", __dir__)).sort.each { |f| require_relative f }
+Dir.glob(File.expand_path("support/*.rb", __dir__)).sort.each { |f| require_relative f }
+Dir.glob(File.expand_path("support/**/*.rb", __dir__)).sort.each { |f| require_relative f }


### PR DESCRIPTION
## Summary

Fixes Style/RedundantConstantBase offenses. This cop was introduced in RuboCop 1.40.0.

## Details

Autocorrects Style/RedundantConstantBase, and cleans up specs that turned out to be actually the same.

## Motivation and Context

Make the build pass again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
