### PR TITLE
Do not unescape actual output text in have_output* matchers

### DIFF
--- a/features/04_aruba_api/filesystem/use_fixtures.feature
+++ b/features/04_aruba_api/filesystem/use_fixtures.feature
@@ -38,7 +38,7 @@ Feature: Use fixtures in your tests
       before { copy '%/my_file.txt', 'new_file.txt' }
       before { run_command 'aruba-test-cli new_file.txt' }
 
-      it { expect(last_command_started).to have_output 'Hello Aruba!' }
+      it { expect(last_command_started).to have_output "Hello Aruba!\n" }
     end
     """
     And a directory named "fixtures"

--- a/lib/aruba/api/text.rb
+++ b/lib/aruba/api/text.rb
@@ -26,11 +26,14 @@ module Aruba
           .gsub('\t', "\t")
       end
 
-      # Remove ansi characters from text
+      # Remove ansi characters from text. Does nothing if
+      # config.remove_ansi_escape_sequences is false
       #
       # @param [#to_s] text
       #   Input
       def extract_text(text)
+        return text unless aruba.config.remove_ansi_escape_sequences
+
         text
           .gsub(/(?:\e|\033)\[\d+(?>(;\d+)*)m/, '')
           .gsub(/\\\[|\\\]/, '')
@@ -43,7 +46,7 @@ module Aruba
       #   The text to sanitize
       def sanitize_text(text)
         text = unescape_text(text)
-        text = extract_text(text) if aruba.config.remove_ansi_escape_sequences
+        text = extract_text(text)
 
         text.chomp
       end

--- a/lib/aruba/matchers/command/have_output.rb
+++ b/lib/aruba/matchers/command/have_output.rb
@@ -27,7 +27,7 @@ RSpec::Matchers.define :have_output do |expected|
 
     @old_actual.stop
 
-    @actual = sanitize_text(actual.output)
+    @actual = extract_text(actual.output)
 
     values_match?(expected, @actual)
   end

--- a/lib/aruba/matchers/command/have_output_on_stderr.rb
+++ b/lib/aruba/matchers/command/have_output_on_stderr.rb
@@ -25,7 +25,7 @@ RSpec::Matchers.define :have_output_on_stderr do |expected|
 
     @old_actual.stop
 
-    @actual = sanitize_text(actual.stderr)
+    @actual = extract_text(actual.stderr)
 
     values_match?(expected, @actual)
   end

--- a/lib/aruba/matchers/command/have_output_on_stdout.rb
+++ b/lib/aruba/matchers/command/have_output_on_stdout.rb
@@ -25,7 +25,7 @@ RSpec::Matchers.define :have_output_on_stdout do |expected|
 
     @old_actual.stop
 
-    @actual = sanitize_text(actual.stdout)
+    @actual = extract_text(actual.stdout)
 
     values_match?(expected, @actual)
   end

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -17,20 +17,20 @@ RSpec.describe Aruba::Api::Commands do
         @aruba.type(+'Hello')
         @aruba.type(+"\u0004")
 
-        expect(@aruba.last_command_started).to have_output 'Hello'
+        expect(@aruba.last_command_started).to have_output "Hello\n"
       end
 
       it 'respond to frozen input' do
         @aruba.type 'Hello'
         @aruba.type "\u0004"
 
-        expect(@aruba.last_command_started).to have_output 'Hello'
+        expect(@aruba.last_command_started).to have_output "Hello\n"
       end
 
       it 'respond to close_input' do
         @aruba.type 'Hello'
         @aruba.close_input
-        expect(@aruba.last_command_started).to have_output 'Hello'
+        expect(@aruba.last_command_started).to have_output "Hello\n"
       end
 
       it 'pipes data' do

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -76,109 +76,168 @@ RSpec.describe 'Command Matchers' do
   end
 
   describe '#have_output' do
-    let(:cmd) { "echo #{output}" }
-    let(:output) { 'hello world' }
-
-    context 'when have output hello world on stdout' do
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).to have_output output }
+    let(:cmd) do
+      instance_double(Aruba::Processes::SpawnProcess,
+                      commandline: 'foo',
+                      stop: true)
     end
 
-    context 'when multiple commands output hello world on stdout' do
-      context 'and all commands must have the output' do
-        before do
-          run_command(cmd)
-          run_command(cmd)
-        end
+    before do
+      allow(cmd).to receive(:output).and_return(output)
+    end
 
-        it { expect(all_commands).to all have_output output }
+    context 'with a simple one-line output' do
+      let(:output) { "hello world\n" }
+
+      it 'succeeds when matching against identical string' do
+        expect(cmd).to have_output output
       end
 
-      context 'and any command can have the output' do
-        before do
-          run_command(cmd)
-          run_command('echo hello universe')
-        end
+      it 'succeeds when negating match against other string' do
+        expect(cmd).not_to have_output "hello universe\n"
+      end
 
-        it { expect(all_commands).to include have_output(output) }
+      it 'succeeds when negating match against empty string' do
+        expect(cmd).not_to have_output ''
       end
     end
 
-    context 'when have output hello world on stderr' do
-      let(:cmd) { "sh -c \"echo #{output} >&2\"" }
+    context 'with empty output' do
+      let(:output) { '' }
 
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).to have_output output }
+      it 'succeeds when matching against empty string' do
+        expect(cmd).to have_output ''
+      end
     end
 
-    context 'when not has output' do
-      before { run_command(cmd) }
+    context 'with output containing ansi escape codes' do
+      let(:output) { "\e[36mhello world\e[0m\n" }
 
-      it { expect(last_command_started).not_to have_output 'hello universe' }
-    end
+      it 'matches with expected string without escape codes' do
+        expect(cmd).to have_output "hello world\n"
+      end
 
-    context 'when has empty output' do
-      before { run_command('false') }
+      it 'does not match with string with escape codes' do
+        expect(cmd).not_to have_output "\e[36mhello world\e[0m\n"
+      end
 
-      it { expect(last_command_started).to have_output '' }
-    end
+      it 'does not match with plain string when ansi codes are kept' do
+        aruba.config.remove_ansi_escape_sequences = false
+        expect(cmd).not_to have_output "hello world\n"
+      end
 
-    context 'when not has empty output' do
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).not_to have_output '' }
+      it 'matches with string with escape codes when ansi codes are kept' do
+        aruba.config.remove_ansi_escape_sequences = false
+        expect(cmd).to have_output "\e[36mhello world\e[0m\n"
+      end
     end
   end
 
   describe '#have_output_on_stdout' do
-    let(:cmd) { "echo #{output}" }
-    let(:output) { 'hello world' }
-
-    context 'when have output hello world on stdout' do
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).to have_output_on_stdout output }
+    let(:cmd) do
+      instance_double(Aruba::Processes::SpawnProcess,
+                      commandline: 'foo',
+                      stop: true)
     end
 
-    context 'when have output hello world on stderr' do
-      let(:cmd) { "sh -c \"echo #{output} >&2\"" }
-
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).not_to have_output_on_stdout output }
+    before do
+      allow(cmd).to receive(:stdout).and_return(output)
     end
 
-    context 'when not has output' do
-      before { run_command(cmd) }
+    context 'with a simple one-line output on stdout' do
+      let(:output) { "hello world\n" }
 
-      it { expect(last_command_started).not_to have_output_on_stdout 'hello universe' }
+      it 'succeeds when matching against identical string' do
+        expect(cmd).to have_output_on_stdout output
+      end
+
+      it 'succeeds when negating match against other string' do
+        expect(cmd).not_to have_output_on_stdout "hello universe\n"
+      end
+    end
+
+    context 'with empty output' do
+      let(:output) { '' }
+
+      it 'succeeds when matching against empty string' do
+        expect(cmd).to have_output_on_stdout ''
+      end
+    end
+
+    context 'with output containing ansi escape codes on stdout' do
+      let(:output) { "\e[36mhello world\e[0m\n" }
+
+      it 'matches with expected string without escape codes' do
+        expect(cmd).to have_output_on_stdout "hello world\n"
+      end
+
+      it 'does not match with string with escape codes' do
+        expect(cmd).not_to have_output_on_stdout "\e[36mhello world\e[0m\n"
+      end
+
+      it 'does not match with plain string when ansi codes are kept' do
+        aruba.config.remove_ansi_escape_sequences = false
+        expect(cmd).not_to have_output_on_stdout "hello world\n"
+      end
+
+      it 'matches with string with escape codes when ansi codes are kept' do
+        aruba.config.remove_ansi_escape_sequences = false
+        expect(cmd).to have_output_on_stdout "\e[36mhello world\e[0m\n"
+      end
     end
   end
 
   describe '#have_output_on_stderr' do
-    let(:cmd) { "echo #{output}" }
-    let(:output) { 'hello world' }
-
-    context 'when have output hello world on stdout' do
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).not_to have_output_on_stderr output }
+    let(:cmd) do
+      instance_double(Aruba::Processes::SpawnProcess,
+                      commandline: 'foo',
+                      stop: true)
     end
 
-    context 'when have output hello world on stderr' do
-      let(:cmd) { "sh -c \"echo #{output} >&2\"" }
-
-      before { run_command(cmd) }
-
-      it { expect(last_command_started).to have_output_on_stderr output }
+    before do
+      allow(cmd).to receive(:stderr).and_return(output)
     end
 
-    context 'when not has output' do
-      before { run_command(cmd) }
+    context 'with a simple one-line output on stderr' do
+      let(:output) { "hello world\n" }
 
-      it { expect(last_command_started).not_to have_output_on_stderr 'hello universe' }
+      it 'succeeds when matching against identical string' do
+        expect(cmd).to have_output_on_stderr output
+      end
+
+      it 'succeeds when negating match against other string' do
+        expect(cmd).not_to have_output_on_stderr "hello universe\n"
+      end
+    end
+
+    context 'with empty output on stderr' do
+      let(:output) { '' }
+
+      it 'succeeds when matching against empty string' do
+        expect(cmd).to have_output_on_stderr ''
+      end
+    end
+
+    context 'with output containing ansi escape codes on stderr' do
+      let(:output) { "\e[36mhello world\e[0m\n" }
+
+      it 'matches with expected string without escape codes' do
+        expect(cmd).to have_output_on_stderr "hello world\n"
+      end
+
+      it 'does not match with string with escape codes' do
+        expect(cmd).not_to have_output_on_stderr "\e[36mhello world\e[0m\n"
+      end
+
+      it 'has negative match with plain string when ansi codes are kept' do
+        aruba.config.remove_ansi_escape_sequences = false
+        expect(cmd).not_to have_output_on_stderr "hello world\n"
+      end
+
+      it 'matches with string with escape codes when ansi codes are kept' do
+        aruba.config.remove_ansi_escape_sequences = false
+        expect(cmd).to have_output_on_stderr "\e[36mhello world\e[0m\n"
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

This removes full text sanitation from the `have_output*` matchers. This means the text is no longer unescaped, but ANSI escape codes are removed if ANSI escape code removal is configured.

## Motivation and Context

All output was run through `sanitize_text` in these matchers, which does some tricky unescaping of the text. This lead to confusing results when output is expected to contain, e.g., the literal text `\n`. To avoid this, the unescaping is removed, but the cleaning of ANSI codes is kept.

Note that there are matchers on strings that still use `sanitize_text`. These will probably be removed entirely. See #545.

## How Has This Been Tested?

I updated the specs and extended them to show behavior with and without ANSI code cleaning enabled. I also ran the `reek` cucumber test suite to check how this change influenced it.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

N/A
