### PR TITLE
Use ruby-setup's native caching

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,19 +40,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - uses: actions/cache@v3
-        with:
-          # NOTE: Bundler expands the path relative to the gemfile, not the
-          # current directory.
-          path: ./gemfiles/vendor/bundle
-          key: bundled-gems-${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ matrix.appraisal }}-${{ hashFiles(env.BUNDLE_GEMFILE, '*.gemspec') }}
-          restore-keys: |
-            bundled-gems-${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ matrix.appraisal }}-
-            bundled-gems-${{ runner.os }}-ruby-${{ matrix.ruby }}-
-      - name: Install gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4
+          bundler-cache: true
       - name: Run specs
         run: bundle exec rake spec
       - name: Run cukes


### PR DESCRIPTION
## Summary

Use ruby-setup's native caching in CI instead of rolling our own.

## Details

The ruby/ruby-setup action supports caching with different gemfiles out of the box. This removes the custom caching setup and turns on caching in the ruby-setup configuration instead.

See https://github.com/ruby/setup-ruby#matrix-of-gemfiles.

## Motivation and Context

Removes a needless complication.

## How Has This Been Tested?

CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
