### PR TITLE
Require development dependencies to be in the gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,8 +21,10 @@ Bundler/OrderedGems:
   Exclude:
     - 'gemfiles/*.gemfile'
 
+# Put development dependencies in the gemspec so rubygems.org knows about them.
 # Don't complicate things in fixture apps and gems
 Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
   Exclude:
     - 'fixtures/**/*'
 


### PR DESCRIPTION
Just updating the RuboCop configuration to match the current setup.