### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/test-ruby.yaml
+++ b/.github/workflows/test-ruby.yaml
@@ -46,19 +46,10 @@ jobs:
         ruby: ["3.2", "3.3", "3.4", "jruby-10.0", "4.0"]
         appraisal: [cucumber_10, cucumber_11]
         include:
-          - ruby: "3.0"
+          - ruby: "3.2"
             appraisal: cucumber_8
-          - ruby: "3.0"
+          - ruby: "3.2"
             appraisal: cucumber_9
-
-          - ruby: "3.1"
-            appraisal: cucumber_9
-          - ruby: "jruby-9.4"
-            appraisal: cucumber_9
-          - ruby: "3.1"
-            appraisal: cucumber_10
-          - ruby: "jruby-9.4"
-            appraisal: cucumber_10
 
           - ruby: "4.0"
             appraisal: rspec_4
@@ -86,7 +77,7 @@ jobs:
       matrix:
         # This will automatically pick the latest supported version of Cucumber
         # for each Ruby version
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -109,7 +100,7 @@ jobs:
       matrix:
         # This will automatically pick the latest supported version of Cucumber
         # for each Ruby version
-        ruby: ["3.0", "3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
     runs-on: windows-latest
     steps:
       - name: git config autocrlf

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ plugins:
 AllCops:
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   Exclude:
     - 'bin/cucumber'
     - 'bin/rspec'
@@ -52,6 +52,10 @@ Metrics/BlockLength:
     - '**/*.gemspec'
     - 'spec/**/*'
 
+# Keep block names explict for now
+Naming/BlockForwarding:
+  EnforcedStyle: explicit
+
 # Stylistic preference for cucumber
 RSpec/MessageSpies:
   EnforcedStyle: receive
@@ -60,6 +64,10 @@ RSpec/MessageSpies:
 # TODO: Re-enable once https://github.com/rubocop/rubocop-rspec/issues/466 is resolved.
 RSpec/PredicateMatcher:
   Enabled: false
+
+# Keep forwarded argument names explict for now
+Style/ArgumentsForwarding:
+  UseAnonymousForwarding: false
 
 # This cop doesn't seem to add much for us.
 Style/FetchEnvVar:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ bump.
 
 ## Supported Ruby versions
 
-Aruba is supported on Ruby 3.0 and up, and tested against CRuby 3.0, 3.1, 3.2,
-3.3, 3.4 and 4.0, and JRuby 9.4 and 10.0.
+Aruba is supported on Ruby 3.2 and up, and tested against CRuby 3.2, 3.3, 3.4
+and 4.0, and JRuby 10.0.
 
 ## Supported Cucumber versions
 

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 3.10'
   spec.add_development_dependency 'simplecov', '>= 0.18.0', '< 0.23.0'
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
   spec.files = File.readlines('Manifest.txt', chomp: true)
 

--- a/fixtures/cli-app/cli-app.gemspec
+++ b/fixtures/cli-app/cli-app.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Description'
   spec.homepage      = 'http://example.com'
 
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.2'
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.

--- a/fixtures/empty-app/cli-app.gemspec
+++ b/fixtures/empty-app/cli-app.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Description'
   spec.homepage      = 'http://example.com'
 
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.2'
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.


### PR DESCRIPTION
## Summary

Bump minimum supported Ruby version to 3.2 and update supporting files accordingly.

## Details

Updates gemspec, rubocop configuration, and GitHub Actions, and fixes some rubocop issues.

## Motivation and Context

In preparation for Aruba 3.0, we should update the minimum supported Ruby version to match Cucumber.

## How Has This Been Tested?

The code didn't change much. CI should catch any issues.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
