### PR TITLE
Support CRuby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", jruby-9.4]
+        ruby: ["3.1", "3.2", "jruby-9.3", "jruby-9.4"]
         appraisal: [cucumber_8]
         include:
           - ruby: "2.6"
@@ -34,8 +34,6 @@ jobs:
             appraisal: cucumber_6
           - ruby: "3.0"
             appraisal: cucumber_7
-          - ruby: "jruby-9.3"
-            appraisal: cucumber_8
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile
@@ -68,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1"]
+        ruby: [2.6, 2.7, "3.0", "3.1", "3.2"]
 
     runs-on: macos-latest
 
@@ -113,7 +111,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: "3.2"
           bundler-cache: true
       - name: Install license_finder
         run: gem install license_finder

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ bump.
 
 ## Supported Ruby versions
 
-Aruba is supported on Ruby 2.6 and up, and tested against CRuby 2.6, 2.7, 3.0
-and 3.1, and JRuby 9.3 and 9.4.
+Aruba is supported on Ruby 2.6 and up, and tested against CRuby 2.6, 2.7, 3.0,
+3.1 and 3.2, and JRuby 9.3 and 9.4.
 
 ## Supported Cucumber versions
 


### PR DESCRIPTION
## Summary

Add Ruby 3.2 to the build matrix

## Details

Adds Ruby 3.2 to the build matrix on Linux and MacOS. Leaves Windows as-is since we already had problems with 3.1 there. Also, updates the Ruby version RuboCop runs under.

## Motivation and Context

It's Christmas.

## How Has This Been Tested?

I ran rake locally on Ruby 3.2

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
