### PR TITLE
Clean up Aruba::Runtime class

### DIFF
--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -39,7 +39,7 @@ module Aruba
     # @!attribute [r] event_bus
     #   Handle events (private)
     #
-    attr_accessor :config, :environment, :logger, :command_monitor, :announcer, :event_bus
+    attr_reader :config, :environment, :logger, :command_monitor, :announcer, :event_bus
 
     def initialize
       @event_bus       = EventBus.new(Aruba::Events.registry)

--- a/lib/aruba/runtime.rb
+++ b/lib/aruba/runtime.rb
@@ -41,21 +41,19 @@ module Aruba
     #
     attr_accessor :config, :environment, :logger, :command_monitor, :announcer, :event_bus
 
-    def initialize(opts = {})
+    def initialize
       @event_bus       = EventBus.new(Aruba::Events.registry)
-      @announcer       = opts.fetch(:announcer, Aruba.platform.announcer.new)
-      @config          = opts.fetch(:config,
-                                    ConfigWrapper.new(Aruba.config.make_copy, @event_bus))
-      @environment     = opts.fetch(:environment, Aruba.platform.environment_variables.new)
+      @announcer       = Aruba.platform.announcer.new
+      @config          = ConfigWrapper.new(Aruba.config.make_copy, @event_bus)
+      @environment     = Aruba.platform.environment_variables.new
       @current_directory = ArubaPath.new(@config.working_directory)
       @root_directory    = ArubaPath.new(@config.root_directory)
 
       @environment.update(@config.command_runtime_environment)
 
-      @command_monitor = opts.fetch(:command_monitor,
-                                    Aruba.platform.command_monitor.new(announcer: @announcer))
+      @command_monitor = Aruba.platform.command_monitor.new(announcer: @announcer)
 
-      @logger = opts.fetch(:logger, Aruba.platform.logger.new)
+      @logger = Aruba.platform.logger.new
       @logger.mode = @config.log_level
 
       @setup_done = false

--- a/spec/aruba/api_spec.rb
+++ b/spec/aruba/api_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Aruba::Api do
 
       context 'enabled' do
         before do
-          @aruba.aruba.announcer = instance_double Aruba::Platforms::Announcer
           allow(@aruba.aruba.announcer).to receive(:announce)
         end
 

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -22,10 +22,6 @@ RSpec.shared_context 'uses aruba API' do
   before do
     klass = Class.new do
       include Aruba::Api
-
-      def set_tag(tag_name, value)
-        instance_variable_set :"@#{tag_name}", value
-      end
     end
 
     @aruba = klass.new


### PR DESCRIPTION
## Summary

Clean up Aruba::Runtime class in preparation for further refactoring.

## Details

- **Remove options parameter from Runtime#initialize**
- **Make Runtime attributes read-only**
- **Remove unused spec helper method**

## Motivation and Context

Makes fixing #984 easier.

## How Has This Been Tested?

I ran the test suite.

## Types of changes

- Internal change in principle, but could break the Aruba setup for people doing something unexpected.

## Checklist:

- My change requires would require a change to the documentation if the options had been documented.
