### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,11 +23,9 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "jruby-9.4", "3.3.0-preview3"]
+        ruby: ["3.1", "3.2", "jruby-9.4", "3.3"]
         appraisal: [cucumber_8, cucumber_9]
         include:
-          - ruby: "2.7"
-            appraisal: cucumber_8
           - ruby: "3.0"
             appraisal: cucumber_8
 
@@ -50,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     runs-on: macos-latest
 
@@ -70,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, "3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
 
     runs-on: windows-latest
 
@@ -95,7 +93,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Install license_finder
         run: gem install license_finder

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ require:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - 'bin/cucumber'
     - 'bin/rspec'

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-rspec", "~> 2.8"
   spec.add_development_dependency "simplecov", ">= 0.18.0", "< 0.23.0"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.files = File.readlines("Manifest.txt", chomp: true)
 

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Description"
   spec.homepage      = "http://example.com"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/fixtures/cli-app/lib/cli/app.rb
+++ b/fixtures/cli-app/lib/cli/app.rb
@@ -1,6 +1,6 @@
 require "cli/app/version"
 
-Dir.glob(File.expand_path("**/*.rb", __dir__)).sort.each { |f| require_relative f }
+Dir.glob(File.expand_path("**/*.rb", __dir__)).each { |f| require_relative f }
 
 module Cli
   module App

--- a/fixtures/cli-app/spec/spec_helper.rb
+++ b/fixtures/cli-app/spec/spec_helper.rb
@@ -4,5 +4,5 @@ require "cli/app"
 
 require_relative "support/aruba"
 
-Dir.glob(File.expand_path("support/**/*.rb", __dir__)).sort
+Dir.glob(File.expand_path("support/**/*.rb", __dir__))
    .each { |f| require_relative f }

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "Description"
   spec.homepage      = "http://example.com"
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/lib/aruba/platforms/unix_environment_variables.rb
+++ b/lib/aruba/platforms/unix_environment_variables.rb
@@ -156,10 +156,10 @@ module Aruba
       end
 
       # Pass on checks
-      def method_missing(name, *args, &block)
+      def method_missing(name, ...)
         super unless to_h.respond_to? name
 
-        to_h.send name, *args, &block
+        to_h.send(name, ...)
       end
 
       # Check for respond_to

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -100,7 +100,7 @@ module Aruba
       end
 
       def require_matching_files(pattern, base)
-        ::Dir.glob(::File.expand_path(pattern, base)).sort.each { |f| require_relative f }
+        ::Dir.glob(::File.expand_path(pattern, base)).each { |f| require_relative f }
       end
 
       # Create directory and subdirectories

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,5 +9,5 @@ unless RUBY_PLATFORM.include?("java")
 end
 
 # Loading support files
-Dir.glob(File.expand_path("support/*.rb", __dir__)).sort.each { |f| require_relative f }
-Dir.glob(File.expand_path("support/**/*.rb", __dir__)).sort.each { |f| require_relative f }
+Dir.glob(File.expand_path("support/*.rb", __dir__)).each { |f| require_relative f }
+Dir.glob(File.expand_path("support/**/*.rb", __dir__)).each { |f| require_relative f }


### PR DESCRIPTION
## Summary

Drop support for Ruby 2.7

## Details

- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
- Autocorrect Style/ArgumentsForwarding
- Autocorrect Lint/RedundantDirGlobSort

## Motivation and Context

Ruby 2.7 has been EOL for quite some time now

## How Has This Been Tested?

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
