### PR TITLE
Improve two step failure messages

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -327,6 +327,38 @@ Feature: All output of commands which were executed
     When I run `cucumber`
     Then the features should all pass
 
+  Scenario: Match passing exit status but fail to match exact output
+    Given an executable named "bin/aruba-test-cli" with:
+    """bash
+    #!/usr/bin/env bash
+
+    echo -ne "hello\nworld"
+    exit 0
+    """
+    And a file named "features/output.feature" with:
+    """cucumber
+    Feature: Run command
+      Scenario: Run command
+        When I run `aruba-test-cli`
+        Then it should pass with exactly:
+        \"\"\"
+        hello
+        worl
+        \"\"\"
+    """
+    When I run `cucumber`
+    Then the features should not pass with:
+    """
+          expected "hello
+    world" to output string is eq: "hello
+    worl"
+          Diff:
+          @@ -1,3 +1,3 @@
+           hello
+          -worl
+          +world
+    """
+
   Scenario: Match failing exit status and partial output
     Given an executable named "bin/aruba-test-cli" with:
     """bash

--- a/features/03_testing_frameworks/cucumber/steps/command/check_stderr_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_stderr_of_command.feature
@@ -66,3 +66,23 @@ Feature: STDERR of commands which were executed
     """
     When I run `cucumber`
     Then the features should all pass
+
+  Scenario: Failure message when checking that stderr from all processes is empty
+    Given a file named "features/output.feature" with:
+    """
+    Feature: Run command
+      Scenario: Run command
+        When I run `bash -c 'printf "hello\nworld!\n" >&2'`
+        And I run `printf "hola"`
+        And the stderr should not contain anything
+    """
+    When I run `cucumber`
+    Then the features should not pass with:
+    """
+          expected "hello
+    world!" to output string is eq: ""
+          Diff:
+          @@ -1,2 +1,4 @@
+          +hello
+          +world!
+    """

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -450,14 +450,10 @@ Then(/^it should (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expect
   expect(last_command_stopped).to have_output an_output_string_matching(expected)
 end
 
-Then(/^(?:the )?(output|stderr|stdout) should not contain anything$/) do |channel|
-  matcher = case channel
-            when 'output'; then :have_output
-            when 'stderr'; then :have_output_on_stderr
-            when 'stdout'; then :have_output_on_stdout
-            end
+Then '(the ){channel} should not contain anything' do |channel|
+  combined_output = send(:"all_#{channel}")
 
-  expect(all_commands).to include send(matcher, be_nil.or(be_empty))
+  expect(combined_output).to output_string_eq ''
 end
 
 Then(/^(?:the )?(output|stdout|stderr) should( not)? contain all of these lines:$/) \

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -423,7 +423,7 @@ Then(/^it should (pass|fail) with exactly:$/) do |pass_fail, expected|
     expect(last_command_stopped).not_to be_successfully_executed
   end
 
-  expect(last_command_stopped).to have_output an_output_string_being_eq(expected)
+  expect(last_command_stopped.output).to output_string_eq(expected)
 end
 
 Then(/^it should not (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|


### PR DESCRIPTION
## Summary

Improve step failure messages for two provided cucumber steps. Also, fix logic of one of the steps so it does what the wording says it does.

## Details

- Fix logic of cucumber step '<channel> should not contain anything', requiring all commands to have no output on the channel, not just one.
- Improve the failure message of the same step so that it shows the actual output.
- Fix cucumber step 'it should pass/fail with exactly:' so that the failure message of the output comparison shows the correct diff.

## Motivation and Context

This fixes #942.

## How Has This Been Tested?

I added cucumber scenarios testing the failure case for both steps, and after implementing the fix I ran the whole test suite to verify that I didn't break anything.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist:

- I've added tests for my code
