### PR TITLE
Add Ruby 3.4 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - ruby: "3.0"
             appraisal: cucumber_8
+          - ruby: "3.4"
+            appraisal: cucumber_9
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.appraisal }}.gemfile
@@ -52,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
 
     runs-on: macos-latest
 
@@ -72,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
 
     runs-on: windows-latest
 


### PR DESCRIPTION
## Summary

Add Ruby 3.4 to the test matrix

## Details

Adds 3.4 to the list of versions of Ruby to be used for testing with GitHub Actions. This version of Ruby is only combined with Cucumber 9, since only Cucumber 9.2.1 (and up) will work with Ruby 3.4. 

## Motivation and Context

Ruby 3.4 is out. We should verify that Aruba works with it.

## How Has This Been Tested?

I ran the test suite with 3.4 locally. With the release of Cucumber 9.4.1, the suite passes.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
