### PR TITLE
Modernize argument handling

### DIFF
--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -131,27 +131,19 @@ module Aruba
       #
       # @param [String] cmd
       #   The command which should be executed
-      #
-      # @param [Hash] opts
-      #   Options
-      #
-      # @option opts [Numeric] exit_timeout
+      # @param [Numeric] exit_timeout
       #   If the timeout is reached the command will be killed
-      #
-      # @option opts [Numeric] io_wait_timeout
+      # @param [Numeric] io_wait_timeout
       #   Wait for IO to finish
-      #
-      # @option opts [Numeric] startup_wait_time
+      # @param [Numeric] startup_wait_time
       #   Wait for a command to start
-      #
-      # @option opts [String] stop_signal
+      # @param [String] stop_signal
       #   Use signal to stop command
-      #
       # @yield [SpawnProcess]
       #   Run block with process
       #
-      def run_command(cmd, opts = {})
-        command = prepare_command(cmd, opts)
+      def run_command(cmd, **)
+        command = prepare_command(cmd, **)
 
         unless command.interactive?
           raise NotImplementedError,
@@ -170,27 +162,19 @@ module Aruba
       #
       # @param [String] cmd
       #   The command to be executed
-      #
-      # @param [Hash] opts
-      #   Options for aruba
-      #
-      # @option opts [Boolean] :fail_on_error
+      # @param [Boolean] fail_on_error
       #   Should aruba fail on error?
-      #
-      # @option opts [Numeric] :exit_timeout
+      # @param [Numeric] exit_timeout
       #   Timeout for execution
-      #
-      # @option opts [Numeric] :io_wait_timeout
+      # @param [Numeric] io_wait_timeout
       #   Timeout for IO - STDERR, STDOUT
+      # @param [String] stop_signal
+      #   Name of signal to send to stop process. E.g. 'HUP'.
+      # @param [Numeric] startup_wait_time
+      #   Timeout for command start-up
       #
-      def run_command_and_stop(cmd, opts = {})
-        fail_on_error = if opts.key?(:fail_on_error)
-                          opts.delete(:fail_on_error) == true
-                        else
-                          true
-                        end
-
-        command = prepare_command(cmd, opts)
+      def run_command_and_stop(cmd, fail_on_error: true, **)
+        command = prepare_command(cmd, **)
         start_command(command)
         command.stop
 
@@ -223,12 +207,11 @@ module Aruba
 
       private
 
-      def prepare_command(cmd, opts)
-        exit_timeout      = opts[:exit_timeout] || aruba.config.exit_timeout
-        io_wait_timeout   = opts[:io_wait_timeout] || aruba.config.io_wait_timeout
-        stop_signal       = opts[:stop_signal] || aruba.config.stop_signal
-        startup_wait_time = opts[:startup_wait_time] || aruba.config.startup_wait_time
-
+      def prepare_command(cmd,
+                          exit_timeout: aruba.config.exit_timeout,
+                          io_wait_timeout: aruba.config.io_wait_timeout,
+                          stop_signal: aruba.config.stop_signal,
+                          startup_wait_time: aruba.config.startup_wait_time)
         @commands ||= []
         @commands << cmd
 

--- a/lib/aruba/api/filesystem.rb
+++ b/lib/aruba/api/filesystem.rb
@@ -150,20 +150,16 @@ module Aruba
 
       # Create an empty file
       #
-      # @param [String] file_name
-      #   The name of the file
-      def touch(*args)
-        args = args.flatten
-
-        options = if args.last.is_a? Hash
-                    args.pop
-                  else
-                    {}
-                  end
+      # @param [String, Array] list
+      #   The names of the files
+      # @param [Hash] options
+      #   Options to pass to FileUtils.touch
+      def touch(list, **options)
+        args = Array(list)
 
         args.each { |p| create_directory(File.dirname(p)) }
 
-        Aruba.platform.touch(args.map { |p| expand_path(p) }, options)
+        Aruba.platform.touch(args.map { |p| expand_path(p) }, **options)
 
         self
       end
@@ -178,11 +174,8 @@ module Aruba
       # @param [String] destination
       #   A file or directory name. If multiple sources are given the destination
       #   needs to be a directory
-      def copy(*args)
-        args = args.flatten
-        destination = args.pop
-        source = args
-
+      def copy(source, destination)
+        source = Array(source)
         source.each do |s|
           raise ArgumentError, %(The following source "#{s}" does not exist.) unless exist? s
         end
@@ -221,11 +214,8 @@ module Aruba
       # @param [String] destination
       #   A file or directory name. If multiple sources are given the destination
       #   needs to be a directory
-      def move(*args)
-        args = args.flatten
-        destination = args.pop
-        source = args
-
+      def move(source, destination)
+        source = Array(source)
         source.each do |s|
           if s.start_with? aruba.config.fixtures_path_prefix
             raise ArgumentError, "Using a fixture as source (#{source}) is not supported"
@@ -294,22 +284,14 @@ module Aruba
       #
       # @param [String] file_name
       #   Name of file to be modified. This file needs to be present to succeed
-      def chmod(*args)
-        args = args.flatten
-
-        options = if args.last.is_a? Hash
-                    args.pop
-                  else
-                    {}
-                  end
-
-        mode = args.shift
+      def chmod(mode, file_name)
         mode = mode.to_i(8) if mode.is_a? String
 
-        args.each { |path| raise "Expected #{path} to be present" unless exist?(path) }
-        paths = args.map { |path| expand_path(path) }
+        paths = [file_name]
+        paths.each { |path| raise "Expected #{path} to be present" unless exist?(path) }
+        paths = paths.map { |path| expand_path(path) }
 
-        Aruba.platform.chmod(mode, paths, options)
+        Aruba.platform.chmod(mode, paths)
 
         self
       end
@@ -362,19 +344,17 @@ module Aruba
       # Remove file or directory
       #
       # @param [Array, String] name
-      #   The name of the file / directory which should be removed
-      def remove(*args)
-        args = args.flatten
-
-        options = if args.last.is_a? Hash
-                    args.pop
-                  else
-                    {}
-                  end
+      #   The name of the file or directory which should be removed,
+      #   or a list of such names.
+      #
+      # @param [Hash] options
+      #   Options to pass to FileUtils.rm_r
+      def remove(name, **options)
+        args = Array(name)
 
         args = args.map { |path| expand_path(path) }
 
-        Aruba.platform.rm(args, options)
+        Aruba.platform.rm(args, **options)
       end
 
       # Read content of file and yield the content to block

--- a/lib/aruba/aruba_logger.rb
+++ b/lib/aruba/aruba_logger.rb
@@ -12,12 +12,9 @@ module Aruba
 
     # Create logger
     #
-    # @param [Hash] opts
-    #   Options
-    #
-    # @option opts [Symbol] :default_mode Log level
-    def initialize(opts = {})
-      @mode = opts.fetch(:default_mode, :info)
+    # @param [Symbol] default_mode Log level
+    def initialize(default_mode: :info)
+      @mode = default_mode
     end
 
     # @!method fatal(msg)

--- a/lib/aruba/basic_configuration.rb
+++ b/lib/aruba/basic_configuration.rb
@@ -19,13 +19,10 @@ module Aruba
 
       # Define an option reader
       #
-      # @param [Symbol] name
-      #   The name of the reader
-      #
-      # @option [Class, Module] type
+      # @param [Class, Module] type
       #   The type contract for the option
       #
-      # @option [Object] default
+      # @param [Object] default
       #   The default value
       def option_reader(name, type:, default: nil)
         raise ArgumentError, 'Either use block or default value' if block_given? && default
@@ -38,13 +35,10 @@ module Aruba
 
       # Define an option reader and writer
       #
-      # @param [Symbol] name
-      #   The name of the reader
-      #
-      # @option [Class, Module] type
+      # @param [Class, Module] type
       #   The type contract for the option
       #
-      # @option [Object] default
+      # @param [Object] default
       #   The default value
       #
       def option_accessor(name, type:, default: nil)

--- a/lib/aruba/basic_configuration/option.rb
+++ b/lib/aruba/basic_configuration/option.rb
@@ -13,13 +13,7 @@ module Aruba
       attr_reader :default_value
 
       # Create option
-      def initialize(opts = {})
-        name = opts[:name]
-        value = opts[:value]
-
-        raise ArgumentError, '"name" is required' unless opts.key? :name
-        raise ArgumentError, '"value" is required' unless opts.key? :value
-
+      def initialize(name:, value:)
         @name          = name
         @value         = value
         @default_value = value

--- a/lib/aruba/command.rb
+++ b/lib/aruba/command.rb
@@ -24,30 +24,29 @@ module Aruba
 
     public
 
-    def initialize(command, opts = {})
+    def initialize(command, exit_timeout:, io_wait_timeout:, working_directory:, environment:, # rubocop:disable Metrics/ParameterLists
+                   main_class:, stop_signal:, startup_wait_time:, event_bus:, mode: nil)
       launchers = []
       launchers << Processes::DebugProcess
       launchers << Processes::InProcess
       launchers << Processes::SpawnProcess
 
-      klass = launchers.find { |l| l.match? opts[:mode] }
+      klass = launchers.find { |l| l.match? mode }
 
       launcher = klass.new(
         command,
-        opts.fetch(:exit_timeout),
-        opts.fetch(:io_wait_timeout),
-        opts.fetch(:working_directory),
-        opts.fetch(:environment),
-        opts.fetch(:main_class),
-        opts.fetch(:stop_signal),
-        opts.fetch(:startup_wait_time)
+        exit_timeout,
+        io_wait_timeout,
+        working_directory,
+        environment,
+        main_class,
+        stop_signal,
+        startup_wait_time
       )
 
       super(launcher)
 
-      @event_bus = opts.fetch(:event_bus)
-    rescue KeyError => e
-      raise ArgumentError, e.message
+      @event_bus = event_bus
     end
 
     # Stop command

--- a/lib/aruba/command_monitor.rb
+++ b/lib/aruba/command_monitor.rb
@@ -44,14 +44,12 @@ module Aruba
       end
     end
 
-    def initialize(opts = {})
+    def initialize(announcer:)
       @registered_commands = []
-      @announcer = opts.fetch(:announcer)
+      @announcer = announcer
 
       @last_command_stopped = DefaultLastCommandStopped.new
       @last_command_started = DefaultLastCommandStarted.new
-    rescue KeyError => e
-      raise ArgumentError, e.message
     end
 
     # Set last command started

--- a/lib/aruba/generators/script_file.rb
+++ b/lib/aruba/generators/script_file.rb
@@ -10,15 +10,15 @@ module Aruba
 
     public
 
-    def initialize(opts = {})
-      @path        = opts[:path]
-      @content     = opts[:content]
-      @interpreter = opts[:interpreter]
+    def initialize(path: nil, content: nil, interpreter: nil)
+      @path        = path
+      @content     = content
+      @interpreter = interpreter
     end
 
     def call
       Aruba.platform.write_file(path, "#{header}#{content}")
-      Aruba.platform.chmod(0o755, path, {})
+      Aruba.platform.chmod(0o755, path)
     end
 
     private

--- a/lib/aruba/platforms/unix_platform.rb
+++ b/lib/aruba/platforms/unix_platform.rb
@@ -112,7 +112,7 @@ module Aruba
       end
 
       # Remove file, directory + sub-directories
-      def rm(paths, options = {})
+      def rm(paths, **options)
         paths = Array(paths).map { |p| ::File.expand_path(p) }
 
         FileUtils.rm_r(paths, **options)
@@ -133,7 +133,7 @@ module Aruba
       end
 
       # Touch file, directory
-      def touch(args, options)
+      def touch(args, **options)
         FileUtils.touch(args, **options)
       end
 
@@ -148,7 +148,7 @@ module Aruba
       end
 
       # Change mode of file/directory
-      def chmod(mode, args, options)
+      def chmod(mode, args, **options)
         FileUtils.chmod_R(mode, args, **options)
       end
 

--- a/lib/aruba/processes/basic_process.rb
+++ b/lib/aruba/processes/basic_process.rb
@@ -45,8 +45,8 @@ module Aruba
       end
 
       # Output stderr and stdout
-      def output(opts = {})
-        stdout(opts) + stderr(opts)
+      def output(**opts)
+        stdout(**opts) + stderr(**opts)
       end
 
       def write(*)

--- a/lib/aruba/processes/spawn_process.rb
+++ b/lib/aruba/processes/spawn_process.rb
@@ -197,18 +197,15 @@ module Aruba
 
       # Access to stdout of process
       #
-      # @param [Hash] opts
-      #   Options
-      #
-      # @option [Integer] wait_for_io
+      # @param [Integer] wait_for_io
       #   Wait for IO to be finished
       #
       # @return [String]
       #   The content of stdout
-      def stdout(opts = {})
+      def stdout(wait_for_io: io_wait_timeout)
         return @stdout_cache if stopped?
 
-        wait_for_io opts.fetch(:wait_for_io, io_wait_timeout) do
+        wait_for_io wait_for_io do
           @process.stdout.flush
           File.read(@stdout_file.path)
         end
@@ -216,18 +213,15 @@ module Aruba
 
       # Access to stderr of process
       #
-      # @param [Hash] opts
-      #   Options
-      #
-      # @option [Integer] wait_for_io
+      # @param [Integer] wait_for_io
       #   Wait for IO to be finished
       #
       # @return [String]
       #   The content of stderr
-      def stderr(opts = {})
+      def stderr(wait_for_io: io_wait_timeout)
         return @stderr_cache if stopped?
 
-        wait_for_io opts.fetch(:wait_for_io, io_wait_timeout) do
+        wait_for_io wait_for_io do
           @process.stderr.flush
           File.read(@stderr_file.path)
         end

--- a/spec/aruba/processes/basic_process_spec.rb
+++ b/spec/aruba/processes/basic_process_spec.rb
@@ -15,17 +15,17 @@ RSpec.describe Aruba::Processes::BasicProcess do
 
     let(:derived_process) do
       Class.new(described_class) do
-        def initialize(*args)
-          @stdout = args.shift
-          @stderr = args.shift
-          super
+        def initialize(stdout, stderr, *args)
+          @stdout = stdout
+          @stderr = stderr
+          super(*args)
         end
 
-        def stdout(*_args)
+        def stdout(*)
           @stdout
         end
 
-        def stderr(*_args)
+        def stderr(*)
           @stderr
         end
       end.new(stdout, stderr, cmd, exit_timeout, io_wait_timeout, working_directory)

--- a/spec/support/shared_contexts/aruba.rb
+++ b/spec/support/shared_contexts/aruba.rb
@@ -4,8 +4,8 @@ require 'fileutils'
 require 'securerandom'
 
 RSpec.shared_context 'uses aruba API' do
-  def random_string(options = {})
-    options[:prefix].to_s + SecureRandom.hex + options[:suffix].to_s
+  def random_string(prefix: nil, suffix: nil)
+    prefix.to_s + SecureRandom.hex + suffix.to_s
   end
 
   def create_test_files(files, data = 'a')


### PR DESCRIPTION
## Summary

Modernize argument handling in Aruba's methods

## Details

- Use keyword arguments instead of options hashes
- Use argument forwarding where relevant
- Update documentation
- Use argument names instead of processing rest-argument arrays
- Update documentation

## Motivation and Context

This fixes #984. Ruby's argument handling has become more powerful over the years so tricks like options hashes and deconstructing argument lists are no longer necessary.

## How Has This Been Tested?

I ran the test suite.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Documentation update

## Checklist:

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
