### PR TITLE
Fix minitest setup code and make minitest support scenarios run at least one test

### DIFF
--- a/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
+++ b/features/01_getting_started_with_aruba/supported_testing_frameworks.feature
@@ -72,15 +72,15 @@ Feature: Supported Testing Frameworks
       include Aruba::Api
 
       def setup
-        aruba_setup
+        setup_aruba
       end
 
-      def getting_started_with_aruba
+      def test_getting_started_with_aruba
         file = 'file.txt'
         content = 'Hello World'
 
         write_file file, content
-        read(file).must_equal [content]
+        assert_equal [content], read(file)
       end
     end
     """

--- a/features/06_use_aruba_cli/initialize_project_with_aruba.feature
+++ b/features/06_use_aruba_cli/initialize_project_with_aruba.feature
@@ -68,7 +68,7 @@ Feature: Initialize project with aruba
     When I successfully run `ruby -Ilib:test test/use_aruba_with_minitest.rb`
     Then the output should contain:
     """
-    0 runs, 0 assertions, 0 failures, 0 errors, 0 skips
+    1 runs, 0 assertions, 0 failures, 0 errors, 1 skips
     """
 
   Scenario: Unknown Test Framework

--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -172,7 +172,11 @@ module Aruba
             include Aruba::Api
 
             def setup
-              aruba_setup
+              setup_aruba
+            end
+
+            def test_dummy
+              skip "Add some real tests here"
             end
           end
         EOS

--- a/lib/aruba/initializer.rb
+++ b/lib/aruba/initializer.rb
@@ -7,6 +7,7 @@ module Aruba
   #
   # Initialize project with aruba configuration files
   module Initializers
+    #
     # Common initializer
     #
     # @private
@@ -35,14 +36,9 @@ module Aruba
         send creator, file, content
       end
     end
-  end
-end
 
-# Aruba
-module Aruba
-  # Initializers
-  module Initializers
-    # Default Initializer
+    #
+    # Failing Initializer
     #
     # This handles invalid values for initializer.
     #
@@ -59,14 +55,8 @@ module Aruba
         end
       end
     end
-  end
-end
 
-# Aruba
-module Aruba
-  # Initializer
-  module Initializers
-    # Add aruba + rspec to project
+    # RSpec Initializer. Adds aruba + rspec to project
     #
     # @private
     class RSpecInitializer < Thor::Group
@@ -100,14 +90,9 @@ module Aruba
         EOS
       end
     end
-  end
-end
 
-# Aruba
-module Aruba
-  # Initializer
-  module Initializers
-    # Add aruba + aruba to project
+    #
+    # Cucumber Initializer. Adds Aruba + Cucumber to project
     #
     # @private
     class CucumberInitializer < Thor::Group
@@ -125,14 +110,9 @@ module Aruba
         EOS
       end
     end
-  end
-end
 
-# Aruba
-module Aruba
-  # Initializer
-  module Initializers
-    # Add aruba + minitest to project
+    #
+    # Minitest Initializer. Adds Aruba + Minitest to project
     #
     # @private
     class MiniTestInitializer < Thor::Group
@@ -183,10 +163,7 @@ module Aruba
       end
     end
   end
-end
 
-# Aruba
-module Aruba
   # The whole initializer
   #
   # This one uses the specific initializers to generate the needed files.


### PR DESCRIPTION
## Summary

Make minitest scenarios run at least one test so test summary is displayed.

## Details

This change fixes the name of the test method in the minitest scenario so minitest actually recognizes it as a test. It also updates the setup code which was outdated. This was never noticed because it was not run.

It also updates the minitest initializer so it generates a dummy test, and fixes the test setup that it generates.

## Motivation and Context

Due to how test success is checked, the failure to run at least one test was never noticed. A change in behavior in minitest exposed the problem by making nearly all CI jobs fail. See https://github.com/minitest/minitest/pull/986.

## How Has This Been Tested?

The failing scenarios now pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
