### PR TITLE
Simplify scenario describing interactive debugging

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -30,9 +30,6 @@ Feature: Debug your command in cucumber-test-run
     """ruby
     #!/usr/bin/env ruby
 
-    $stderr.sync = true
-    $stdout.sync = true
-
     foo = 'hello'
 
     require 'pry'

--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -19,10 +19,6 @@ Feature: Debug your command in cucumber-test-run
     program. However, Aruba steps that access the input and output of your
     program will not work.
 
-    Please make sure, that there's a statement after the `binding.pry`-call.
-    Otherwise you might not get an interactive shell, because your program will
-    just exit.
-
     We are going to demonstrate this using `pry`, but any other interactive
     debugger for any other programming language should also work.
 
@@ -34,8 +30,6 @@ Feature: Debug your command in cucumber-test-run
 
     require 'pry'
     binding.pry
-
-    exit 0
     """
     And a file named "features/debug.feature" with:
     """cucumber

--- a/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/debug_your_command_in_aruba.feature
@@ -7,7 +7,6 @@ Feature: Debug your command in cucumber-test-run
     Given I use a fixture named "cli-app"
     And the default aruba exit timeout is 60 seconds
 
-  @unsupported-on-platform-java
   Scenario: You can use a debug repl in your cli program
 
     If you want to debug an error, which only occurs in one of your


### PR DESCRIPTION
## Summary

Clean up interactive debugging scenario. Also, allow it to run on JRuby.

## Details

- Remove stream configuration that is no longer needed
- Remove obsolete warning about binding.pry and related code
- Mark debugging scenario as supported on JRuby

## Motivation and Context

While debugging #910, I noticed some obsolete bits in the scenario that is failing with upcoming Ruby 3.3.

## How Has This Been Tested?

I ran the scenario again after applying the simplifications. I also checked that it passed on JRuby.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
