### PR TITLE
Depend on process launcher to set child process environment

### DIFF
--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -97,10 +97,8 @@ module Aruba
         @process.environment.update(environment)
 
         begin
-          Aruba.platform.with_environment(environment) do
-            @process.start
-            sleep startup_wait_time
-          end
+          @process.start
+          sleep startup_wait_time
         rescue ChildProcess::LaunchError => e
           raise LaunchError, "It tried to start #{commandline}. " + e.message
         end


### PR DESCRIPTION
## Summary

Depend on process launcher to set child process environment

## Details

This change removes a needless `#with_environment` call when spawning a process. Setting the local environment at this point no effect since we already set the environment by configuring the child process launcher.

## Motivation and Context

Cleaning up a needless complication in preparation for switching to `Process.spawn`.

## How Has This Been Tested?

Specs and cukes were run and there was no regression.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
