### PR TITLE
Restore lowest allowed rspec and rspec-expectations versions

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bundler', ['>= 1.17', '< 3.0']
   spec.add_dependency 'contracts', ['>= 0.16.0', '< 0.18.0']
   spec.add_dependency 'cucumber', '>= 8.0', '< 11.0'
-  spec.add_dependency 'rspec-expectations', '> 3.4', '< 5.0'
+  spec.add_dependency 'rspec-expectations', '>= 3.4', '< 5.0'
   spec.add_dependency 'thor', '~> 1.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.4'
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.10'
   spec.add_development_dependency 'rake', ['>= 12.0', '< 14.0']
   spec.add_development_dependency 'rake-manifest', '~> 0.2.0'
-  spec.add_development_dependency 'rspec', '> 3.11', '< 5.0'
+  spec.add_development_dependency 'rspec', '>= 3.11', '< 5.0'
   spec.add_development_dependency 'rubocop', '~> 1.80'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.26'


### PR DESCRIPTION
In https://github.com/cucumber/aruba/pull/956, the upper bound of these dependencies was relaxed. However, the lower bound was made exclusive. This change restores the lower bound.
