### PR TITLE
Fix new RuboCop offense

### DIFF
--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -52,7 +52,7 @@ module Aruba
         add_option(name, block_given? ? yield(InConfigWrapper.new(known_options)) : default)
 
         Contract type => type
-        define_method("#{name}=") { |v| find_option(name).value = v }
+        define_method(:"#{name}=") { |v| find_option(name).value = v }
 
         # Add reader
         option_reader name, type: type

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -121,28 +121,28 @@ end
 
 ## the stderr should contain "hello"
 Then "(the ){channel} should contain {string}" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).to include_output_string expected
 end
 
 ## the stderr should not contain "hello"
 Then "(the ){channel} should not contain {string}" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).not_to include_output_string expected
 end
 
 ## the stderr should contain exactly "hello"
 Then "(the ){channel} should contain exactly {string}" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).to output_string_eq expected
 end
 
 ## the stderr should not contain exactly "hello"
 Then "(the ){channel} should not contain exactly {string}" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).not_to output_string_eq expected
 end
@@ -211,28 +211,28 @@ end
 
 ## the stderr should contain:
 Then "(the ){channel} should contain:" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).to include_output_string(expected)
 end
 
 ## the stderr should not contain:
 Then "(the ){channel} should not contain:" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).not_to include_output_string(expected)
 end
 
 ## the stderr should contain exactly:
 Then "(the ){channel} should contain exactly:" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).to output_string_eq(expected)
 end
 
 ## the stderr should not contain exactly:
 Then "(the ){channel} should not contain exactly:" do |channel, expected|
-  combined_output = send("all_#{channel}")
+  combined_output = send(:"all_#{channel}")
 
   expect(combined_output).not_to output_string_eq(expected)
 end

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -22,7 +22,7 @@ RSpec.shared_context "uses aruba API" do
       include Aruba::Api
 
       def set_tag(tag_name, value)
-        instance_variable_set "@#{tag_name}", value
+        instance_variable_set :"@#{tag_name}", value
       end
     end
 


### PR DESCRIPTION
## Summary

Fix new RuboCop offenses

## Details

The latest version of rubocop-performance introduces Performance/StringIdentifierArgument. This PR fixes resulting failures.

## Motivation and Context

Stop builds for other PRs from failing in CI.

## How Has This Been Tested?

I ran RuboCop.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
