### PR TITLE
Update rubocop-rspec to version 3.0

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 1.62"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.21"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.28"
+  spec.add_development_dependency "rubocop-rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", ">= 0.18.0", "< 0.23.0"
 
   spec.required_ruby_version = ">= 3.0.0"


### PR DESCRIPTION
## Summary

Update rubocop-rspec to version 3.0

## Motivation and Context

Needs updating and Renovate doesn't seem to be doing it for us :disappointed:

## How Has This Been Tested?

I ran `bundle exec rubocop`

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
