### PR TITLE
Require a bundler version that supports with_unbundled_env

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/cucumber/aruba'
   }
 
-  spec.add_dependency 'bundler', '>= 1.17'
+  spec.add_dependency 'bundler', '>= 2.20.0'
   spec.add_dependency 'contracts', ['>= 0.16.0', '< 0.18.0']
   spec.add_dependency 'cucumber', '~> 11.0'
   spec.add_dependency 'marcel', '~> 1.0'

--- a/lib/aruba/api/bundler.rb
+++ b/lib/aruba/api/bundler.rb
@@ -23,11 +23,7 @@ module Aruba
       private
 
       def with_unbundled_env(&block)
-        if ::Bundler.respond_to?(:with_unbundled_env)
-          ::Bundler.with_unbundled_env(&block)
-        else
-          ::Bundler.with_clean_env(&block)
-        end
+        ::Bundler.with_unbundled_env(&block)
       end
     end
   end


### PR DESCRIPTION
## Summary

Require bundler 2.20, so we can simplify our bundler integration.

## Motivation and Context

`Bundler.with_unbundled_env` was introduced in version 2.20, which is old enough to allow requiring it as the minumum version.

## How Has This Been Tested?

CI

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
