### PR TITLE
Improve clarity of environment manipulation

### DIFF
--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -221,7 +221,7 @@ module Aruba
       def with_environment(env = {}, &block)
         aruba.environment.nest do |nested_env|
           nested_env.update(env)
-          Aruba.platform.with_environment nested_env.to_h, &block
+          Aruba.platform.with_replaced_environment nested_env.to_h, &block
         end
       end
     end

--- a/lib/aruba/platforms/local_environment.rb
+++ b/lib/aruba/platforms/local_environment.rb
@@ -8,6 +8,12 @@ module Aruba
     #
     # Wraps logic to make enviroment local and restorable
     class LocalEnvironment
+      def initialize(platform)
+        @platform = platform
+      end
+
+      attr_reader :platform
+
       # Run in environment
       #
       # @param [Hash] env
@@ -16,7 +22,7 @@ module Aruba
       # @yield
       #   The block of code which should with local ENV
       def call(env)
-        old_env = Aruba.platform.environment_variables.hash_from_env
+        old_env = platform.environment_variables.hash_from_env
 
         ENV.clear
         ENV.update env

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -77,8 +77,8 @@ module Aruba
         ArubaFixedSizeFileCreator.new.call(*args)
       end
 
-      def with_environment(env = {}, &block)
-        LocalEnvironment.new.call(env, &block)
+      def with_replaced_environment(env = {}, &block)
+        LocalEnvironment.new(self).call(env, &block)
       end
 
       def default_shell
@@ -128,7 +128,7 @@ module Aruba
       def chdir(dir_name, &block)
         dir_name = ::File.expand_path(dir_name.to_s)
 
-        with_environment "OLDPWD" => getwd, "PWD" => dir_name do
+        with_replaced_environment "OLDPWD" => getwd, "PWD" => dir_name do
           ::Dir.chdir(dir_name, &block)
         end
       end

--- a/lib/aruba/processes/debug_process.rb
+++ b/lib/aruba/processes/debug_process.rb
@@ -26,7 +26,7 @@ module Aruba
       def start
         @started = true
         Dir.chdir @working_directory do
-          Aruba.platform.with_environment(environment) do
+          Aruba.platform.with_replaced_environment(environment) do
             @exit_status = system(command, *arguments) ? 0 : 1
           end
         end

--- a/lib/aruba/processes/in_process.rb
+++ b/lib/aruba/processes/in_process.rb
@@ -70,7 +70,8 @@ module Aruba
         Dir.chdir @working_directory do
           before_run
 
-          Aruba.platform.with_environment environment.merge("PWD" => @working_directory) do
+          new_env = environment.merge("PWD" => @working_directory)
+          Aruba.platform.with_replaced_environment new_env do
             main_class.new(@argv, @stdin, @stdout, @stderr, @kernel).execute!
           end
 


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Cleans up code related to environment manipulation.

## Details

This does two things:

- It avoids having two methods `#with_environment` that, apart from operating at a different level, also use their arguments differently: one takes changes to the environment as an argument, the other takes a full replacement environment.

- It decouples LocalEnvironment from the global platform singleton. This is neater because it makes the dependency go only one way.

## Motivation and Context

I just spent quite some time looking at the wrong `#with_environment` and wondering how any environment variables could be left inside the block.

## How Has This Been Tested?

CI will test it.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
