### PR TITLE
Remove obsolete statement about Ruby version used in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Instructions
 # ------------
 #
-# This Dockerfile will always target the lowest version of Ruby supported by
-# Aruba. This is currently version 2.4.0.
-#
 # Build the Docker image using:
 #
 #   docker build -t test-aruba .


### PR DESCRIPTION
## Summary

Remove obsolete Ruby version statement in the Dockerfile comments

## Details

This change removes the now-incorrect statement that the Dockerfile will use the lowest supported Ruby version.

There is no real need to use the lowest version since this Dockerfile is provided just so contributors can use a known-good development setup if necessary.

## Motivation and Context

Renovate updated the Ruby version, making the comment incorrect.

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
