### PR TITLE
Update simplecov dependency and simplify its configuration

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,35 +1,5 @@
 # frozen_string_literal: true
 
 SimpleCov.configure do
-  # Activate branch coverage
   enable_coverage :branch
-
-  # ignore this file
-  skip '.simplecov'
-  skip 'features'
-
-  # Rake tasks aren't tested with rspec
-  skip 'Rakefile'
-  skip 'lib/tasks'
-
-  #
-  # Changed Files in Git Group
-  # @see http://fredwu.me/post/35625566267/simplecov-test-coverage-for-changed-files-only
-  untracked         = `git ls-files --exclude-standard --others`
-  unstaged          = `git diff --name-only`
-  staged            = `git diff --name-only --cached`
-  all               = untracked + unstaged + staged
-  changed_filenames = all.split("\n")
-
-  group 'Changed' do |source_file|
-    changed_filenames.select do |changed_filename|
-      source_file.filename.end_with?(changed_filename)
-    end
-  end
-
-  group 'Libraries', 'lib'
-
-  # Specs are reported on to ensure that all examples are being run and all
-  # lets, befores, afters, etc are being used.
-  group 'Specs', 'spec/'
 end

--- a/.simplecov
+++ b/.simplecov
@@ -5,12 +5,12 @@ SimpleCov.configure do
   enable_coverage :branch
 
   # ignore this file
-  add_filter '.simplecov'
-  add_filter 'features'
+  skip '.simplecov'
+  skip 'features'
 
   # Rake tasks aren't tested with rspec
-  add_filter 'Rakefile'
-  add_filter 'lib/tasks'
+  skip 'Rakefile'
+  skip 'lib/tasks'
 
   #
   # Changed Files in Git Group
@@ -21,15 +21,15 @@ SimpleCov.configure do
   all               = untracked + unstaged + staged
   changed_filenames = all.split("\n")
 
-  add_group 'Changed' do |source_file|
+  group 'Changed' do |source_file|
     changed_filenames.select do |changed_filename|
       source_file.filename.end_with?(changed_filename)
     end
   end
 
-  add_group 'Libraries', 'lib'
+  group 'Libraries', 'lib'
 
   # Specs are reported on to ensure that all examples are being run and all
   # lets, befores, afters, etc are being used.
-  add_group 'Specs', 'spec/'
+  group 'Specs', 'spec/'
 end

--- a/aruba.gemspec
+++ b/aruba.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-packaging', '~> 0.6.0'
   spec.add_development_dependency 'rubocop-performance', '~> 1.26'
   spec.add_development_dependency 'rubocop-rspec', '~> 3.10'
-  spec.add_development_dependency 'simplecov', '>= 0.18.0', '< 0.23.0'
+  spec.add_development_dependency 'simplecov', '~> 1.0.2'
 
   spec.required_ruby_version = '>= 3.2.0'
 

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe 'Command Matchers', type: :aruba do
   end
 
   describe '#run_too_long' do
-    let(:slow_cmd) { 'sleep 0.2' }
+    let(:slow_cmd) { 'sleep 0.3' }
     let(:fast_cmd) { 'true' }
 
     before { aruba.config.exit_timeout = 0.1 }


### PR DESCRIPTION
## Summary

Use latest simplecov dependency. Also, simplify `.simplecov` to the bare minimum.

## Details

Simplecov 1.0 changes its configuration format. That's a good occasion to look at the configuration itself.

I'v simplified the configuration to the bare minimum, since I found:

- The grouping of 'changed files' was not very useful, since changed spec files may be intended to increase coverage for committed and hence 'unchanged' code. Also, this introduced a dependency on `git`, which was interfering with my attempts to run the test suite under Wine.
- The Specs group was empty since simplecov now excludes `spec/` (and more) by default
- The Library group now included all code so was identical to 'All files'.

## Motivation and Context

- Keeping dependencies up-to-date
- Getting to run the test suite on Wine without git

## How Has This Been Tested?

I ran the whole test suite.

## Types of changes

- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

N/A
