### PR TITLE
Always clean up the working directory for the next test or scenario

### DIFF
--- a/features/01_getting_started_with_aruba/cleanup_working_directory.feature
+++ b/features/01_getting_started_with_aruba/cleanup_working_directory.feature
@@ -1,9 +1,6 @@
 Feature: Cleanup Aruba Working Directory
 
-  By default Aruba removes its scratch directory *before* every scenario. This
-  isn't always the right thing to do, especially when the path to the default
-  directory has been changed. Use the `@no-clobber`-tag on your scenarios to
-  stop Aruba from cleaning up *before* it runs.
+  Aruba removes its scratch directory *before* every scenario.
 
   Background:
     Given I use a fixture named "cli-app"
@@ -24,32 +21,6 @@ Feature: Cleanup Aruba Working Directory
       Scenario: Check #2
         Then a file named "file.txt" should not exist
         And a directory named "dir.d" should not exist
-        When I run `pwd`
-        Then the output should match %r</tmp/aruba$>
-    """
-    When I run `cucumber`
-    Then the features should all pass
-
-  Scenario: Do not clobber before run
-    The `@no-clobber` tag stops Aruba from clearing out its scratch directory.
-    Other setup steps are still performed, such as setting the current working
-    directory.
-
-    Given a file named "tmp/aruba/file.txt" with "content"
-    And a directory named "tmp/aruba/dir.d"
-    And a file named "features/cleanup.feature" with:
-    """
-    Feature: Check
-      Scenario: Check #1
-        Given a file named "file.txt" with "content"
-        And a directory named "dir.d"
-        Then a file named "file.txt" should exist
-        And a directory named "dir.d" should exist
-
-      @no-clobber
-      Scenario: Check #2
-        Then a file named "file.txt" should exist
-        And a directory named "dir.d" should exist
         When I run `pwd`
         Then the output should match %r</tmp/aruba$>
     """

--- a/lib/aruba/api/core.rb
+++ b/lib/aruba/api/core.rb
@@ -29,8 +29,8 @@ module Aruba
       # This will only clean up aruba's working directory to remove all
       # artifacts of your tests. This does NOT clean up the current working
       # directory.
-      def setup_aruba(clobber = true)
-        Aruba::Setup.new(aruba).call(clobber)
+      def setup_aruba
+        Aruba::Setup.new(aruba).call
 
         self
       end

--- a/lib/aruba/cucumber/hooks.rb
+++ b/lib/aruba/cucumber/hooks.rb
@@ -23,11 +23,7 @@ After do
   aruba.command_monitor.clear
 end
 
-Before('@no-clobber') do
-  setup_aruba(false)
-end
-
-Before('not @no-clobber') do
+Before do
   setup_aruba
 end
 

--- a/lib/aruba/setup.rb
+++ b/lib/aruba/setup.rb
@@ -12,10 +12,10 @@ module Aruba
       @runtime = runtime
     end
 
-    def call(clobber = true)
+    def call
       return if runtime.setup_already_done?
 
-      working_directory(clobber)
+      working_directory
       register_event_handlers
 
       runtime.setup_done
@@ -25,12 +25,10 @@ module Aruba
 
     private
 
-    def working_directory(clobber = true)
-      if clobber
-        Aruba.platform.rm File.join(runtime.config.root_directory,
-                                    runtime.working_directory),
-                          force: true
-      end
+    def working_directory
+      Aruba.platform.rm File.join(runtime.config.root_directory,
+                                  runtime.working_directory),
+                        force: true
       Aruba.platform.mkdir File.join(runtime.config.root_directory,
                                      runtime.working_directory)
       Aruba.platform.chdir runtime.config.root_directory

--- a/spec/aruba/matchers/command_spec.rb
+++ b/spec/aruba/matchers/command_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe 'Command Matchers', type: :aruba do
       let(:cmd) { "echo #{output}" }
       let(:output) { 'hello world' }
 
-      before { run_command(cmd) }
+      before { run_command_and_stop(cmd) }
 
       it 'matches directly on the command itself' do
         expect(last_command_started).to have_output_size "#{output}\n".length


### PR DESCRIPTION
## Summary

Removes the option not to clobber the Aruba workspace during setup.

## Details

This the `clobber` parameter from `setup_aruba` and its underlying implementation. The workspace directory will always be clobbered.

## Motivation and Context

Making your tests interdependent is generally considered a bad idea, and will become impossible with the upcoming full workspace isolation.

## How Has This Been Tested?

I ran the test suite

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- My change requires a change to the documentation.
- I have updated the documentation accordingly.
