### PR TITLE
Make aruba console work on Ruby 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
         include:
           - ruby: "3.0"
             appraisal: cucumber_8
+          - ruby: "4.0.0-preview3"
+            appraisal: cucumber_10
         exclude:
           - ruby: "3.4"
             appraisal: cucumber_8

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bundler', '>= 1.17'
   spec.add_dependency 'contracts', ['>= 0.16.0', '< 0.18.0']
   spec.add_dependency 'cucumber', '>= 8.0', '< 11.0'
+  spec.add_dependency 'irb', '~> 1.16'
   spec.add_dependency 'rspec-expectations', '>= 3.4', '< 5.0'
   spec.add_dependency 'thor', '~> 1.0'
 


### PR DESCRIPTION

<!-- These sections are meant as guidance for you. If something doesn't fit, you can just skip it. -->

## Summary

Add explict irb dependency.

## Details

In Ruby 4.0, irb is no longer part of Ruby's default gems, so it must be added as an explicit dependency. This pull request adds the dependency, and also adds Ruby 4.0's latest preview release to the CI matrix.

## Motivation and Context

Ruby 4.0 is near!

## How Has This Been Tested?

I ran the test suite on Ruby 4.0.0-preview3.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
