### PR TITLE
Remove code that was marked deprecated in the previous release

### DIFF
--- a/lib/aruba/cucumber/command.rb
+++ b/lib/aruba/cucumber/command.rb
@@ -44,12 +44,6 @@ When 'I run {command} in the background' do |cmd|
   run_command(sanitize_text(cmd))
 end
 
-When 'I run {command} in background' do |cmd|
-  Aruba.platform.deprecated \
-    'This cucumber step is deprecated. Use "I run {command} in the background" instead.'
-  run_command(sanitize_text(cmd))
-end
-
 When 'I type {string}' do |input|
   type(unescape_text(input))
 end
@@ -387,21 +381,6 @@ Then(/^it should (pass|fail)$/) do |pass_fail|
   end
 end
 
-Then(/^it should not (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
-  Aruba.platform.deprecated \
-    'This cucumber step has confusing behavior and is deprecated.' \
-    "Use 'it should #{pass_fail}' with a negative output matcher step instead."
-  last_command_started.stop
-
-  if pass_fail == 'pass'
-    expect(last_command_stopped).to be_successfully_executed
-  else
-    expect(last_command_stopped).not_to be_successfully_executed
-  end
-
-  expect(last_command_stopped).not_to have_output an_output_string_including(expected)
-end
-
 Then(/^it should (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
   last_command_started.stop
 
@@ -412,21 +391,6 @@ Then(/^it should (pass|fail) with "(.*?)"$/) do |pass_fail, expected|
   end
 
   expect(last_command_stopped).to have_output an_output_string_including(expected)
-end
-
-Then(/^it should not (pass|fail) with:$/) do |pass_fail, expected|
-  Aruba.platform.deprecated \
-    'This cucumber step has confusing behavior and is deprecated.' \
-    "Use 'it should #{pass_fail}' with a negative output matcher step instead."
-  last_command_started.stop
-
-  if pass_fail == 'pass'
-    expect(last_command_stopped).to be_successfully_executed
-  else
-    expect(last_command_stopped).not_to be_successfully_executed
-  end
-
-  expect(last_command_stopped).not_to have_output an_output_string_including(expected)
 end
 
 Then(/^it should (pass|fail) with:$/) do |pass_fail, expected|
@@ -441,21 +405,6 @@ Then(/^it should (pass|fail) with:$/) do |pass_fail, expected|
   expect(last_command_stopped).to have_output an_output_string_including(expected)
 end
 
-Then(/^it should not (pass|fail) with exactly:$/) do |pass_fail, expected|
-  Aruba.platform.deprecated \
-    'This cucumber step has confusing behavior and is deprecated.' \
-    "Use 'it should #{pass_fail}' with a negative output matcher step instead."
-  last_command_started.stop
-
-  if pass_fail == 'pass'
-    expect(last_command_stopped).to be_successfully_executed
-  else
-    expect(last_command_stopped).not_to be_successfully_executed
-  end
-
-  expect(last_command_stopped).not_to have_output an_output_string_eq(expected)
-end
-
 Then(/^it should (pass|fail) with exactly:$/) do |pass_fail, expected|
   last_command_started.stop
 
@@ -466,21 +415,6 @@ Then(/^it should (pass|fail) with exactly:$/) do |pass_fail, expected|
   end
 
   expect(last_command_stopped.output).to output_string_eq(expected)
-end
-
-Then(/^it should not (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|
-  Aruba.platform.deprecated \
-    'This cucumber step has confusing behavior and is deprecated.' \
-    "Use 'it should #{pass_fail}' with a negative output matcher step instead."
-  last_command_started.stop
-
-  if pass_fail == 'pass'
-    expect(last_command_stopped).to be_successfully_executed
-  else
-    expect(last_command_stopped).not_to be_successfully_executed
-  end
-
-  expect(last_command_stopped).not_to have_output an_output_string_matching(expected)
 end
 
 Then(/^it should (pass|fail) (?:with regexp?|matching):$/) do |pass_fail, expected|

--- a/lib/aruba/cucumber/testing_frameworks.rb
+++ b/lib/aruba/cucumber/testing_frameworks.rb
@@ -6,10 +6,7 @@
 # This defines the following steps:
 #
 # 1. Simple pass/not pass/fail
-# 2. Pass/not pass/fail with a multiline string or regex
-#
-# For item 2, the 'not pass' variant is deprecated because the wording makes it
-# unclear how the negation should be applied.
+# 2. Pass/fail with a multiline string or regex
 #
 Then(/^the feature(?:s)? should fail$/) do
   expect(all_output).to include_output_string ' failed)'
@@ -38,20 +35,6 @@ Then(/^the feature(?:s)? should fail with( regex)?:$/) do |regex, string|
   end
 end
 
-Then(/^the feature(?:s)? should not(?: all)? pass with( regex)?:$/) do |regex, string|
-  Aruba.platform.deprecated \
-    'This cucumber step has confusing wording and is deprecated.' \
-    "Use 'the feature(s) should fail with#{regex}:' instead."
-  expect(all_output).to include_output_string ' failed)'
-  expect(last_command_stopped).to have_exit_status 1
-
-  if regex
-    expect(all_output).to match_output_string(string)
-  else
-    expect(all_output).to include_output_string(string)
-  end
-end
-
 Then(/^the feature(?:s)? should(?: all)? pass with( regex)?:$/) do |regex, string|
   expect(all_output).not_to include_output_string ' failed)'
   expect(all_output).not_to include_output_string ' undefined)'
@@ -70,11 +53,8 @@ end
 # This defines the following steps:
 #
 # 1. Simple pass/not pass/fail
-# 2. Not pass/fail with a failure count
-# 3. Pass/not pass/fail with a multiline string or regex
-#
-# For items 2 and 3, the 'not pass' variant is deprecated because the wording
-# makes it unclear how the negation should be applied.
+# 2. Fail with a failure count
+# 3. Pass/fail with a multiline string or regex
 #
 Then(/^the spec(?:s)? should fail$/) do
   expect(all_output).not_to include_output_string '0 failures'
@@ -97,30 +77,7 @@ Then(/^the spec(?:s)? should fail with (\d+) failures?$/) do |count|
   expect(last_command_stopped).to have_exit_status 1
 end
 
-Then(/^the spec(?:s)? should not(?: all)? pass with (\d+) failures?$/) do |count|
-  Aruba.platform.deprecated \
-    'This rspec step has confusing wording and is deprecated.' \
-    "Use 'the spec(s) should fail with #{count} failures' instead."
-  expect(all_output).to include_output_string "#{count} failures"
-
-  expect(last_command_stopped).to have_exit_status 1
-end
-
 Then(/^the spec(?:s)? should fail with( regex)?:$/) do |regex, string|
-  expect(all_output).not_to include_output_string '0 failures'
-  expect(last_command_stopped).to have_exit_status 1
-
-  if regex
-    expect(all_output).to match_output_string(string)
-  else
-    expect(all_output).to include_output_string(string)
-  end
-end
-
-Then(/^the spec(?:s)? should not(?: all)? pass with( regex)?:$/) do |regex, string|
-  Aruba.platform.deprecated \
-    'This rspec step has confusing wording and is deprecated.' \
-    "Use 'the spec(s) should fail with#{regex}:' instead."
   expect(all_output).not_to include_output_string '0 failures'
   expect(last_command_stopped).to have_exit_status 1
 
@@ -148,11 +105,8 @@ end
 # This defines the following steps:
 #
 # 1. Simple pass/not pass/fail
-# 2. Not pass/fail with a failure count
-# 3. Pass/not pass/fail with a multiline string or regex
-#
-# For items 2 and 3, the 'not pass' variant is deprecated because the wording
-# makes it unclear how the negation should be applied.
+# 2. Fail with a failure count
+# 3. Pass/fail with a multiline string or regex
 #
 Then(/^the test(?:s)? should fail$/) do
   expect(all_output).not_to include_output_string '0 errors'
@@ -174,29 +128,7 @@ Then(/^the test(?:s)? should fail with (\d+) errors?$/) do |count|
   expect(last_command_stopped).to have_exit_status 1
 end
 
-Then(/^the tests(?:s)? should not(?: all)? pass with (\d+) failures?$/) do |count|
-  Aruba.platform.deprecated \
-    'This minitest step has confusing wording and is deprecated.' \
-    "Use 'the test(s) should fail #{count} errors' instead."
-  expect(all_output).to include_output_string "#{count} errors"
-  expect(last_command_stopped).to have_exit_status 1
-end
-
 Then(/^the test(?:s)? should fail with( regex)?:$/) do |regex, string|
-  expect(all_output).not_to include_output_string '0 errors'
-  expect(last_command_stopped).to have_exit_status 1
-
-  if regex
-    expect(all_output).to match_output_string(string)
-  else
-    expect(all_output).to include_output_string(string)
-  end
-end
-
-Then(/^the test(?:s)? should not(?: all)? pass with( regex)?:$/) do |regex, string|
-  Aruba.platform.deprecated \
-    'This minitest step has confusing wording and is deprecated.' \
-    "Use 'the test(s) should fail with#{regex}:' instead."
   expect(all_output).not_to include_output_string '0 errors'
   expect(last_command_stopped).to have_exit_status 1
 

--- a/lib/aruba/matchers/command/have_output_size.rb
+++ b/lib/aruba/matchers/command/have_output_size.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
-# @!method have_output_size(output)
-#   This matchers checks if output has size.
+# @!method have_output_size
+#   This matcher checks if the process has produced output of a given size.
 #
-#   @param [String,Aruba::Process:BasicProcess] output or process
-#     The content which should be checked, or the process whose output should be checked
-#
-#     Use of this matcher with a string is deprecated.
+#   @param [Aruba::Process:BasicProcess] process
+#     The process whose output should be checked
 #
 #   @return [Boolean] The result
 #
@@ -18,24 +16,13 @@
 #   @example Use matcher
 #
 #     RSpec.describe do
-#       it { expect(file1).to have_output_size(256) }
-#     end
-#
-#     RSpec.describe do
 #       it { expect(last_command_started).to have_output_size(256) }
 #     end
 RSpec::Matchers.define :have_output_size do |expected|
   match do |actual|
-    if actual.respond_to? :size
-      Aruba.platform.deprecated \
-        'Application of the have_output_size matcher to a string is deprecated. ' \
-        'Apply the matcher directly to the process object instead'
-      actual_size = actual.size
-    elsif actual.respond_to? :output
-      actual_size = actual.output.size
-    else
-      raise "Expected #{actual} to respond to #size or #output"
-    end
+    raise "Expected #{actual} to respond to #output" unless actual.respond_to? :output
+
+    actual_size = actual.output.size
 
     values_match? expected, actual_size
   end

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -240,30 +240,7 @@ RSpec.describe 'Command Matchers', type: :aruba do
   end
 
   describe '#have_output_size' do
-    context 'when actual is a string' do
-      let(:obj) { 'string' }
-
-      before do
-        allow(Aruba.platform).to receive(:deprecated)
-      end
-
-      it 'matches when the string is the given size' do
-        expect(obj).to have_output_size 6
-      end
-
-      it 'does not match when the string does not have the given size' do
-        expect(obj).not_to have_output_size 5
-      end
-
-      it 'emits a deprecation warning' do
-        aggregate_failures do
-          expect(Aruba.platform).to receive(:deprecated)
-          expect(obj).to have_output_size 6
-        end
-      end
-    end
-
-    context 'when actual is a command' do
+    context 'when command has some output' do
       let(:cmd) { "echo #{output}" }
       let(:output) { 'hello world' }
 


### PR DESCRIPTION
## Summary

Remove all code marked deprecated. Users using the 2.4.1 release should be seeing these deprecation messages and should resolve them before upgrading.

## Details

- **Remove deprecated step definitions**
- **Remove deprecated option of passing a string to have_output_size**

## Motivation and Context

Preparing for 3.0

## How Has This Been Tested?

I ran the test suite.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
