### PR TITLE
Unlink Tempfiles after use in SpawnProcess

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,7 +17,7 @@ Metrics/BlockLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 145
+  Max: 146
 
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/CyclomaticComplexity:
@@ -101,8 +101,6 @@ RSpec/InstanceVariable:
     - 'spec/aruba/api/filesystem_spec.rb'
     - 'spec/aruba/api_spec.rb'
     - 'spec/aruba/event_bus_spec.rb'
-    - 'spec/aruba/matchers/command/have_output_size_spec.rb'
-    - 'spec/aruba/matchers/command_spec.rb'
     - 'spec/aruba/matchers/directory_spec.rb'
     - 'spec/aruba/matchers/file_spec.rb'
     - 'spec/aruba/matchers/path_spec.rb'

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -360,6 +360,7 @@ module Aruba
         file.rewind
         data = file.read
         file.close
+        file.unlink
 
         data.force_encoding("UTF-8")
       end


### PR DESCRIPTION
## Summary

Explictly call `#unlink` on Tempfiles used in SpawnProcess, instead of waiting for the finalizer.

## Details

Adds a call to `#unlink` right after reading the Tempfile and storing the contents in a variable.

## Motivation and Context

On Windows, the finalizer for Tempfile will raise an error if Errno::ENOACCES is raised when removing the file. However, if this happens when #unlink is called, the error is caught.

This change calls `#unlink` on the Tempfiles that are used to store the output of spawned processes. This means the finalizer will not need to unlink the file, so any Errno::ENOACCES errors during unlinking will be caught.

The raised errors did not make any specs fail, but they did appear in the rspec output.

## How Has This Been Tested?

I ran the specs. In CI, we will see if the backtraces are gone.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
