### PR TITLE
Depend only on cucumber-core at runtime

### DIFF
--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -25,12 +25,13 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bundler', '>= 2.20.0'
   spec.add_dependency 'contracts', ['>= 0.16.0', '< 0.18.0']
-  spec.add_dependency 'cucumber', '~> 11.0'
+  spec.add_dependency 'cucumber-core', '~> 16.0'
   spec.add_dependency 'marcel', '~> 1.0'
   spec.add_dependency 'rspec-expectations', '>= 3.4', '< 5.0'
   spec.add_dependency 'thor', '~> 1.0'
 
   spec.add_development_dependency 'appraisal', '~> 2.4'
+  spec.add_development_dependency 'cucumber', '~> 11.0'
   spec.add_development_dependency 'diff-lcs', '~> 1.6'
   spec.add_development_dependency 'irb', '~> 1.16'
   spec.add_development_dependency 'json', '~> 2.1'

--- a/features/step_definitions/hooks.rb
+++ b/features/step_definitions/hooks.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'cucumber/platform'
+require 'cucumber/core/platform'
 
 Before '@requires-zsh' do
   next unless Aruba.platform.which('zsh').nil?


### PR DESCRIPTION
## Summary

Limit Aruba's runtime dependency on cucumber to just cucumber-core.

## Details

This limits Aruba's runtime dependencies on the cucumber ecosystem to just cucumber-core. Aruba uses cucumber-core for its event bus implementation

## Motivation and Context

This makes using Aruba with RSpec or minitest less awkward by not pulling in the entirety of Cucumber. See #402 and #806 for background on this.

## How Has This Been Tested?

CI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've added tests for my code
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
