### PR TITLE
Bump minimum rubocop versions and fix new offenses

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -38,10 +38,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', ['>= 12.0', '< 14.0']
   spec.add_development_dependency 'rake-manifest', '~> 0.2.0'
   spec.add_development_dependency 'rspec', '>= 3.11', '< 5.0'
-  spec.add_development_dependency 'rubocop', '~> 1.80'
+  spec.add_development_dependency 'rubocop', '~> 1.87'
   spec.add_development_dependency 'rubocop-packaging', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.26'
-  spec.add_development_dependency 'rubocop-rspec', '~> 3.7'
+  spec.add_development_dependency 'rubocop-rspec', '~> 3.10'
   spec.add_development_dependency 'simplecov', '>= 0.18.0', '< 0.23.0'
 
   spec.required_ruby_version = '>= 3.0.0'

--- a/spec/aruba/api/filesystem_spec.rb
+++ b/spec/aruba/api/filesystem_spec.rb
@@ -521,8 +521,8 @@ RSpec.describe Aruba::Api::Filesystem do
       it 'is successful when the inner expectations match' do
         expect do
           @aruba.with_file_content name do |full_content|
-            expect(full_content).to     match(/foo/)
-            expect(full_content).not_to match(/zoo/)
+            expect(full_content).to     include('foo')
+            expect(full_content).not_to include('zoo')
           end
         end.not_to raise_error
       end
@@ -530,8 +530,8 @@ RSpec.describe Aruba::Api::Filesystem do
       it "raises ExpectationNotMetError when the inner expectations don't match" do
         expect do
           @aruba.with_file_content name do |full_content|
-            expect(full_content).to     match(/zoo/)
-            expect(full_content).not_to match(/foo/)
+            expect(full_content).to     include('zoo')
+            expect(full_content).not_to include('foo')
           end
         end.to raise_error RSpec::Expectations::ExpectationNotMetError
       end


### PR DESCRIPTION
## Summary

Bump minimum versions of RuboCop gems and autocorrect new offenses

## Details

- **Bump mininum rubocop dependency versions**
- **Autocorrect RSpec/MatchWithSimpleRegex offenses**

## Motivation and Context

New RuboCop offenses are causing PR builds to fail.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)
