### PR TITLE
Remove yard-junk and pry-doc dependencies

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ Bundler.setup
 require "cucumber/rake/task"
 require "rspec/core/rake_task"
 require "rubocop/rake_task"
-require "yard-junk/rake"
 
 Cucumber::Rake::Task.new do |t|
   t.cucumber_opts = %w(--format progress)
@@ -26,7 +25,6 @@ desc "Run the whole test suite."
 task test: [:spec, :cucumber]
 
 RuboCop::RakeTask.new
-YardJunk::Rake.define_task
 
 Bundler::GemHelper.install_tasks
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-performance", "~> 1.13"
   spec.add_development_dependency "rubocop-rspec", "~> 2.8"
   spec.add_development_dependency "simplecov", ">= 0.18.0", "< 0.23.0"
-  spec.add_development_dependency "yard-junk", "~> 0.0.7"
 
   spec.required_ruby_version = ">= 2.6"
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "kramdown", "~> 2.1"
   spec.add_development_dependency "minitest", "~> 5.10"
   spec.add_development_dependency "pry", [">= 0.13.0", "< 0.15.0"]
-  spec.add_development_dependency "pry-doc", "~> 1.0"
   spec.add_development_dependency "rake", [">= 12.0", "< 14.0"]
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rspec", "~> 3.11"


### PR DESCRIPTION
## Summary

Removes dependencies that pull in yard and hence webrick

## Details

By removing yard-junk and pry-doc, we drop the dependency on YARD. This is done mainly to avoid the outdated dependency on webrick that YARD pulls in in turn.

Running yard-junk was not part of CI, so we lose nothing there. When desired, yard junk can be checked for by running `yard doc --plugin junk`.  Documentation provided by pry-doc can easily be read outside of the REPL.

## Motivation and Context

Dropping an outdated dependency.

## How Has This Been Tested?

N/A

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)