### PR TITLE
Add support for JRuby 9.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", jruby-9.3]
+        ruby: ["3.1", jruby-9.4]
         appraisal: [cucumber_8]
         include:
           - ruby: "2.6"
@@ -34,6 +34,8 @@ jobs:
             appraisal: cucumber_6
           - ruby: "3.0"
             appraisal: cucumber_7
+          - ruby: "jruby-9.3"
+            appraisal: cucumber_8
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ bump.
 ## Supported Ruby versions
 
 Aruba is supported on Ruby 2.6 and up, and tested against CRuby 2.6, 2.7, 3.0
-and 3.1, and JRuby 9.3.
+and 3.1, and JRuby 9.3 and 9.4.
 
 ## Supported Cucumber versions
 


### PR DESCRIPTION
## Summary

Add support for JRuby 9.4

## Details

This just adds jruby-9.4 to the build matrix for now.

## Motivation and Context

JRuby 9.4 is out and we should support it officially.

## How Has This Been Tested?

CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
