### PR TITLE
Update expected diff output to match changes in diff-lcs

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'thor', '~> 1.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.4'
+  spec.add_development_dependency 'diff-lcs', '~> 1.6'
   spec.add_development_dependency 'json', '~> 2.1'
   spec.add_development_dependency 'kramdown', '~> 2.1'
   spec.add_development_dependency 'minitest', '~> 5.10'

--- a/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_output_of_command.feature
@@ -353,7 +353,7 @@ Feature: All output of commands which were executed
     world" to output string is eq: "hello
     worl"
           Diff:
-          @@ -1,3 +1,3 @@
+          @@ -1,2 +1,2 @@
            hello
           -worl
           +world

--- a/features/03_testing_frameworks/cucumber/steps/command/check_stderr_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/check_stderr_of_command.feature
@@ -82,7 +82,7 @@ Feature: STDERR of commands which were executed
           expected "hello
     world!" to output string is eq: ""
           Diff:
-          @@ -1,2 +1,4 @@
+          @@ -0,0 +1,2 @@
           +hello
           +world!
     """


### PR DESCRIPTION
## Summary

Fix the build by the bumping diff-lcs dependency and updating expected output.

## Details

Version 1.6.0 of diff-lcs included a bug fix that corrects the hunk ranges it outputs. This change bumps the minimum version of diff-lcs to 1.6.0 so this change is sure to be included, and updates the expectations in the cucumber scenarios that depend on exact diff-lcs output.

## Motivation and Context

Builds were failing.

## How Has This Been Tested?

I ran the previously failing scenarios.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
