### PR TITLE
Add OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,9 @@
-<h1 align="center">
-  <img src="https://raw.githubusercontent.com/cucumber/cucumber-js/46a5a78107be27e99c6e044c69b6e8f885ce456c/docs/images/logo.svg" alt="Cucumber logo" width="75">
-  <br>
-  Aruba
-</h1>
-<p align="center">
-
-**Test command-line applications with Cucumber-Ruby, RSpec or Minitest**
-
-</p>
-
-<div align="center">
+# Aruba
 
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/main/LICENSE)
 [![Gem Version](https://badge.fury.io/rb/aruba.svg)](http://badge.fury.io/rb/aruba)
 [![Support](https://img.shields.io/badge/cucumber-support-orange.svg)](https://cucumber.io/support)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cucumber/aruba/badge)](https://scorecard.dev/viewer/?uri=github.com/cucumber/aruba)
-
-[![CI](https://github.com/cucumber/aruba/actions/workflows/test-ruby.yaml/badge.svg)](https://github.com/cucumber/aruba/actions/workflows/test-ruby.yaml)
-
-</div>
+[![CI](https://github.com/cucumber/aruba/actions/workflows/test.yml/badge.svg)](https://github.com/cucumber/aruba/actions/workflows/test.yml)
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
-# Aruba
+<h1 align="center">
+  <img src="https://raw.githubusercontent.com/cucumber/cucumber-js/46a5a78107be27e99c6e044c69b6e8f885ce456c/docs/images/logo.svg" alt="Cucumber logo" width="75">
+  <br>
+  Aruba
+</h1>
+<p align="center">
+
+**Test command-line applications with Cucumber-Ruby, RSpec or Minitest**
+
+</p>
+
+<div align="center">
 
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/main/LICENSE)
 [![Gem Version](https://badge.fury.io/rb/aruba.svg)](http://badge.fury.io/rb/aruba)
 [![Support](https://img.shields.io/badge/cucumber-support-orange.svg)](https://cucumber.io/support)
-[![CI](https://github.com/cucumber/aruba/actions/workflows/test.yml/badge.svg)](https://github.com/cucumber/aruba/actions/workflows/test.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cucumber/aruba/badge)](https://scorecard.dev/viewer/?uri=github.com/cucumber/aruba)
+
+[![CI](https://github.com/cucumber/aruba/actions/workflows/test-ruby.yaml/badge.svg)](https://github.com/cucumber/aruba/actions/workflows/test-ruby.yaml)
+
+</div>
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 [![MIT license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/cucumber/aruba/main/LICENSE)
 [![Gem Version](https://badge.fury.io/rb/aruba.svg)](http://badge.fury.io/rb/aruba)
 [![Support](https://img.shields.io/badge/cucumber-support-orange.svg)](https://cucumber.io/support)
-[![CI](https://github.com/cucumber/aruba/actions/workflows/test.yml/badge.svg)](https://github.com/cucumber/aruba/actions/workflows/test.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/cucumber/aruba/badge)](https://scorecard.dev/viewer/?uri=github.com/cucumber/aruba)
+
+[![CI](https://github.com/cucumber/aruba/actions/workflows/test-ruby.yaml/badge.svg)](https://github.com/cucumber/aruba/actions/workflows/test-ruby.yaml)
 
 ## Install
 


### PR DESCRIPTION
### 🤔 What's changed?

* Added OpenSSF Scorecard badge
* Spruced up the header a bit
* Because the GitHub actions badge has a different style I've put it on a separate line.

### ⚡️ What's your motivation? 

We improved the Cucumber orgs security stance a bit. The OpenSSF Scorecard provides a way to display that stance as a number. 

Contribute to: https://github.com/cucumber/common/issues/2312


### 🏷️ What kind of change is this?
- :book: Documentation (improvements without changing code)

### ♻️ Anything particular you want feedback on?

@mvz up to you if you want to display it. 

Overall we also get low scores for code-review and not requiring PR's for all changes. This primarily caused by using Renovate to automatically update our dependencies. Personally, I don't think the requirements the scorecard puts down to get good marks here are worth it though for a mostly unpaid opensource project. But if you want to make improvements here you are of-course free to do so.

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
