### PR TITLE
Prepare for Ruby 3.3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,7 +23,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "jruby-9.4"]
+        ruby: ["3.1", "3.2", "jruby-9.4", "3.3.0-preview3"]
         appraisal: [cucumber_8, cucumber_9]
         include:
           - ruby: "2.7"

--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -10,15 +10,15 @@ Feature: Debug your command in cucumber-test-run
   Scenario: You can use a debug repl in your cli program
 
     If you want to debug an error, which only occurs in one of your
-    `cucumber`-tests, the `@debug`-tag becomes handy. This will use the
+    Cucumber tests, the `@debug`-tag becomes handy. This will use the
     DebugProcess runner, making your program use the default stdin, stdout and
     stderr streams so you can interact with it directly.
 
-    This will, for example, make `binding.pry` and `byebug` work in your
+    This will, for example, make `binding.irb` and `byebug` work in your
     program. However, Aruba steps that access the input and output of your
     program will not work.
 
-    We are going to demonstrate this using `pry`, but any other interactive
+    We are going to demonstrate this using `irb`, but any other interactive
     debugger for any other programming language should also work.
 
     Given an executable named "bin/aruba-test-cli" with:
@@ -27,8 +27,7 @@ Feature: Debug your command in cucumber-test-run
 
     foo = 'hello'
 
-    require 'pry'
-    binding.pry
+    binding.irb
     """
     And a file named "features/debug.feature" with:
     """cucumber
@@ -44,9 +43,9 @@ Feature: Debug your command in cucumber-test-run
     And I type "exit"
     Then the output should contain:
     """
-    [1] pry(main)> foo
-    => "hello"
-    [2] pry(main)> exit
+    foo
+    "hello"
+    exit
     """
 
   Scenario: Can handle announcers

--- a/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
@@ -12,7 +12,7 @@ Feature: Wait for output of commands
     """cucumber
     Feature: Run command
       Scenario: Run command
-        When I run `irb --prompt default` interactively
+        When I run `irb --prompt classic` interactively
         And I wait for output to contain "irb"
         And I type "puts 6 + 5"
         And I type "exit"
@@ -32,7 +32,7 @@ Feature: Wait for output of commands
     """cucumber
     Feature: Run command
       Scenario: Run command
-        When I run `irb --prompt default` interactively
+        When I run `irb --prompt classic` interactively
         And I wait for output to contain:
           \"\"\"
           irb(main):001:0>
@@ -49,7 +49,7 @@ Feature: Wait for output of commands
     """cucumber
     Feature: Run command
       Scenario: Run command
-        When I run `irb --prompt default` interactively
+        When I run `irb --prompt classic` interactively
         And I wait for output to contain:
           \"\"\"
           irb(main):001:0>

--- a/lib/aruba/console.rb
+++ b/lib/aruba/console.rb
@@ -29,7 +29,6 @@ module Aruba
       IRB.conf[:RC] = false
 
       require "irb/completion"
-      require "irb/ext/save-history"
       IRB.conf[:READLINE] = true
       IRB.conf[:SAVE_HISTORY] = 1000
       IRB.conf[:HISTORY_FILE] = Aruba.config.console_history_file


### PR DESCRIPTION
## Summary

Prepare for upcoming Ruby 3.3

## Details

This pull request consists of the following changes:

- Test with Ruby 3.3.0-preview3 in CI. This tests that Aruba is ready for Ruby 3.3
- Use irb instead of pry in the interactive debugging scenario. This fixes an issue in the Cucumber scenario's. This issue occurs because our output streams are not reall TTYs. See #910 for details.
-  Stop requiring 'irb/ext/save-history' extension in Aruba console. This extension has been renamed and did not do what its old name said.
- Ensure irb uses a consistent prompt format in tests on all Ruby versions.

## Motivation and Context

Mainly, #910.

## How Has This Been Tested?

I ran the Cucumber scenario with the added gem in Ruby 3.3.0-preview3. I also tried just setting TERM=dumb as in https://github.com/rails/rails/pull/48369 but that didn't work.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
