### PR TITLE
Use RSpec annotations instead of included class to trigger RSpec hooks

### DIFF
--- a/lib/aruba/rspec.rb
+++ b/lib/aruba/rspec.rb
@@ -10,47 +10,35 @@ RSpec.configure do |config|
   config.include Aruba::Api, type: :aruba
 
   # Setup environment for aruba
-  config.around :each do |example|
-    if self.class.include? Aruba::Api
-      setup_aruba
+  config.around :each, type: :aruba do |example|
+    setup_aruba
 
-      # Modify PATH to include project/bin
-      prepend_environment_variable(
-        'PATH',
-        aruba.config.command_search_paths.join(File::PATH_SEPARATOR) + File::PATH_SEPARATOR
-      )
+    # Modify PATH to include project/bin
+    prepend_environment_variable(
+      'PATH',
+      aruba.config.command_search_paths.join(File::PATH_SEPARATOR) + File::PATH_SEPARATOR
+    )
 
-      # Use configured home directory as HOME
-      set_environment_variable 'HOME', aruba.home_directory
-    end
+    # Use configured home directory as HOME
+    set_environment_variable 'HOME', aruba.home_directory
 
     example.run
-
-    next unless self.class.include? Aruba::Api
 
     stop_all_commands
   end
 
-  config.around :each do |example|
-    if self.class.include? Aruba::Api
-      with_environment do
-        example.run
-      end
-    else
+  config.around :each, type: :aruba do |example|
+    with_environment do
       example.run
     end
   end
 
-  config.before :each do |example|
-    next unless self.class.include? Aruba::Api
-
+  config.before :each, type: :aruba do |example|
     example.metadata.each { |k, v| aruba.config.set_if_option(k, v) }
   end
 
   # Activate announcers based on rspec metadata
-  config.before :each do |example|
-    next unless self.class.include?(Aruba::Api)
-
+  config.before :each, type: :aruba do |example|
     if example.metadata[:announce_full_environment]
       aruba.announcer.activate(:full_environment)
     end


### PR DESCRIPTION
## Summary

Use `type: :aruba` to trigger all RSpec hooks in the default integration, replacing the check for inclusion of Aruba::Api.

## Details

When using the default aruba/rspec integration, the initial inclusion of `Aruba::Api` was triggered by a `type: :aruba` annotation to the spec, but the other hooks were filtered by a check for inclusion of Aruba::Api.

Since we already use :type to trigger inclusion of Aruba::Api, we can safely use it to activate the around hooks as well, thus simplifying the code

This also increases safety for custom integrations, since having those work correctly depended on "aruba/rspec" never being loaded.

## Motivation and Context

This improves simplicity of the code by relying on existing mechanisms instead of introducing our own.

## How Has This Been Tested?

CI will check this

## Types of changes

- (Maybe) bug fix (non-breaking change which fixes an issue)
- Internal change (refactoring, test improvements, developer experience or update of dependencies)
