### PR TITLE
Stop any commands running after each spec in Aruba's spec suite

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --order random
 --warnings
+--format documentation

--- a/spec/support/configs/rspec.rb
+++ b/spec/support/configs/rspec.rb
@@ -13,4 +13,5 @@ RSpec.configure do |config|
 
   config.include Aruba::Api
   config.before { setup_aruba }
+  config.after { stop_all_commands }
 end


### PR DESCRIPTION
## Summary

Clean up running commands after each spec.

## Details

On windows, commands left running prevent clean-up of tmp files used to store stdout and stderr. This change should ensure commands are stopped and tmp files closed before they're garbage-collected.

## Motivation and Context

The specs on windows report a lot of warnings about access being denied on tmp files. This should clean that up.

## How Has This Been Tested?

I ran one spec locally. This should mainly be tested by checking the logs in CI.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
