### PR TITLE
Allow for type input of frozen strings

### DIFF
--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -210,7 +210,7 @@ module Aruba
       def type(input)
         return close_input if input == "\u0004"
 
-        last_command_started.write(input << "\n")
+        last_command_started.write("#{input}\n")
       end
 
       # Close stdin

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe Aruba::Api::Commands do
         expect(@aruba.last_command_started).to have_output "Hello"
       end
 
+      it "respond to frozen input" do
+        @aruba.type "Hello".freeze
+        @aruba.type "\u0004".freeze
+        expect(@aruba.last_command_started).to have_output "Hello"
+      end
+
       it "respond to close_input" do
         @aruba.type "Hello"
         @aruba.close_input


### PR DESCRIPTION
## Summary

Some codebases follow the convention of enforcing frozen string literals, e.g. by using a `# frozen_string_literal: true` magic comment or via `RUBYOPT`.

The current implementation of the `type` API Command breaks when this is the case, as it mutates the string passed to it to add a newline.

## Details

To avoid this, this PR tweaks the implementation to use interpolation rather than mutating the string input value.

## Motivation and Context

Allows the `type` API Command to be used in codebases that enforce frozen string literals.

## How Has This Been Tested?

I've added a test case to the existing specs for `Aruba::Api::Commands#run_command` to assert that frozen strings can be passed as an input value.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- [x] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
