### PR TITLE
Update GitHub Actions to run specs on Windows on all supported Rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0"]
+        ruby: [2.7, "3.0", "3.1", "3.2"]
 
     runs-on: windows-latest
 


### PR DESCRIPTION
## Summary

Extends the GitHub Actions jobs to run the specs on Windows on all supported Rubies

## Details

This is a follow-up for https://github.com/cucumber/aruba/pull/892.

Since ChildProcess is no longer used, running the specs on Ruby 3.1 and 3.2 should work.

## Motivation and Context

Closes #871.

## How Has This Been Tested?

CI

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)