### PR TITLE
Improve Aruba::Api#which and allow empty path

### DIFF
--- a/lib/aruba/api/commands.rb
+++ b/lib/aruba/api/commands.rb
@@ -13,20 +13,26 @@ module Aruba
   module Api
     # Command module
     module Commands
-      # Resolve path for command using the PATH-environment variable
+      # Resolve path for command.
+      # - An absolute path resolves to the path itself
+      # - A relative path is resolved with respect to the current Aruba working
+      #   directory
+      # - Other paths are resolved using the path
       #
       # @param [#to_s] program
       #   The name of the program which should be resolved
       #
       # @param [String] path
       #   The PATH, a string concatenated with ":", e.g. /usr/bin/:/bin on a
-      #   UNIX-system
+      #   UNIX-system, or nil to use the path from the Aruba environment.
       def which(program, path = nil)
         with_environment do
           # ENV is set within this block
           path = ENV['PATH'] if path.nil?
 
-          Aruba.platform.which(program, path)
+          in_current_directory do
+            Aruba.platform.which(program, path)
+          end
         end
       end
 

--- a/lib/aruba/platforms/unix_which.rb
+++ b/lib/aruba/platforms/unix_which.rb
@@ -40,7 +40,7 @@ module Aruba
 
         def call(program, path)
           # Iterate over each path glob the dir + program.
-          path.split(File::PATH_SEPARATOR).each do |dir|
+          path&.split(File::PATH_SEPARATOR)&.each do |dir|
             dir = Aruba.platform.expand_path(dir, Dir.getwd)
             next unless Aruba.platform.exist?(dir) # In case of bogus second argument
 

--- a/lib/aruba/platforms/unix_which.rb
+++ b/lib/aruba/platforms/unix_which.rb
@@ -65,7 +65,7 @@ module Aruba
         @whiches << DefaultWhich
       end
 
-      # Find fully quallified path for program
+      # Find fully qualified path for program
       #
       # @param [String] program
       #   Name of program
@@ -73,8 +73,6 @@ module Aruba
       # @param [String] path
       #   ENV['PATH']
       def call(program, path = ENV['PATH'])
-        raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
-
         program = program.to_s
 
         whiches.find { |w| w.match? program }.new.call(program, path)

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -43,7 +43,7 @@ module Aruba
 
         def call(program, path)
           # Iterate over each path glob the dir + program.
-          path.split(File::PATH_SEPARATOR).each do |dir|
+          path&.split(File::PATH_SEPARATOR)&.each do |dir|
             dir = Aruba.platform.expand_path(dir, Dir.getwd)
 
             next unless Aruba.platform.exist?(dir) # In case of bogus second argument

--- a/lib/aruba/platforms/windows_which.rb
+++ b/lib/aruba/platforms/windows_which.rb
@@ -79,7 +79,7 @@ module Aruba
         @whiches << DefaultWhich
       end
 
-      # Find fully quallified path for program
+      # Find fully qualified path for program
       #
       # @param [String] program
       #   Name of program
@@ -87,8 +87,6 @@ module Aruba
       # @param [String] path
       #   ENV['PATH']
       def call(program, path = ENV['PATH'])
-        raise ArgumentError, "ENV['PATH'] cannot be empty" if path.nil? || path.empty?
-
         program = program.to_s
         program += windows_executable_extentions if File.extname(program).empty?
 

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -110,6 +110,11 @@ RSpec.describe Aruba::Api::Commands, type: :aruba do
       expect(which('echo')).to end_with expected
     end
 
+    it 'does not find a globally available command if path is empty' do
+      expect(which('echo', '')).to be_nil
+    end
+
+    context 'when looking for a relative command' do
       let(:cmd) { Gem.win_platform? ? 'bin/testcmd.bat' : 'bin/testcmd' }
 
       before do
@@ -129,5 +134,10 @@ RSpec.describe Aruba::Api::Commands, type: :aruba do
       it 'finds the command in the workspace' do
         expect(which(cmd)).to eq expand_path(cmd)
       end
+
+      it 'finds the command even when the path is empty' do
+        expect(which(cmd, '')).to eq expand_path(cmd)
+      end
+    end
   end
 end

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -99,4 +99,35 @@ RSpec.describe Aruba::Api::Commands, type: :aruba do
       expect(last_command_started).to have_output "Hello\nWorld!"
     end
   end
+
+  describe '#which' do
+    it 'finds a globally available command' do
+      expected = if Gem.win_platform?
+                   '\\echo.exe'
+                 else
+                   '/echo'
+                 end
+      expect(which('echo')).to end_with expected
+    end
+
+      let(:cmd) { Gem.win_platform? ? 'bin/testcmd.bat' : 'bin/testcmd' }
+
+      before do
+        if Gem.win_platform?
+          write_file cmd, <<~BAT
+            exit 0
+          BAT
+        else
+          write_file cmd, <<~BASH
+            #!/bin/bash
+            exit 0
+          BASH
+          chmod 0o755, cmd
+        end
+      end
+
+      it 'finds the command in the workspace' do
+        expect(which(cmd)).to eq expand_path(cmd)
+      end
+  end
 end

--- a/spec/aruba/api/commands_spec.rb
+++ b/spec/aruba/api/commands_spec.rb
@@ -5,39 +5,17 @@ require 'aruba/api'
 require 'fileutils'
 
 RSpec.describe Aruba::Api::Commands, type: :aruba do
-  include_context 'uses aruba API'
-
   describe '#run_command' do
-    context 'when succesfully running a command' do
-      before { run_command 'cat' }
-
+    context 'when running a globally available command' do
       after { all_commands.each(&:stop) }
 
-      it 'respond to unfrozen input' do
-        type(+'Hello')
-        type(+"\u0004")
+      it 'runs the command succesfully' do
+        run_command 'echo "Hello"'
 
-        expect(last_command_started).to have_output "Hello\n"
-      end
-
-      it 'respond to frozen input' do
-        type 'Hello'
-        type "\u0004"
-
-        expect(last_command_started).to have_output "Hello\n"
-      end
-
-      it 'respond to close_input' do
-        type 'Hello'
-        close_input
-        expect(last_command_started).to have_output "Hello\n"
-      end
-
-      it 'pipes data' do
-        write_file(@file_name, "Hello\nWorld!")
-        pipe_in_file(@file_name)
-        close_input
-        expect(last_command_started).to have_output "Hello\nWorld!"
+        aggregate_failures do
+          expect(last_command_started).to be_successfully_executed
+          expect(last_command_started).to have_output "Hello\n"
+        end
       end
     end
 
@@ -76,6 +54,49 @@ RSpec.describe Aruba::Api::Commands, type: :aruba do
         run_command(cmd)
         expect(last_command_started).to be_successfully_executed
       end
+    end
+  end
+
+  describe '#type' do
+    before { run_command 'cat' }
+
+    after { all_commands.each(&:stop) }
+
+    it 'works with unfrozen input' do
+      type(+'Hello')
+      type(+"\u0004")
+
+      expect(last_command_started).to have_output "Hello\n"
+    end
+
+    it 'works with frozen input' do
+      type 'Hello'
+      type "\u0004"
+
+      expect(last_command_started).to have_output "Hello\n"
+    end
+  end
+
+  describe '#close_input' do
+    after { all_commands.each(&:stop) }
+
+    it 'closes the input stream' do
+      run_command 'cat'
+      type 'Hello'
+      close_input
+      expect { type 'Goodbye' }.to raise_error IOError
+    end
+  end
+
+  describe '#pipe_in_file' do
+    after { all_commands.each(&:stop) }
+
+    it 'pipes data' do
+      run_command 'cat'
+      write_file('test.txt', "Hello\nWorld!")
+      pipe_in_file('test.txt')
+      close_input
+      expect(last_command_started).to have_output "Hello\nWorld!"
     end
   end
 end

--- a/spec/aruba/platforms/unix_which_spec.rb
+++ b/spec/aruba/platforms/unix_which_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Aruba::Platforms::UnixWhich do
+  let(:which) { described_class.new }
+
+  describe '#call' do
+    it 'returns nil if the program cannot be found' do
+      program = 'foobar'
+      expect(which.call(program)).to be_nil
+    end
+
+    it 'returns nil for a bare program name if path is nil' do
+      program = 'foobar'
+      expect(which.call(program, nil)).to be_nil
+    end
+  end
+end

--- a/spec/aruba/platforms/windows_which_spec.rb
+++ b/spec/aruba/platforms/windows_which_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Aruba::Platforms::WindowsWhich do
+  let(:which) { described_class.new }
+
+  describe '#call' do
+    it 'returns nil if the program cannot be found' do
+      program = 'foobar.exe'
+      expect(which.call(program)).to be_nil
+    end
+
+    it 'returns nil for a bare program name if path is nil' do
+      program = 'foobar.exe'
+      expect(which.call(program, nil)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The implementations of `Aruba.platform.which` would raise an early exception of the path was empty. This is not really necessary, so this PR removes that limitation.

In addition, it makes `Aruba::Api#which` find relative paths from the working directory rather than from the root directory, making it consistent with `#run_command`.

## Details

For the main change, this just removes the check on empty path from the platform-specific implementations of `which`.

For the API change, this wraps the call to `Aruba.platform.which` in `#in_current_directory`, so relative paths are resolved with respect to the workspace.

- **Organize specs for Aruba::Api::Commands by method**
- **Make Aruba::Api#which look up relative commands in the workspace**
- **Allow path argument for which to be empty**

## Motivation and Context

Some specs were sometimes failing in CI on Windows due to PATH being empty.

## How Has This Been Tested?

I added specs for `which` and ran them.

## Types of changes

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Internal change (refactoring, test improvements, developer experience or update of dependencies)

## Checklist:

- I've added tests for my code
- My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
