### PR TITLE
Remove needless mangling of message from indenting helper

### DIFF
--- a/lib/aruba/matchers/base/message_indenter.rb
+++ b/lib/aruba/matchers/base/message_indenter.rb
@@ -10,7 +10,6 @@ module Aruba
         module_function
 
         def indent_multiline_message(message)
-          message = message.sub(/\n+\z/, '')
           message.lines.map do |line|
             /\S/.match?(line) ? "   #{line}" : line
           end.join


### PR DESCRIPTION
## Summary

Removes logic to remove trailing empty lines from message before indenting it to display.

## Motivation and Context

Why remove extra lines that may be important for debugging?

## How Has This Been Tested?

I ran the test suite.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
