### PR TITLE
Simplify use of match_array to just eq

### DIFF
--- a/spec/aruba/event_bus_spec.rb
+++ b/spec/aruba/event_bus_spec.rb
@@ -63,7 +63,7 @@ describe Aruba::EventBus do
       it "keeps all registrations" do
         bus.notify event_instance
 
-        expect(received_events).to match_array [event_instance, event_instance]
+        expect(received_events).to eq [event_instance, event_instance]
       end
     end
 


### PR DESCRIPTION
## Summary

Replace `match_array` with just `eq`.

## Details

Both elements of the array are the same, so testing for equality is just fine.

## Motivation and Context

This fixes a RuboCop RSpec/MatchArray offense.


## How Has This Been Tested?

I ran the relevant spec file.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
