### PR TITLE
Replace ChildProcess with Process.spawn

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -2,25 +2,20 @@
 
 appraise "cucumber_4" do
   gem "cucumber", "~> 4.0"
-  gem "childprocess", "~> 2.0.0"
 end
 
 appraise "cucumber_5" do
   gem "cucumber", "~> 5.0"
-  gem "childprocess", "~> 3.0.0"
 end
 
 appraise "cucumber_6" do
   gem "cucumber", "~> 6.0"
-  gem "childprocess", "~> 4.0"
 end
 
 appraise "cucumber_7" do
   gem "cucumber", "~> 7.0"
-  gem "childprocess", "~> 4.0"
 end
 
 appraise "cucumber_8" do
   gem "cucumber", "~> 8.0"
-  gem "childprocess", "~> 4.0"
 end

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_runtime_dependency "bundler", [">= 1.17", "< 3.0"]
-  spec.add_runtime_dependency "childprocess", [">= 2.0", "< 5.0"]
   spec.add_runtime_dependency "contracts", [">= 0.16.0", "< 0.18.0"]
   spec.add_runtime_dependency "cucumber", ">= 4.0", "< 9.0"
   spec.add_runtime_dependency "rspec-expectations", "~> 3.4"

--- a/gemfiles/cucumber_4.gemfile
+++ b/gemfiles/cucumber_4.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "cucumber", "~> 4.0"
-gem "childprocess", "~> 2.0.0"
 
 gemspec path: "../"

--- a/gemfiles/cucumber_5.gemfile
+++ b/gemfiles/cucumber_5.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "cucumber", "~> 5.0"
-gem "childprocess", "~> 3.0.0"
 
 gemspec path: "../"

--- a/gemfiles/cucumber_6.gemfile
+++ b/gemfiles/cucumber_6.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "cucumber", "~> 6.0"
-gem "childprocess", "~> 4.0"
 
 gemspec path: "../"

--- a/gemfiles/cucumber_7.gemfile
+++ b/gemfiles/cucumber_7.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "cucumber", "~> 7.0"
-gem "childprocess", "~> 4.0"
 
 gemspec path: "../"

--- a/gemfiles/cucumber_8.gemfile
+++ b/gemfiles/cucumber_8.gemfile
@@ -3,6 +3,5 @@
 source "https://rubygems.org"
 
 gem "cucumber", "~> 8.0"
-gem "childprocess", "~> 4.0"
 
 gemspec path: "../"

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -81,7 +81,7 @@ When(/^I stop the command(?: started last)? if (output|stdout|stderr) contains:$
       sleep 0.1
     end
   end
-rescue ChildProcess::TimeoutError, Timeout::Error
+rescue Timeout::Error
   last_command_started.terminate
 end
 

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -241,6 +241,10 @@ module Aruba
       def builtin_shell_commands
         []
       end
+
+      def term_signal_supported?
+        true
+      end
     end
   end
 end

--- a/lib/aruba/platforms/windows_command_string.rb
+++ b/lib/aruba/platforms/windows_command_string.rb
@@ -4,8 +4,6 @@ module Aruba
   module Platforms
     # This is a command which should be run
     #
-    # This adds `cmd.exec` in front of commmand
-    #
     # @private
     class WindowsCommandString
       def initialize(command, *arguments)
@@ -15,22 +13,7 @@ module Aruba
 
       # Convert to array
       def to_a
-        [cmd_path, "/c", [escaped_command, *escaped_arguments].join(" ")]
-      end
-
-      private
-
-      def escaped_arguments
-        @arguments.map { |arg| arg.gsub(/"/, '"""') }
-                  .map { |arg| / /.match?(arg) ? "\"#{arg}\"" : arg }
-      end
-
-      def escaped_command
-        @command.gsub(/ /, '""" """')
-      end
-
-      def cmd_path
-        Aruba.platform.which("cmd.exe")
+        [@command, *@arguments]
       end
     end
   end

--- a/lib/aruba/platforms/windows_platform.rb
+++ b/lib/aruba/platforms/windows_platform.rb
@@ -39,6 +39,10 @@ module Aruba
       def builtin_shell_commands
         %w(cd dir echo exit set type)
       end
+
+      def term_signal_supported?
+        false
+      end
     end
   end
 end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -17,7 +17,7 @@ module Aruba
         @exit_status = nil
       end
 
-      attr_accessor :stdout, :stderr, :duplex, :cwd, :environment
+      attr_accessor :stdout, :stderr, :cwd, :environment
       attr_reader :command_array, :pid
 
       def start
@@ -162,13 +162,11 @@ module Aruba
         @stderr_file.set_encoding("ASCII-8BIT")
 
         @exit_status = nil
-        @duplex      = true
 
         before_run
 
         @process.stdout = @stdout_file
         @process.stderr = @stderr_file
-        @process.duplex = @duplex
         @process.cwd    = @working_directory
 
         @process.environment = environment

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -36,6 +36,17 @@ module Aruba
         @stdin_w
       end
 
+      def stop
+        return if @exit_status
+
+        send_signal "TERM"
+        return if poll_for_exit(3)
+
+        send_signal "KILL"
+        _, status = Process.waitpid2 @pid
+        @exit_status = status
+      end
+
       def exited?
         return true if @exit_status
 
@@ -62,6 +73,12 @@ module Aruba
 
       def exit_code
         @exit_status&.exitstatus
+      end
+
+      private
+
+      def send_signal(signal)
+        Process.kill signal, @pid
       end
     end
 

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -202,7 +202,7 @@ module Aruba
         return @stdout_cache if stopped?
 
         wait_for_io opts.fetch(:wait_for_io, io_wait_timeout) do
-          @process.io.stdout.flush
+          @process.stdout.flush
           open(@stdout_file.path).read
         end
       end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -246,7 +246,7 @@ module Aruba
       def stop(*)
         return @exit_status if stopped?
 
-        @process.poll_for_exit(@exit_timeout)
+        @process.poll_for_exit(@exit_timeout) or @timed_out = true
 
         terminate
       end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -38,8 +38,10 @@ module Aruba
       def stop
         return if @exit_status
 
-        send_signal "TERM"
-        return if poll_for_exit(3)
+        if Aruba.platform.term_signal_supported?
+          send_signal "TERM"
+          return if poll_for_exit(3)
+        end
 
         send_signal "KILL"
         wait

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -221,7 +221,7 @@ module Aruba
         return @stderr_cache if stopped?
 
         wait_for_io opts.fetch(:wait_for_io, io_wait_timeout) do
-          @process.io.stderr.flush
+          @process.stderr.flush
           open(@stderr_file.path).read
         end
       end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -25,8 +25,8 @@ module Aruba
         @pid = Process.spawn(environment, *command_array,
                              unsetenv_others: true,
                              in: @stdin_r,
-                             out: stdout, # alternative: IO.pipe
-                             err: stderr, # alternative: IO.pipe
+                             out: stdout.fileno,
+                             err: stderr.fileno,
                              close_others: true,
                              chdir: cwd)
       end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -63,8 +63,9 @@ module Aruba
       def poll_for_exit(exit_timeout)
         start = Time.now
         wait_until = start + exit_timeout
-        while Time.now < wait_until
+        loop do
           return true if exited?
+          break if Time.now >= wait_until
 
           sleep 0.1
         end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -43,6 +43,10 @@ module Aruba
         return if poll_for_exit(3)
 
         send_signal "KILL"
+        wait
+      end
+
+      def wait
         _, status = Process.waitpid2 @pid
         @exit_status = status
       end

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -1,4 +1,3 @@
-require "childprocess"
 require "tempfile"
 require "shellwords"
 

--- a/spec/aruba/platforms/windows_command_string_spec.rb
+++ b/spec/aruba/platforms/windows_command_string_spec.rb
@@ -2,24 +2,19 @@ require "spec_helper"
 
 RSpec.describe Aruba::Platforms::WindowsCommandString do
   let(:command_string) { described_class.new(base_command, *arguments) }
-  let(:cmd_path) { 'C:\Some Path\cmd.exe' }
   let(:arguments) { [] }
-
-  before do
-    allow(Aruba.platform).to receive(:which).with("cmd.exe").and_return(cmd_path)
-  end
 
   describe "#to_a" do
     context "with a command with a path" do
       let(:base_command) { "C:\\Foo\\Bar" }
 
-      it { expect(command_string.to_a).to eq [cmd_path, "/c", base_command] }
+      it { expect(command_string.to_a).to eq [base_command] }
     end
 
     context "with a command with a path containing spaces" do
       let(:base_command) { "C:\\Foo Bar\\Baz" }
 
-      it { expect(command_string.to_a).to eq [cmd_path, "/c", 'C:\Foo""" """Bar\Baz'] }
+      it { expect(command_string.to_a).to eq [base_command] }
     end
 
     context "with a command and arguments" do
@@ -28,7 +23,7 @@ RSpec.describe Aruba::Platforms::WindowsCommandString do
 
       it {
         expect(command_string.to_a)
-          .to eq [cmd_path, "/c", "#{base_command} -w \"baz quux\""]
+          .to eq [base_command, *arguments]
       }
     end
   end

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -146,6 +146,8 @@ RSpec.describe Aruba::Processes::SpawnProcess do
       end
 
       before do
+        skip "Signals other than KILL are not supported on Windows" if Gem.win_platform?
+
         @aruba.write_file cmd, <<~BASH
           #!/usr/bin/env bash
 

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe Aruba::Processes::SpawnProcess do
         expect(process).to be_timed_out
       end
     end
+
+    context "with zero exit timeout" do
+      let(:exit_timeout) { 0 }
+
+      it "does not make the command timed out if it already stopped" do
+        process.start
+        sleep 0.1
+        process.stop
+        expect(process).not_to be_timed_out
+      end
+    end
   end
 
   describe "#start" do

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -266,7 +266,6 @@ RSpec.describe Aruba::Processes::SpawnProcess do
       before do
         allow(Aruba.platform).to receive(:command_string)
           .and_return Aruba::Platforms::WindowsCommandString
-        allow(Aruba.platform).to receive(:which).with("cmd.exe").and_return(cmd_path)
         allow(Aruba.platform)
           .to receive(:which).with(command, anything).and_return(command_path)
         allow(Aruba::Processes::ProcessRunner).to receive(:new).and_return(child)
@@ -289,30 +288,30 @@ RSpec.describe Aruba::Processes::SpawnProcess do
       end
 
       context "with a command without a space in the path" do
-        it "passes the command and shell paths as single strings to ProcessRunner.new" do
+        it "passes the command as-is" do
           process.start
           expect(Aruba::Processes::ProcessRunner).to have_received(:new)
-            .with([cmd_path, "/c", command_path])
+            .with([command_path])
         end
       end
 
       context "with a command with a space in the path" do
         let(:command_path) { 'D:\Bar Baz\foo' }
 
-        it "escapes the spaces using excessive double quotes" do
+        it "passes the command as-is" do
           process.start
           expect(Aruba::Processes::ProcessRunner).to have_received(:new)
-            .with([cmd_path, "/c", 'D:\Bar""" """Baz\foo'])
+            .with([command_path])
         end
       end
 
       context "with a command with arguments" do
         let(:command_line) { "foo -x 'bar \"baz\"'" }
 
-        it "passes the command and arguments as one string with escaped quotes" do
+        it "passes the command and arguments individually" do
           process.start
           expect(Aruba::Processes::ProcessRunner).to have_received(:new)
-            .with([cmd_path, "/c", "#{command_path} -x \"bar \"\"\"baz\"\"\"\""])
+            .with([command_path, "-x", "bar \"baz\""])
         end
       end
     end

--- a/spec/aruba/processes/spawn_process_spec.rb
+++ b/spec/aruba/processes/spawn_process_spec.rb
@@ -127,6 +127,12 @@ RSpec.describe Aruba::Processes::SpawnProcess do
         process.stop
         expect(process).not_to have_output "Success"
       end
+
+      it "makes the command timed out" do
+        process.start
+        process.stop
+        expect(process).to be_timed_out
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

This replaces ChildProcess with Process.spawn for the purpose of starting, stopping and controlling the processes under test.

## Details

To make this change be the least invasive, I created a new class that emulates the interface provided by ChildProcess, with a few differences where this was more practical. For example, where ChildProcess provides an #io method that returns an object giving access to stdout etc., this new class simply privides #stdout and related methods directly.

This also removes the childprocess dependency.

## Motivation and Context

This fixes #884.

## How Has This Been Tested?

I ran the full test suite with MRI 3.2 and JRuby 9.4.

I also added specs for SpawnProcess so its tested more fully in the RSpec suite.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- I've added tests for my code