### PR TITLE
Use File.read instead of Kernel.open

### DIFF
--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -209,7 +209,7 @@ module Aruba
 
         wait_for_io opts.fetch(:wait_for_io, io_wait_timeout) do
           @process.stdout.flush
-          open(@stdout_file.path).read
+          File.read(@stdout_file.path)
         end
       end
 
@@ -228,7 +228,7 @@ module Aruba
 
         wait_for_io opts.fetch(:wait_for_io, io_wait_timeout) do
           @process.stderr.flush
-          open(@stderr_file.path).read
+          File.read(@stderr_file.path)
         end
       end
 


### PR DESCRIPTION
## Summary

Replaces use of `Kernel.open(...).read` with `File.read`.

## Motivation and Context

Kernel.open allows piping to a command so is not recommended if such functionality is not relevant. Additionally, it leaves the file open so may leak file descriptors.

## How Has This Been Tested?

I ran the test suite.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
