### PR TITLE
Make wording for steps waiting for output read better

### DIFF
--- a/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
+++ b/features/03_testing_frameworks/cucumber/steps/command/wait_for_output_of_command.feature
@@ -13,7 +13,7 @@ Feature: Wait for output of commands
     Feature: Run command
       Scenario: Run command
         When I run `irb --prompt classic` interactively
-        And I wait for output to contain "irb"
+        And I wait for the output to contain "irb"
         And I type "puts 6 + 5"
         And I type "exit"
         Then the output should contain "11"
@@ -33,7 +33,7 @@ Feature: Wait for output of commands
     Feature: Run command
       Scenario: Run command
         When I run `irb --prompt classic` interactively
-        And I wait for output to contain:
+        And I wait for the output to contain:
           \"\"\"
           irb(main):001:0>
           \"\"\"
@@ -50,7 +50,7 @@ Feature: Wait for output of commands
     Feature: Run command
       Scenario: Run command
         When I run `irb --prompt classic` interactively
-        And I wait for output to contain:
+        And I wait for the output to contain:
           \"\"\"
           irb(main):001:0>
           \"\"\"

--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -105,7 +105,7 @@ When(/^I stop the command(?: started last)? if (output|stdout|stderr) contains:$
   end
 end
 
-When 'I wait for output/stdout to contain:' do |expected|
+When 'I wait for (the )output/stdout to contain:' do |expected|
   start_time = Time.now
   loop do
     output = last_command_started.stdout wait_for_io: 0
@@ -124,7 +124,7 @@ When 'I wait for output/stdout to contain:' do |expected|
   end
 end
 
-When 'I wait for output/stdout to contain {string}' do |expected|
+When 'I wait for (the )output/stdout to contain {string}' do |expected|
   start_time = Time.now
   loop do
     output = last_command_started.stdout wait_for_io: 0


### PR DESCRIPTION
## Summary

Allow step to read 'wait for the output to contain'.

## Details

Updates the step definitions to allow the optional article.

## Motivation and Context

Just reads nicer.

## How Has This Been Tested?

I ran the relevant cucumber scenario

## Types of changes

A small non-breaking improvement.

## Checklist:

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
