### PR TITLE
Make #have_output_size work on a process

### DIFF
--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -116,7 +116,7 @@ When "I wait for output/stdout to contain {string}" do |expected|
 end
 
 Then "the output should be {int} bytes long" do |size|
-  expect(last_command_started.output).to have_output_size size.to_i
+  expect(last_command_started).to have_output_size size.to_i
 end
 
 ## the stderr should contain "hello"

--- a/lib/aruba/matchers/command/have_output_size.rb
+++ b/lib/aruba/matchers/command/have_output_size.rb
@@ -4,6 +4,8 @@
 #   @param [String,Aruba::Process:BasicProcess] output or process
 #     The content which should be checked, or the process whose output should be checked
 #
+#     Use of this matcher with a string is deprecated.
+#
 #   @return [Boolean] The result
 #
 #     false:
@@ -23,6 +25,9 @@
 RSpec::Matchers.define :have_output_size do |expected|
   match do |actual|
     if actual.respond_to? :size
+      Aruba.platform.deprecated \
+        "Application of the have_output_size matcher to a string is deprecated." \
+        " Apply the matcher directly to the process object instead"
       actual_size = actual.size
     elsif actual.respond_to? :output
       actual_size = actual.output.size

--- a/lib/aruba/matchers/command/have_output_size.rb
+++ b/lib/aruba/matchers/command/have_output_size.rb
@@ -1,8 +1,8 @@
 # @!method have_output_size(output)
 #   This matchers checks if output has size.
 #
-#   @param [String] output
-#     The content which should be checked
+#   @param [String,Aruba::Process:BasicProcess] output or process
+#     The content which should be checked, or the process whose output should be checked
 #
 #   @return [Boolean] The result
 #
@@ -16,12 +16,21 @@
 #     RSpec.describe do
 #       it { expect(file1).to have_output_size(256) }
 #     end
+#
+#     RSpec.describe do
+#       it { expect(last_command_started).to have_output_size(256) }
+#     end
 RSpec::Matchers.define :have_output_size do |expected|
   match do |actual|
-    raise "Expected #{actual} to respond to #size" unless actual.respond_to? :size
+    if actual.respond_to? :size
+      actual_size = actual.size
+    elsif actual.respond_to? :output
+      actual_size = actual.output.size
+    else
+      raise "Expected #{actual} to respond to #size or #output"
+    end
 
-    @actual = actual.size
-    values_match? expected, @actual
+    values_match? expected, actual_size
   end
 
   description { "output has size #{description_of expected}" }

--- a/spec/aruba/matchers/command/have_output_size_spec.rb
+++ b/spec/aruba/matchers/command/have_output_size_spec.rb
@@ -13,5 +13,20 @@ RSpec.describe "Output Matchers" do
         expect(obj).not_to have_output_size 5
       end
     end
+
+    context "when actual is a command" do
+      let(:cmd) { "echo #{output}" }
+      let(:output) { "hello world" }
+
+      before { run_command(cmd) }
+
+      it "matches directly on the command itself" do
+        expect(last_command_started).to have_output_size "#{output}\n".length
+      end
+
+      it "does not match if output size is different" do
+        expect(last_command_started).not_to have_output_size "#{output}\n".length + 1
+      end
+    end
   end
 end

--- a/spec/aruba/matchers/command/have_output_size_spec.rb
+++ b/spec/aruba/matchers/command/have_output_size_spec.rb
@@ -1,21 +1,17 @@
 require "spec_helper"
 
 RSpec.describe "Output Matchers" do
-  include_context "uses aruba API"
-
   describe "#to_have_output_size" do
-    let(:obj) { "string" }
-
-    context "when has size" do
-      context "when is string" do
-        it { expect(obj).to have_output_size 6 }
-      end
-    end
-
-    context "when does not have size" do
+    context "when actual is a string" do
       let(:obj) { "string" }
 
-      it { expect(obj).not_to have_output_size(-1) }
+      it "matches when the string is the given size" do
+        expect(obj).to have_output_size 6
+      end
+
+      it "does not match when the string does not have the given size" do
+        expect(obj).not_to have_output_size 5
+      end
     end
   end
 end

--- a/spec/aruba/matchers/command/have_output_size_spec.rb
+++ b/spec/aruba/matchers/command/have_output_size_spec.rb
@@ -5,12 +5,23 @@ RSpec.describe "Output Matchers" do
     context "when actual is a string" do
       let(:obj) { "string" }
 
+      before do
+        allow(Aruba.platform).to receive(:deprecated)
+      end
+
       it "matches when the string is the given size" do
         expect(obj).to have_output_size 6
       end
 
       it "does not match when the string does not have the given size" do
         expect(obj).not_to have_output_size 5
+      end
+
+      it "emits a deprecation warning" do
+        aggregate_failures do
+          expect(obj).to have_output_size 6
+          expect(Aruba.platform).to have_received(:deprecated)
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Make `#have_output_size` matcher work with process objects, and deprecate its use with strings.

## Details

- Simplify existing specs for `#have_output_size matcher`
- Make `#have_output_size` matcher work with process objects
- Deprecate use of `#have_output_size1 matcher with a string actual
- Use `#have_output_size` matcher with process object in supplied step

## Motivation and Context

Fixes #484.

## How Has This Been Tested?

I ran the relevant specs and cukes.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- [x] I've added tests for my code
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
