### PR TITLE
Remove superfluous method definitions from specs

### DIFF
--- a/spec/aruba/matchers/command/have_output_size_spec.rb
+++ b/spec/aruba/matchers/command/have_output_size_spec.rb
@@ -3,10 +3,6 @@ require "spec_helper"
 RSpec.describe "Output Matchers" do
   include_context "uses aruba API"
 
-  def expand_path(*args)
-    @aruba.expand_path(*args)
-  end
-
   describe "#to_have_output_size" do
     let(:obj) { "string" }
 

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -3,14 +3,6 @@ require "spec_helper"
 RSpec.describe "Command Matchers" do
   include_context "uses aruba API"
 
-  def expand_path(*args)
-    @aruba.expand_path(*args)
-  end
-
-  def announcer(*args)
-    @aruba.send(:announcer, *args)
-  end
-
   describe "#to_have_exit_status" do
     let(:cmd) { "true" }
 

--- a/spec/aruba/matchers/path_spec.rb
+++ b/spec/aruba/matchers/path_spec.rb
@@ -6,10 +6,6 @@ require "aruba/matchers/path"
 RSpec.describe "Path Matchers" do
   include_context "uses aruba API"
 
-  def expand_path(*args)
-    @aruba.expand_path(*args)
-  end
-
   describe "to_be_an_absolute_path" do
     let(:name) { @file_name }
     let(:path) { @aruba.expand_path(name) }


### PR DESCRIPTION
<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Removes some unused spec helper methods.

## Details

Specs contained helper methdos that were defined but never used. This change removes them.

## Motivation and Context

Originally part of #881, but since that change turned out to be a bit more complex than expected, I'm presenting it separately here.

## How Has This Been Tested?

I ran the specs.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
