### PR TITLE
Introduce Cucumber parameter type 'command'

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/run_commands_which_require_a_shell.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/run_commands_which_require_a_shell.feature
@@ -12,7 +12,6 @@ Feature: Running shell commands
     Given I use a fixture named "cli-app"
 
   @requires-ruby
-  @requires-python
   Scenario: Creating and running scripts
     Given a file named "features/shell.feature" with:
     """
@@ -23,15 +22,6 @@ Feature: Running shell commands
         #!/usr/bin/env ruby
 
         puts "Hello"
-        \"\"\"
-        Then the output should contain exactly "Hello"
-
-      Scenario: Running python script
-        When I run the following script:
-        \"\"\"bash
-        #!/usr/bin/env python
-
-        print("Hello")
         \"\"\"
         Then the output should contain exactly "Hello"
     """

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -2,12 +2,6 @@
 
 require 'cucumber/platform'
 
-Before '@requires-python' do
-  next unless Aruba.platform.which('python').nil?
-
-  skip_this_scenario
-end
-
 Before '@requires-zsh' do
   next unless Aruba.platform.which('zsh').nil?
 

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -2,35 +2,46 @@
 
 require 'aruba/generators/script_file'
 
-When(/^I run `([^`]*)`$/) do |cmd|
+When 'I run {command}' do |cmd|
   cmd = sanitize_text(cmd)
   run_command_and_stop(cmd, fail_on_error: false)
 end
 
-## I successfully run `echo -n "Hello"`
-## I successfully run `sleep 29` for up to 30 seconds
-When(/^I successfully run `(.*?)`(?: for up to ([\d.]+) seconds)?$/) do |cmd, secs|
+When 'I successfully run {command}' do |cmd|
   cmd = sanitize_text(cmd)
-  run_command_and_stop(cmd, fail_on_error: true, exit_timeout: secs && secs.to_f)
+  run_command_and_stop(cmd, fail_on_error: true)
 end
 
-When(/^I run the following (?:commands|script)(?: (?:with|in) `([^`]+)`)?:$/) \
-  do |shell, commands|
+When 'I successfully run {command} for up to {float} seconds' do |cmd, secs|
+  cmd = sanitize_text(cmd)
+  run_command_and_stop(cmd, fail_on_error: true, exit_timeout: secs.to_f)
+end
+
+When 'I run the following commands:/script:' do |commands|
   full_path = expand_path('bin/myscript')
 
   Aruba.platform.mkdir(expand_path('bin'))
-  shell ||= Aruba.platform.default_shell
+  shell = Aruba.platform.default_shell
 
   Aruba::ScriptFile.new(interpreter: shell, content: commands, path: full_path).call
   run_command_and_stop(Shellwords.escape(full_path), fail_on_error: false)
 end
 
-When(/^I run `([^`]*)` interactively$/) do |cmd|
+When 'I run the following commands/script with/in {command}:' do |shell, commands|
+  full_path = expand_path('bin/myscript')
+
+  Aruba.platform.mkdir(expand_path('bin'))
+
+  Aruba::ScriptFile.new(interpreter: shell, content: commands, path: full_path).call
+  run_command_and_stop(Shellwords.escape(full_path), fail_on_error: false)
+end
+
+When 'I run {command} interactively' do |cmd|
   run_command(sanitize_text(cmd))
 end
 
 # Merge interactive and background after refactoring with event queue
-When(/^I run `([^`]*)` in background$/) do |cmd|
+When 'I run {command} in background' do |cmd|
   run_command(sanitize_text(cmd))
 end
 

--- a/lib/aruba/cucumber/parameter_types.rb
+++ b/lib/aruba/cucumber/parameter_types.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 ParameterType(name: 'channel', regexp: 'output|stderr|stdout', transformer: ->(name) { name })
+ParameterType(name: 'command', regexp: '`([^`]*)`', transformer: ->(name) { name })


### PR DESCRIPTION
## Summary

Introduce Cucumber parameter type 'command' and use it

## Details

This introduces a new Cucumber parameter type 'command', matching a string between backticks. It then uses this new parameter types to replace the old regular expression based step definitions. This allows more steps to use the Cucumber Expression syntax.

It also removes the need for python to be installed on of the scenarios that uses these step definitions, to ensure they're properly tested.

## Motivation and Context

While working on #894, I noticed that the steps matching output from a particular command could not match against a command including quote characters. This change will make it easier to add an extra step definition to support that case. **Update:** It turns out matching is possible by using `\`. The present change is still an improvement, however.

## How Has This Been Tested?

I ran the relevant scenarios with the updated step definitions.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
