### PR TITLE
Make bundle install succeed on JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ source 'https://rubygems.org'
 # Use dependencies from gemspec
 gemspec
 
+# Prevent attempts to install rbs on jruby
+# See https://github.com/ruby/rbs/issues/2067
+gem 'rdoc', '~> 7.2.0', platform: :jruby
 # Needed on Ruby 4.0, since win32ole is now a gem
 gem 'win32ole', platform: :windows
 

--- a/gemfiles/cucumber_10.gemfile
+++ b/gemfiles/cucumber_10.gemfile
@@ -4,6 +4,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rdoc', '~> 7.2.0', platform: :jruby
 gem 'win32ole', platform: :windows
 gem 'cucumber', '~> 10.0'
 

--- a/gemfiles/cucumber_11.gemfile
+++ b/gemfiles/cucumber_11.gemfile
@@ -4,6 +4,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rdoc', '~> 7.2.0', platform: :jruby
 gem 'win32ole', platform: :windows
 gem 'cucumber', '~> 11.0'
 

--- a/gemfiles/cucumber_8.gemfile
+++ b/gemfiles/cucumber_8.gemfile
@@ -4,6 +4,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rdoc', '~> 7.2.0', platform: :jruby
 gem 'win32ole', platform: :windows
 gem 'cucumber', '~> 8.0'
 

--- a/gemfiles/cucumber_9.gemfile
+++ b/gemfiles/cucumber_9.gemfile
@@ -4,6 +4,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rdoc', '~> 7.2.0', platform: :jruby
 gem 'win32ole', platform: :windows
 gem 'cucumber', ['~> 9.0', '>= 9.0.1']
 

--- a/gemfiles/rspec_4.gemfile
+++ b/gemfiles/rspec_4.gemfile
@@ -4,6 +4,7 @@
 
 source 'https://rubygems.org'
 
+gem 'rdoc', '~> 7.2.0', platform: :jruby
 gem 'win32ole', platform: :windows
 gem 'rspec', git: 'https://github.com/rspec/rspec', branch: '4-0-dev'
 gem 'rspec-core', git: 'https://github.com/rspec/rspec', branch: '4-0-dev',


### PR DESCRIPTION
## Summary

Restrict rdoc version on jruby to prevent bundle install failures

## Details

This change adds an explicit dependency on rdoc 7.2.0 just for the jruby platform.

## Motivation and Context

The irb dependency pulls in rdoc. With rdoc 8.0.0, a new dependency on rbs is introduced. However, rbs currently does not build on jruby. This is causing bundle install to fail, and hence build failures in CI.

By limiting the rdoc version to 7.2.x, we prevent attempts to install rbs there.

Note that users of Aruba on JRuby will have to add their own limitation of rdoc versions if necessary.

## How Has This Been Tested?

I ran `bundle install` on JRuby 10.0, first on `main`, then with this commit added.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
