### PR TITLE
Move UnixPlatform#simple_table into Announcer

### DIFF
--- a/lib/aruba/platforms/announcer.rb
+++ b/lib/aruba/platforms/announcer.rb
@@ -2,6 +2,7 @@
 
 require "shellwords"
 require "aruba/colorizer"
+require "aruba/platforms/simple_table"
 
 Aruba::Colorizer.coloring = false if !$stdout.tty? && !ENV.key?("AUTOTEST")
 
@@ -82,6 +83,10 @@ module Aruba
 
       private
 
+      def simple_table(hash, opts = {})
+        SimpleTable.new(hash, opts).to_s
+      end
+
       def after_init
         output_format :changed_configuration, proc { |n, v| format("# %s = %s", n, v) }
         output_format :changed_environment,
@@ -93,7 +98,7 @@ module Aruba
         output_format :full_environment,
                       proc { |h|
                         format("<<-ENVIRONMENT\n%s\nENVIRONMENT",
-                               Aruba.platform.simple_table(h))
+                               simple_table(h))
                       }
         output_format :modified_environment,
                       proc { |n, v| format("$ export %s=%s", n, Shellwords.escape(v)) }
@@ -109,7 +114,7 @@ module Aruba
         output_format :command_filesystem_status,
                       proc { |status|
                         format("<<-COMMAND FILESYSTEM STATUS\n%s\nCOMMAND FILESYSTEM STATUS",
-                               Aruba.platform.simple_table(status.to_h, sort: false))
+                               simple_table(status.to_h, sort: false))
                       }
       end
 

--- a/lib/aruba/platforms/simple_table.rb
+++ b/lib/aruba/platforms/simple_table.rb
@@ -6,21 +6,13 @@ module Aruba
   module Platforms
     # Generate simple table
     class SimpleTable
-      private
-
-      attr_reader :hash, :opts
-
-      public
-
       # Create
       #
       # @param [Hash] hash
       #   Input
-      def initialize(hash, opts)
+      def initialize(hash, sort: true)
         @hash = hash
-        @opts = {
-          sort: true
-        }.merge opts
+        @sort = sort
       end
 
       # Generate table
@@ -37,12 +29,16 @@ module Aruba
           format("# %-*s => %s", name_size, k, v)
         end
 
-        if opts[:sort] == true
+        if sort
           rows.sort.join("\n")
         else
           rows.join("\n")
         end
       end
+
+      private
+
+      attr_reader :hash, :sort
     end
   end
 end

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -8,7 +8,6 @@ require "aruba/aruba_logger"
 require "aruba/aruba_path"
 require "aruba/command_monitor"
 
-require "aruba/platforms/simple_table"
 require "aruba/platforms/unix_command_string"
 require "aruba/platforms/unix_which"
 require "aruba/platforms/determine_file_size"
@@ -219,11 +218,6 @@ module Aruba
       # Write to file
       def write_file(path, content)
         File.write(path, content)
-      end
-
-      # Transform hash to a string table which can be output on stderr/stdout
-      def simple_table(hash, opts = {})
-        SimpleTable.new(hash, opts).to_s
       end
 
       # Resolve path for command using the PATH-environment variable

--- a/spec/aruba/platforms/simple_table_spec.rb
+++ b/spec/aruba/platforms/simple_table_spec.rb
@@ -3,35 +3,48 @@
 require "spec_helper"
 require "aruba/platform"
 
-RSpec.describe ".simple_table" do
-  context "when valid hash" do
-    let(:hash) do
-      {
-        key1: "value",
-        key2: "value"
+RSpec.describe Aruba::Platforms::SimpleTable do
+  describe "#to_s" do
+    it "renders a sorted table of the provided hash" do
+      hash = {
+        key2: "value",
+        key1: "value"
       }
+
+      expect(described_class.new(hash).to_s).to eq <<~TABLE.chomp
+        # key1 => value
+        # key2 => value
+      TABLE
     end
-    let(:rows) { ["# key1 => value", "# key2 => value"] }
 
-    it { expect(Aruba.platform.simple_table(hash).to_s).to eq rows.join("\n") }
-  end
+    it "renders an unsorted table provided hash unsorted if requested" do
+      hash = {
+        key2: "value",
+        key1: "value"
+      }
 
-  context "when valid hash with unequal key lengths" do
-    let(:hash) do
-      {
+      expect(described_class.new(hash, sort: false).to_s).to eq <<~TABLE.chomp
+        # key2 => value
+        # key1 => value
+      TABLE
+    end
+
+    it "renders an empty string if the provided hash is empty" do
+      hash = {}
+
+      expect(described_class.new(hash).to_s).to eq ""
+    end
+
+    it "aligns values when key lengths are unequal" do
+      hash = {
         key1: "value",
         long_key2: "value"
       }
+
+      expect(described_class.new(hash).to_s).to eq <<~TABLE.chomp
+        # key1      => value
+        # long_key2 => value
+      TABLE
     end
-    let(:rows) { ["# key1      => value", "# long_key2 => value"] }
-
-    it { expect(Aruba.platform.simple_table(hash).to_s).to eq rows.join("\n") }
-  end
-
-  context "when empty hash" do
-    let(:hash) { {} }
-    let(:rows) { [] }
-
-    it { expect(Aruba.platform.simple_table(hash).to_s).to eq rows.join("\n") }
   end
 end


### PR DESCRIPTION
## Summary

Move `UnixPlatform#simple_table` to `Announcer`.

## Details

The `#simple_table` method is only used inside `Announcer` and is not platform-dependent. This changes moves that method to `Announcer` and makes it private. Specs for `#simple_table` are updated to test `SimpleTable` directly instead.

The implementation of `SimpleTable` is adjusted to only take one option.

## Motivation and Context

This refactoring was part of a larger branch but it's useful to merge this already.

## How Has This Been Tested?

I ran the specs. CI will run the cukes.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
