### PR TITLE
Update 'disable bundler' scenarios to work with Bundler 2.4.17 and up

### DIFF
--- a/features/03_testing_frameworks/cucumber/disable_bundler.feature
+++ b/features/03_testing_frameworks/cucumber/disable_bundler.feature
@@ -17,7 +17,7 @@ Feature: Disable Bundler environment
         \"\"\"
         source 'https://rubygems.org'
         \"\"\"
-        When I run `bundle --local`
+        When I run `bundle list`
         Then the output should not contain "aruba"
 
       Scenario: Run bundle in the existing bundler environment
@@ -25,7 +25,7 @@ Feature: Disable Bundler environment
         \"\"\"
         source 'https://rubygems.org'
         \"\"\"
-        When I run `bundle --local`
+        When I run `bundle list`
         Then the output should contain "aruba"
     """
     When I run `bundle exec cucumber`


### PR DESCRIPTION
## Summary

Make the 'disable bundler' scenarios work with Bundler version 2.4.17 and up

## Details

In recent versions of bundler, plain 'bundle' no longer prints a message for dependencies that were not updated. This change makes the scenarios use 'bundle list' instead, which should always keep printing all dependencies.

## Motivation and Context

The relevent cucumber scenario started failing

## How Has This Been Tested?

I ran the scenario again after the update to the code.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
