### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,13 +26,9 @@ jobs:
         ruby: ["3.1", "3.2", "jruby-9.4"]
         appraisal: [cucumber_8, cucumber_9]
         include:
-          - ruby: "2.6"
-            appraisal: cucumber_8
           - ruby: "2.7"
             appraisal: cucumber_8
           - ruby: "3.0"
-            appraisal: cucumber_8
-          - ruby: "jruby-9.3"
             appraisal: cucumber_8
 
     env:
@@ -66,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1", "3.2"]
+        ruby: [2.7, "3.0", "3.1", "3.2"]
 
     runs-on: macos-latest
 
@@ -86,7 +82,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, "3.0"]
+        ruby: [2.7, "3.0"]
 
     runs-on: windows-latest
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   Exclude:
     - 'bin/cucumber'
     - 'bin/rspec'

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ bump.
 
 ## Supported Ruby versions
 
-Aruba is supported on Ruby 2.6 and up, and tested against CRuby 2.6, 2.7, 3.0,
-3.1 and 3.2, and JRuby 9.3 and 9.4.
+Aruba is supported on Ruby 2.7 and up, and tested against CRuby 2.7, 3.0,
+3.1 and 3.2, and JRuby 9.4.
 
 ## Supported Cucumber versions
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec", "~> 2.8"
   spec.add_development_dependency "simplecov", ">= 0.18.0", "< 0.23.0"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.files = File.readlines("Manifest.txt", chomp: true)
 

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Description"
   spec.homepage      = "http://example.com"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Description"
   spec.homepage      = "http://example.com"
 
-  spec.required_ruby_version = ">= 2.6"
+  spec.required_ruby_version = ">= 2.7"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Drop support for Ruby 2.6

## Details

Bumps up the mimimum Ruby version and adjusts rubocop configuration and GitHub Actions accordingly.

## Motivation and Context

Ruby 2.6 has been unmaintained for a long time.

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
