### PR TITLE
Improve Cucumber timing helper

### DIFF
--- a/features/support/timing.rb
+++ b/features/support/timing.rb
@@ -3,11 +3,7 @@
 scenario_times = {}
 
 Around do |scenario, block|
-  name = if scenario.respond_to?(:feature) # Cucumber < 4
-           "#{scenario.feature.file}::#{scenario.name}"
-         else
-           "#{scenario.location.file}:#{scenario.location.line} # #{scenario.name}"
-         end
+  name = "#{scenario.location.file}:#{scenario.location.line} # #{scenario.name}"
 
   start = Time.now
   block.call

--- a/features/support/timing.rb
+++ b/features/support/timing.rb
@@ -16,10 +16,10 @@ Around do |scenario, block|
 end
 
 at_exit do
-  max_scenarios = scenario_times.size > 20 ? 20 : scenario_times.size
-  puts "------------- Top #{max_scenarios} slowest scenarios -------------"
   sorted_times = scenario_times.sort { |a, b| b[1] <=> a[1] }
-  sorted_times[0..max_scenarios - 1].each do |key, value|
+  slowest_times = sorted_times.first(20)
+  puts "------------- Top #{slowest_times.size} slowest scenarios -------------"
+  slowest_times.each do |key, value|
     puts format("%.2f  %s", value, key)
   end
 end


### PR DESCRIPTION
## Summary

Refactor the helper that shows the slowest 20 Cucumber scenario's after a run

## Details

- Refactor slowest scenario list display
- Remove code supporting Cucumber < 4 from scenario timing helper

## Motivation and Context

RuboCop registered an offense for this code but I saw some more opportunity for improvement

## How Has This Been Tested?

I ran cucumber and checked that the slowest scenarios were displayed

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)