### PR TITLE
Fix some new RuboCop offenses

### DIFF
--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -180,7 +180,7 @@ module Aruba
 
     # Set if name is option
     def set_if_option(name, *args)
-      public_send("#{name}=".to_sym, *args) if option? name
+      public_send(:"#{name}=", *args) if option? name
     end
 
     private

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -28,9 +28,9 @@ module Aruba
       launchers << Processes::InProcess
       launchers << Processes::SpawnProcess
 
-      launcher = launchers.find { |l| l.match? opts[:mode] }
+      klass = launchers.find { |l| l.match? opts[:mode] }
 
-      super launcher.new(
+      launcher = klass.new(
         command,
         opts.fetch(:exit_timeout),
         opts.fetch(:io_wait_timeout),
@@ -40,6 +40,8 @@ module Aruba
         opts.fetch(:stop_signal),
         opts.fetch(:startup_wait_time)
       )
+
+      super(launcher)
 
       @event_bus = opts.fetch(:event_bus)
     rescue KeyError => e


### PR DESCRIPTION
## Summary

Fixes two new RuboCop offenses

## Details

- Autocorrect Lint/SymbolConversion
- Correct Style/SuperWithArgsParentheses offense

## Motivation and Context

The latest RuboCop has some new cops.

## How Has This Been Tested?

Ran RuboCop after.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A