### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -23,11 +23,11 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/cucumber/aruba"
   }
 
-  spec.add_runtime_dependency "bundler", [">= 1.17", "< 3.0"]
-  spec.add_runtime_dependency "contracts", [">= 0.16.0", "< 0.18.0"]
-  spec.add_runtime_dependency "cucumber", ">= 8.0", "< 10.0"
-  spec.add_runtime_dependency "rspec-expectations", "~> 3.4"
-  spec.add_runtime_dependency "thor", "~> 1.0"
+  spec.add_dependency "bundler", [">= 1.17", "< 3.0"]
+  spec.add_dependency "contracts", [">= 0.16.0", "< 0.18.0"]
+  spec.add_dependency "cucumber", ">= 8.0", "< 10.0"
+  spec.add_dependency "rspec-expectations", "~> 3.4"
+  spec.add_dependency "thor", "~> 1.0"
 
   spec.add_development_dependency "appraisal", "~> 2.4"
   spec.add_development_dependency "json", "~> 2.1"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
